### PR TITLE
Code refactor

### DIFF
--- a/app/src/androidTestE2eTest/java/io/appium/uiautomator2/unittest/test/HandlersTest.java
+++ b/app/src/androidTestE2eTest/java/io/appium/uiautomator2/unittest/test/HandlersTest.java
@@ -194,7 +194,6 @@ public class HandlersTest {
         click(findElement(By.name("Views")));
 
         response = findElements(By.androidUiAutomator("resourceId(\"android:id/text1\")"));
-
         Logger.info("[AppiumUiAutomator2Server]", " findElement By.androidUiAutomator: " + response);
         result = getStringValueInJsonObject(response, "status");
         assertEquals(WDStatus.SUCCESS.code(), Integer.parseInt(result));
@@ -202,7 +201,7 @@ public class HandlersTest {
         JSONArray elements = new JSONArray(getStringValueInJsonObject(response, "value"));
         int elementCount = getJsonObjectCountInJsonArray(elements);
         assertTrue("Elements Count in views screen should at least > 5, " +
-                "in all variants of screen sizes, but actual" + elementCount, elementCount > 5);
+                "in all variants of screen sizes, but actual: " + elementCount, elementCount > 5);
 
     }
 

--- a/app/src/androidTestE2eTest/java/io/appium/uiautomator2/unittest/test/TestHelper.java
+++ b/app/src/androidTestE2eTest/java/io/appium/uiautomator2/unittest/test/TestHelper.java
@@ -18,7 +18,6 @@ import org.json.JSONException;
 
 import java.io.IOException;
 
-import io.appium.uiautomator2.common.exceptions.UiAutomator2Exception;
 import io.appium.uiautomator2.utils.Logger;
 
 import static android.os.SystemClock.elapsedRealtime;
@@ -74,7 +73,7 @@ public abstract class TestHelper {
             Response response = client.newCall(request).execute();
             result = response.body().string();
         } catch (IOException e) {
-            throw new UiAutomator2Exception(request.method() + " \"" + request.urlString() + "\" failed. " + e);
+            throw new RuntimeException(request.method() + " \"" + request.urlString() + "\" failed. " + e);
         }
         return result;
     }

--- a/app/src/androidTestE2eTest/java/io/appium/uiautomator2/unittest/test/TestUtil.java
+++ b/app/src/androidTestE2eTest/java/io/appium/uiautomator2/unittest/test/TestUtil.java
@@ -6,7 +6,6 @@ import android.content.Intent;
 import org.json.JSONException;
 import org.json.JSONObject;
 
-import io.appium.uiautomator2.common.exceptions.UiAutomator2Exception;
 import io.appium.uiautomator2.model.By;
 import io.appium.uiautomator2.model.By.ByName;
 import io.appium.uiautomator2.server.WDStatus;
@@ -299,7 +298,7 @@ public class TestUtil {
                 jsonObject.put("using", "-android uiautomator");
                 jsonObject.put("value", ((By.ByAndroidUiAutomator) by).getElementLocator());
             } else {
-                throw new UiAutomator2Exception("Unable to create json object: " + by);
+                throw new JSONException("Unable to create json object: " + by);
             }
         } catch (JSONException e) {
             Logger.error("Unable to form JSON Object: " + e);

--- a/app/src/main/java/io/appium/uiautomator2/common/exceptions/UiAutomator2Exception.java
+++ b/app/src/main/java/io/appium/uiautomator2/common/exceptions/UiAutomator2Exception.java
@@ -1,6 +1,6 @@
 package io.appium.uiautomator2.common.exceptions;
 
-public class UiAutomator2Exception extends RuntimeException {
+public class UiAutomator2Exception extends Exception {
     private static final long serialVersionUID = -1592305571101012889L;
 
     public UiAutomator2Exception(String message) {

--- a/app/src/main/java/io/appium/uiautomator2/core/AccessibilityNodeInfoDumper.java
+++ b/app/src/main/java/io/appium/uiautomator2/core/AccessibilityNodeInfoDumper.java
@@ -27,6 +27,7 @@ import java.io.IOException;
 import java.io.StringWriter;
 import java.util.regex.Pattern;
 
+import io.appium.uiautomator2.common.exceptions.UiAutomator2Exception;
 import io.appium.uiautomator2.utils.API;
 import io.appium.uiautomator2.utils.Logger;
 
@@ -50,7 +51,7 @@ public class AccessibilityNodeInfoDumper {
      *
      * @param root The root accessibility node.
      */
-    public static String getWindowXMLHierarchy(AccessibilityNodeInfo root) {
+    public static String getWindowXMLHierarchy(AccessibilityNodeInfo root) throws UiAutomator2Exception {
         final long startTime = SystemClock.uptimeMillis();
         StringWriter xmlDump = new StringWriter();
         try {

--- a/app/src/main/java/io/appium/uiautomator2/core/AccessibilityNodeInfoGetter.java
+++ b/app/src/main/java/io/appium/uiautomator2/core/AccessibilityNodeInfoGetter.java
@@ -5,6 +5,8 @@ import android.support.test.uiautomator.UiObject;
 import android.support.test.uiautomator.UiObject2;
 import android.view.accessibility.AccessibilityNodeInfo;
 
+import io.appium.uiautomator2.common.exceptions.UiAutomator2Exception;
+
 import static io.appium.uiautomator2.utils.ReflectionUtils.invoke;
 import static io.appium.uiautomator2.utils.ReflectionUtils.method;
 
@@ -24,7 +26,7 @@ public abstract class AccessibilityNodeInfoGetter {
         } else if (object instanceof UiObject) {
             return (AccessibilityNodeInfo) invoke(method(UiObject.class, "findAccessibilityNodeInfo"), object);
         } else {
-            throw new RuntimeException("Unknown object type: " + object.getClass().getName());
+            throw new UiAutomator2Exception("Unknown object type: " + object.getClass().getName());
         }
     }
 }

--- a/app/src/main/java/io/appium/uiautomator2/core/AccessibilityNodeInfoGetter.java
+++ b/app/src/main/java/io/appium/uiautomator2/core/AccessibilityNodeInfoGetter.java
@@ -20,7 +20,7 @@ public abstract class AccessibilityNodeInfoGetter {
     /**
      * Gets the {@link AccessibilityNodeInfo} associated with the given {@link UiObject2}
      */
-    public static AccessibilityNodeInfo fromUiObject(Object object) {
+    public static AccessibilityNodeInfo fromUiObject(Object object) throws UiAutomator2Exception {
         if (object instanceof UiObject2) {
             return (AccessibilityNodeInfo) invoke(method(UiObject2.class, "getAccessibilityNodeInfo"), object);
         } else if (object instanceof UiObject) {

--- a/app/src/main/java/io/appium/uiautomator2/core/InteractionController.java
+++ b/app/src/main/java/io/appium/uiautomator2/core/InteractionController.java
@@ -18,6 +18,8 @@ package io.appium.uiautomator2.core;
 import android.view.InputEvent;
 import android.view.MotionEvent.PointerCoords;
 
+import io.appium.uiautomator2.common.exceptions.UiAutomator2Exception;
+
 import static io.appium.uiautomator2.utils.ReflectionUtils.invoke;
 import static io.appium.uiautomator2.utils.ReflectionUtils.method;
 
@@ -36,27 +38,27 @@ public class InteractionController {
         this.interactionController = interactionController;
     }
 
-    public boolean sendKey(int keyCode, int metaState) {
+    public boolean sendKey(int keyCode, int metaState) throws UiAutomator2Exception {
         return (Boolean) invoke(method(CLASS_INTERACTION_CONTROLLER, METHOD_SEND_KEY, int.class, int.class), interactionController, keyCode, metaState);
     }
 
-    public boolean injectEventSync(InputEvent event) {
+    public boolean injectEventSync(InputEvent event) throws UiAutomator2Exception {
         return (Boolean) invoke(method(CLASS_INTERACTION_CONTROLLER, METHOD_INJECT_EVENT_SYNC, InputEvent.class), interactionController, event);
     }
 
-    public boolean touchDown(int x, int y) {
+    public boolean touchDown(int x, int y) throws UiAutomator2Exception {
         return (Boolean) invoke(method(CLASS_INTERACTION_CONTROLLER, METHOD_TOUCH_DOWN, int.class, int.class), interactionController, x, y);
     }
 
-    public boolean touchUp(int x, int y) {
+    public boolean touchUp(int x, int y) throws UiAutomator2Exception {
         return (Boolean) invoke(method(CLASS_INTERACTION_CONTROLLER, METHOD_TOUCH_UP, int.class, int.class), interactionController, x, y);
     }
 
-    public boolean touchMove(int x, int y) {
+    public boolean touchMove(int x, int y) throws UiAutomator2Exception {
         return (Boolean) invoke(method(CLASS_INTERACTION_CONTROLLER, METHOD_TOUCH_MOVE, int.class, int.class), interactionController, x, y);
     }
 
-    public Boolean performMultiPointerGesture(PointerCoords[][] pcs) {
+    public Boolean performMultiPointerGesture(PointerCoords[][] pcs) throws UiAutomator2Exception {
         return (Boolean) invoke(method(CLASS_INTERACTION_CONTROLLER, METHOD_PERFORM_MULTI_POINTER_GESTURE, PointerCoords[][].class), interactionController, (Object) pcs);
     }
 }

--- a/app/src/main/java/io/appium/uiautomator2/core/QueryController.java
+++ b/app/src/main/java/io/appium/uiautomator2/core/QueryController.java
@@ -17,6 +17,8 @@ package io.appium.uiautomator2.core;
 
 import android.view.accessibility.AccessibilityNodeInfo;
 
+import io.appium.uiautomator2.common.exceptions.UiAutomator2Exception;
+
 import static io.appium.uiautomator2.utils.ReflectionUtils.invoke;
 import static io.appium.uiautomator2.utils.ReflectionUtils.method;
 
@@ -31,7 +33,7 @@ public class QueryController {
         this.queryController = queryController;
     }
 
-    public AccessibilityNodeInfo getAccessibilityRootNode() {
+    public AccessibilityNodeInfo getAccessibilityRootNode() throws UiAutomator2Exception {
         return (AccessibilityNodeInfo) invoke(method(CLASS_QUERY_CONTROLLER, METHOD_GET_ACCESSIBILITY_ROOT_NODE), queryController);
     }
 

--- a/app/src/main/java/io/appium/uiautomator2/core/UiAutomatorBridge.java
+++ b/app/src/main/java/io/appium/uiautomator2/core/UiAutomatorBridge.java
@@ -48,10 +48,10 @@ public class UiAutomatorBridge {
 
             this.uiAutomatorBridge = getField(UiDevice.class, FIELD_UI_AUTOMATOR_BRIDGE, device);
         } catch (Error error) {
-            Logger.error("ERROR", "error", error);
+            Logger.error("ERROR", error);
             throw error;
         } catch (UiAutomator2Exception error) {
-            Logger.error("ERROR", "error", error);
+            Logger.error("ERROR", error);
             throw new Error(error);
         }
     }

--- a/app/src/main/java/io/appium/uiautomator2/core/UiAutomatorBridge.java
+++ b/app/src/main/java/io/appium/uiautomator2/core/UiAutomatorBridge.java
@@ -20,6 +20,7 @@ import android.util.Log;
 import android.view.Display;
 import android.view.InputEvent;
 
+import io.appium.uiautomator2.common.exceptions.UiAutomator2Exception;
 import io.appium.uiautomator2.utils.Device;
 
 import static io.appium.uiautomator2.utils.ReflectionUtils.getField;
@@ -49,6 +50,9 @@ public class UiAutomatorBridge {
         } catch (Error error) {
             Log.e("ERROR", "error", error);
             throw error;
+        } catch (UiAutomator2Exception error) {
+            Log.e("ERROR", "error", error);
+            throw new Error(error);
         }
     }
 
@@ -56,19 +60,19 @@ public class UiAutomatorBridge {
         return INSTANCE;
     }
 
-    public InteractionController getInteractionController() {
+    public InteractionController getInteractionController() throws UiAutomator2Exception {
         return new InteractionController(getField(CLASS_UI_AUTOMATOR_BRIDGE, FIELD_INTERACTION_CONTROLLER, uiAutomatorBridge));
     }
 
-    public QueryController getQueryController() {
+    public QueryController getQueryController() throws UiAutomator2Exception {
         return new QueryController(getField(CLASS_UI_AUTOMATOR_BRIDGE, FIELD_QUERY_CONTROLLER, uiAutomatorBridge));
     }
 
-    public Display getDefaultDisplay() {
+    public Display getDefaultDisplay() throws UiAutomator2Exception {
         return (Display) invoke(method(CLASS_UI_AUTOMATOR_BRIDGE, METHOD_GET_DEFAULT_DISPLAY), uiAutomatorBridge);
     }
 
-    public boolean injectInputEvent(InputEvent event, boolean sync) {
+    public boolean injectInputEvent(InputEvent event, boolean sync) throws UiAutomator2Exception {
         return (Boolean) invoke(method(CLASS_UI_AUTOMATOR_BRIDGE, METHOD_INJECT_INPUT_EVENT, InputEvent.class, boolean.class), uiAutomatorBridge, event, sync);
     }
 }

--- a/app/src/main/java/io/appium/uiautomator2/core/UiAutomatorBridge.java
+++ b/app/src/main/java/io/appium/uiautomator2/core/UiAutomatorBridge.java
@@ -16,12 +16,12 @@
 package io.appium.uiautomator2.core;
 
 import android.support.test.uiautomator.UiDevice;
-import android.util.Log;
 import android.view.Display;
 import android.view.InputEvent;
 
 import io.appium.uiautomator2.common.exceptions.UiAutomator2Exception;
 import io.appium.uiautomator2.utils.Device;
+import io.appium.uiautomator2.utils.Logger;
 
 import static io.appium.uiautomator2.utils.ReflectionUtils.getField;
 import static io.appium.uiautomator2.utils.ReflectionUtils.invoke;
@@ -48,10 +48,10 @@ public class UiAutomatorBridge {
 
             this.uiAutomatorBridge = getField(UiDevice.class, FIELD_UI_AUTOMATOR_BRIDGE, device);
         } catch (Error error) {
-            Log.e("ERROR", "error", error);
+            Logger.error("ERROR", "error", error);
             throw error;
         } catch (UiAutomator2Exception error) {
-            Log.e("ERROR", "error", error);
+            Logger.error("ERROR", "error", error);
             throw new Error(error);
         }
     }

--- a/app/src/main/java/io/appium/uiautomator2/handler/FindElement.java
+++ b/app/src/main/java/io/appium/uiautomator2/handler/FindElement.java
@@ -15,6 +15,7 @@ import javax.xml.parsers.ParserConfigurationException;
 
 import io.appium.uiautomator2.common.exceptions.ElementNotFoundException;
 import io.appium.uiautomator2.common.exceptions.InvalidSelectorException;
+import io.appium.uiautomator2.common.exceptions.UiAutomator2Exception;
 import io.appium.uiautomator2.common.exceptions.UiSelectorSyntaxException;
 import io.appium.uiautomator2.handler.request.SafeRequestHandler;
 import io.appium.uiautomator2.http.AppiumResponse;
@@ -47,7 +48,7 @@ public class FindElement extends SafeRequestHandler {
     /**
      * returns  UiObject2 for an xpath expression
      */
-    private static Object getXPathUiObject(final String expression, final boolean multiple, String contextId) throws ElementNotFoundException, ParserConfigurationException, InvalidSelectorException, ClassNotFoundException {
+    private static Object getXPathUiObject(final String expression, final boolean multiple, String contextId) throws ElementNotFoundException, ParserConfigurationException, InvalidSelectorException, ClassNotFoundException, UiAutomator2Exception {
         final List<BySelector> selectors = new ArrayList<BySelector>();
 
         final ArrayList<ClassInstancePair> pairs = contextId.equals("") ? XMLHierarchy.getClassInstancePairs(expression) : XMLHierarchy.getClassInstancePairs(expression, contextId);
@@ -109,13 +110,16 @@ public class FindElement extends SafeRequestHandler {
         } catch (UiSelectorSyntaxException e) {
             Logger.error("Unable to parse UiSelector: ", e);
             return new AppiumResponse(getSessionId(request), WDStatus.UNKNOWN_ERROR, e);
+        } catch (UiAutomator2Exception e) {
+            Logger.error("Exception while finding element: ", e);
+            return new AppiumResponse(getSessionId(request), WDStatus.JSON_DECODER_ERROR, e);
         }
     }
 
     /**
      * returns  UiObject2 for an xpath expression
      */
-    private Object findElement(By by) throws InvalidSelectorException, ElementNotFoundException, ParserConfigurationException, ClassNotFoundException, UiSelectorSyntaxException {
+    private Object findElement(By by) throws InvalidSelectorException, ElementNotFoundException, ParserConfigurationException, ClassNotFoundException, UiSelectorSyntaxException, UiAutomator2Exception {
         if (by instanceof ById) {
             return getInstance().findObject(android.support.test.uiautomator.By.res(by.getElementLocator()));
         } else if (by instanceof ByLinkText) {

--- a/app/src/main/java/io/appium/uiautomator2/handler/FindElements.java
+++ b/app/src/main/java/io/appium/uiautomator2/handler/FindElements.java
@@ -18,6 +18,7 @@ import javax.xml.parsers.ParserConfigurationException;
 
 import io.appium.uiautomator2.common.exceptions.ElementNotFoundException;
 import io.appium.uiautomator2.common.exceptions.InvalidSelectorException;
+import io.appium.uiautomator2.common.exceptions.UiAutomator2Exception;
 import io.appium.uiautomator2.common.exceptions.UiSelectorSyntaxException;
 import io.appium.uiautomator2.handler.request.SafeRequestHandler;
 import io.appium.uiautomator2.http.AppiumResponse;
@@ -49,7 +50,7 @@ public class FindElements extends SafeRequestHandler {
     /**
      * returns  UiObject2 for an xpath expression
      **/
-    private static List<Object> getXPathUiObjects(final String expression, final boolean multiple, String contextId) throws ElementNotFoundException, ParserConfigurationException, InvalidSelectorException, ClassNotFoundException {
+    private static List<Object> getXPathUiObjects(final String expression, final boolean multiple, String contextId) throws ElementNotFoundException, ParserConfigurationException, InvalidSelectorException, ClassNotFoundException, UiAutomator2Exception {
         final List<BySelector> selectors = new ArrayList<BySelector>();
 
         final ArrayList<ClassInstancePair> pairs = contextId.equals("") ? XMLHierarchy.getClassInstancePairs(expression) : XMLHierarchy.getClassInstancePairs(expression, contextId);
@@ -78,7 +79,7 @@ public class FindElements extends SafeRequestHandler {
             String selector = payload.getString("value");
             Logger.info(String.format("find element command using '%s' with selector '%s'.", method, selector));
             By by = new NativeAndroidBySelector().pickFrom(method, selector);
-
+            getUiDevice().waitForIdle();
             List<Object> elements = this.findElements(by);
 
 
@@ -112,10 +113,13 @@ public class FindElements extends SafeRequestHandler {
         } catch (ClassNotFoundException e) {
             Logger.error("Class not found: ", e);
             return new AppiumResponse(getSessionId(request), WDStatus.UNKNOWN_ERROR, e);
+        } catch (UiAutomator2Exception e) {
+            Logger.error("Exception while finding element: ", e);
+            return new AppiumResponse(getSessionId(request), WDStatus.UNKNOWN_ERROR, e);
         }
     }
 
-    private List<Object> findElements(By by) throws ElementNotFoundException, ParserConfigurationException, ClassNotFoundException, InvalidSelectorException {
+    private List<Object> findElements(By by) throws ElementNotFoundException, ParserConfigurationException, ClassNotFoundException, InvalidSelectorException, UiAutomator2Exception {
         if (by instanceof By.ById) {
             return getInstance().findObjects(android.support.test.uiautomator.By.res(by.getElementLocator()));
         }/* else if (by instanceof ByTagName) {

--- a/app/src/main/java/io/appium/uiautomator2/handler/LongPressKeyCode.java
+++ b/app/src/main/java/io/appium/uiautomator2/handler/LongPressKeyCode.java
@@ -8,6 +8,7 @@ import android.view.KeyEvent;
 import org.json.JSONException;
 import org.json.JSONObject;
 
+import io.appium.uiautomator2.common.exceptions.UiAutomator2Exception;
 import io.appium.uiautomator2.core.InteractionController;
 import io.appium.uiautomator2.core.UiAutomatorBridge;
 import io.appium.uiautomator2.handler.request.SafeRequestHandler;
@@ -62,6 +63,9 @@ public class LongPressKeyCode extends SafeRequestHandler {
         } catch (JSONException e) {
             Logger.error("Exception while reading JSON: ", e);
             return new AppiumResponse(getSessionId(request), WDStatus.JSON_DECODER_ERROR, e);
+        } catch (UiAutomator2Exception e) {
+            Logger.error("Exception while performing LongPressKeyCode action: ", e);
+            return new AppiumResponse(getSessionId(request), WDStatus.UNKNOWN_ERROR, e);
         }
     }
 }

--- a/app/src/main/java/io/appium/uiautomator2/handler/MultiPointerGesture.java
+++ b/app/src/main/java/io/appium/uiautomator2/handler/MultiPointerGesture.java
@@ -6,6 +6,7 @@ import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
+import io.appium.uiautomator2.common.exceptions.UiAutomator2Exception;
 import io.appium.uiautomator2.core.UiAutomatorBridge;
 import io.appium.uiautomator2.handler.request.SafeRequestHandler;
 import io.appium.uiautomator2.http.AppiumResponse;
@@ -41,6 +42,9 @@ public class MultiPointerGesture extends SafeRequestHandler {
         } catch (JSONException e) {
             Logger.error("Exception while reading JSON: ", e);
             return new AppiumResponse(getSessionId(request), WDStatus.JSON_DECODER_ERROR, e);
+        } catch (UiAutomator2Exception e) {
+            Logger.error("Exception while performing LongPressKeyCode action: ", e);
+            return new AppiumResponse(getSessionId(request), WDStatus.UNKNOWN_ERROR, e);
         }
     }
 

--- a/app/src/main/java/io/appium/uiautomator2/handler/SendKeysToElement.java
+++ b/app/src/main/java/io/appium/uiautomator2/handler/SendKeysToElement.java
@@ -48,13 +48,13 @@ public class SendKeysToElement extends SafeRequestHandler {
 
             String currText = element.getText();
             new Clear("/wd/hub/session/:sessionId/element/:id/clear").handle(request);
-            if (element.getText() == null || element.getText().isEmpty()) {
+            if (!isTextFieldCleared(element)) {
                 // clear could have failed, or we could have a hint in the field
                 // we'll assume it is the latter
                 Logger.debug("Text not cleared. Assuming remainder is hint text.");
                 currText = "";
             }
-            if (!replace) {
+            if (!replace && currText != null) {
                 text = currText + text;
             }
             element.setText(text, unicodeKeyboard);
@@ -79,7 +79,16 @@ public class SendKeysToElement extends SafeRequestHandler {
             Logger.error("Exception while reading JSON: ", e);
             return new AppiumResponse(getSessionId(request), WDStatus.JSON_DECODER_ERROR, e);
         }
+    }
 
+    private boolean isTextFieldCleared(AndroidElement element) throws UiObjectNotFoundException {
+        if(element.getText() == null){
+            return true;
+        } else if(element.getText().isEmpty()) {
+            return true;
+        } else {
+            return false;
+        }
     }
 }
 

--- a/app/src/main/java/io/appium/uiautomator2/handler/Source.java
+++ b/app/src/main/java/io/appium/uiautomator2/handler/Source.java
@@ -31,24 +31,25 @@ public class Source extends SafeRequestHandler {
 
     @Override
     public AppiumResponse safeHandle(IHttpRequest request) {
-        ReflectionUtils.clearAccessibilityCache();
-
-        final Document doc = (Document) XMLHierarchy.getFormattedXMLDoc();
-
-        final TransformerFactory tf = TransformerFactory.newInstance();
-        final StringWriter writer = new StringWriter();
-        Transformer transformer;
-        String xmlString;
         try {
-            transformer = tf.newTransformer();
+            ReflectionUtils.clearAccessibilityCache();
+
+            final Document doc = (Document) XMLHierarchy.getFormattedXMLDoc();
+            final TransformerFactory tf = TransformerFactory.newInstance();
+            final StringWriter writer = new StringWriter();
+            Transformer transformer = tf.newTransformer();
             transformer.transform(new DOMSource(doc), new StreamResult(writer));
-            xmlString = writer.getBuffer().toString();
+            String xmlString = writer.getBuffer().toString();
             return new AppiumResponse(getSessionId(request), WDStatus.SUCCESS, xmlString);
+
         } catch (final TransformerConfigurationException e) {
             Logger.error("Unable to handle the request:" + e);
-            throw new UiAutomator2Exception("Something went terribly wrong while converting xml document to string", e);
+            return new AppiumResponse(getSessionId(request), WDStatus.UNKNOWN_ERROR, "Something went terribly wrong while converting xml document to string:" + e);
         } catch (final TransformerException e) {
             return new AppiumResponse(getSessionId(request), WDStatus.UNKNOWN_ERROR, "Could not parse xml hierarchy to string: " + e);
+        } catch (UiAutomator2Exception e) {
+            Logger.error("Exception while performing LongPressKeyCode action: ", e);
+            return new AppiumResponse(getSessionId(request), WDStatus.UNKNOWN_ERROR, e);
         }
 
     }

--- a/app/src/main/java/io/appium/uiautomator2/handler/Source.java
+++ b/app/src/main/java/io/appium/uiautomator2/handler/Source.java
@@ -11,6 +11,7 @@ import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
 
+import io.appium.uiautomator2.common.exceptions.UiAutomator2Exception;
 import io.appium.uiautomator2.handler.request.SafeRequestHandler;
 import io.appium.uiautomator2.http.AppiumResponse;
 import io.appium.uiautomator2.http.IHttpRequest;
@@ -45,7 +46,7 @@ public class Source extends SafeRequestHandler {
             return new AppiumResponse(getSessionId(request), WDStatus.SUCCESS, xmlString);
         } catch (final TransformerConfigurationException e) {
             Logger.error("Unable to handle the request:" + e);
-            throw new RuntimeException("Something went terribly wrong while converting xml document to string", e);
+            throw new UiAutomator2Exception("Something went terribly wrong while converting xml document to string", e);
         } catch (final TransformerException e) {
             return new AppiumResponse(getSessionId(request), WDStatus.UNKNOWN_ERROR, "Could not parse xml hierarchy to string: " + e);
         }

--- a/app/src/main/java/io/appium/uiautomator2/handler/TouchDown.java
+++ b/app/src/main/java/io/appium/uiautomator2/handler/TouchDown.java
@@ -1,5 +1,6 @@
 package io.appium.uiautomator2.handler;
 
+import io.appium.uiautomator2.common.exceptions.UiAutomator2Exception;
 import io.appium.uiautomator2.core.UiAutomatorBridge;
 
 public class TouchDown extends TouchEvent {
@@ -9,7 +10,7 @@ public class TouchDown extends TouchEvent {
     }
 
     @Override
-    public boolean executeTouchEvent() {
+    public boolean executeTouchEvent() throws UiAutomator2Exception {
         printEventDebugLine("TouchDown");
         boolean isTouchDownPerformed = UiAutomatorBridge.getInstance().getInteractionController().touchDown(clickX, clickY);
         return isTouchDownPerformed;

--- a/app/src/main/java/io/appium/uiautomator2/handler/TouchEvent.java
+++ b/app/src/main/java/io/appium/uiautomator2/handler/TouchEvent.java
@@ -8,6 +8,7 @@ import com.jayway.jsonpath.JsonPath;
 import org.json.JSONException;
 import org.json.JSONObject;
 
+import io.appium.uiautomator2.common.exceptions.UiAutomator2Exception;
 import io.appium.uiautomator2.handler.request.SafeRequestHandler;
 import io.appium.uiautomator2.http.AppiumResponse;
 import io.appium.uiautomator2.http.IHttpRequest;
@@ -55,10 +56,12 @@ public abstract class TouchEvent extends SafeRequestHandler {
             return new AppiumResponse(getSessionId(request), WDStatus.JSON_DECODER_ERROR, e);
         } catch (UiObjectNotFoundException e) {
             return new AppiumResponse(getSessionId(request), WDStatus.UNKNOWN_ERROR, e);
+        } catch (UiAutomator2Exception e) {
+            return new AppiumResponse(getSessionId(request), WDStatus.UNKNOWN_ERROR, e);
         }
     }
 
-    protected abstract boolean executeTouchEvent() throws UiObjectNotFoundException;
+    protected abstract boolean executeTouchEvent() throws UiObjectNotFoundException, UiAutomator2Exception;
 
     protected void printEventDebugLine(final String methodName,
                                        final Integer... duration) {

--- a/app/src/main/java/io/appium/uiautomator2/handler/TouchMove.java
+++ b/app/src/main/java/io/appium/uiautomator2/handler/TouchMove.java
@@ -1,5 +1,6 @@
 package io.appium.uiautomator2.handler;
 
+import io.appium.uiautomator2.common.exceptions.UiAutomator2Exception;
 import io.appium.uiautomator2.core.UiAutomatorBridge;
 
 public class TouchMove extends TouchEvent {
@@ -9,7 +10,7 @@ public class TouchMove extends TouchEvent {
     }
 
     @Override
-    public boolean executeTouchEvent() {
+    public boolean executeTouchEvent() throws UiAutomator2Exception {
         printEventDebugLine("TouchMove");
         boolean isTouchMovePerformed = UiAutomatorBridge.getInstance().getInteractionController().touchMove(clickX, clickY);
         return isTouchMovePerformed;

--- a/app/src/main/java/io/appium/uiautomator2/handler/TouchUp.java
+++ b/app/src/main/java/io/appium/uiautomator2/handler/TouchUp.java
@@ -1,5 +1,6 @@
 package io.appium.uiautomator2.handler;
 
+import io.appium.uiautomator2.common.exceptions.UiAutomator2Exception;
 import io.appium.uiautomator2.core.UiAutomatorBridge;
 
 public class TouchUp extends TouchEvent {
@@ -9,7 +10,7 @@ public class TouchUp extends TouchEvent {
     }
 
     @Override
-    public boolean executeTouchEvent() {
+    public boolean executeTouchEvent() throws UiAutomator2Exception {
         printEventDebugLine("TouchUp");
         boolean isTouchUpPerformed = UiAutomatorBridge.getInstance().getInteractionController().touchUp(clickX, clickY);
         return isTouchUpPerformed;

--- a/app/src/main/java/io/appium/uiautomator2/handler/request/SafeRequestHandler.java
+++ b/app/src/main/java/io/appium/uiautomator2/handler/request/SafeRequestHandler.java
@@ -29,7 +29,7 @@ public abstract class SafeRequestHandler extends BaseRequestHandler {
     }
 
 
-    protected String[] extractKeysToSendFromPayload(IHttpRequest request) throws JSONException {
+    protected String[] extractKeysToSendFromPayload(IHttpRequest request) throws JSONException, UiAutomator2Exception {
         JSONArray valueArr = getPayload(request).getJSONArray("value");
         if (valueArr == null || valueArr.length() == 0) {
             throw new UiAutomator2Exception("No key to send to an element was found.");

--- a/app/src/main/java/io/appium/uiautomator2/handler/request/SafeRequestHandler.java
+++ b/app/src/main/java/io/appium/uiautomator2/handler/request/SafeRequestHandler.java
@@ -60,7 +60,7 @@ public abstract class SafeRequestHandler extends BaseRequestHandler {
             // The advantage of catching general Exception here is that we can propagate the Exception to clients.
             Logger.error("Exception while handling action in: " + this.getClass().getName(), e);
             return AppiumResponse.forCatchAllError(getSessionId(request), e);
-        } catch (Error e) {
+        } catch (Throwable e) {
             // Catching Errors seems like a bad idea in general but if we don't catch this, Netty will catch it anyway.
             // The advantage of catching it here is that we can propagate the Error to clients.
             Logger.error("Fatal error while handling action in: " + this.getClass().getName(), e);

--- a/app/src/main/java/io/appium/uiautomator2/model/internal/NativeAndroidBySelector.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/internal/NativeAndroidBySelector.java
@@ -16,7 +16,7 @@ public class NativeAndroidBySelector {
     public static final String SELECTOR_CLASS = "class name";
     public static final String SELECTOR_ANDROID_UIAUTOMATOR = "-android uiautomator";
 
-    public By pickFrom(String method, String selector) {
+    public By pickFrom(String method, String selector) throws UiAutomator2Exception {
         if (SELECTOR_NATIVE_ID.equals(method)) {
             return By.id(selector);
         } else if (SELECTOR_NAME.equals(method)) {

--- a/app/src/main/java/io/appium/uiautomator2/server/AppiumServlet.java
+++ b/app/src/main/java/io/appium/uiautomator2/server/AppiumServlet.java
@@ -169,7 +169,7 @@ public class AppiumServlet implements IHttpServlet {
     }
 
     @Override
-    public void handleHttpRequest(IHttpRequest request, IHttpResponse response) throws Exception {
+    public void handleHttpRequest(IHttpRequest request, IHttpResponse response) {
         BaseRequestHandler handler = null;
         if ("GET".equals(request.method())) {
             handler = findMatcher(request, getHandler);
@@ -182,7 +182,7 @@ public class AppiumServlet implements IHttpServlet {
         handleRequest(request, response, handler);
     }
 
-    public void handleRequest(IHttpRequest request, IHttpResponse response, BaseRequestHandler handler) throws Exception {
+    public void handleRequest(IHttpRequest request, IHttpResponse response, BaseRequestHandler handler) {
         if (handler == null) {
             response.setStatus(HttpStatusCode.NOT_FOUND.getStatusCode()).end();
             return;

--- a/app/src/main/java/io/appium/uiautomator2/server/ServerInstrumentation.java
+++ b/app/src/main/java/io/appium/uiautomator2/server/ServerInstrumentation.java
@@ -4,7 +4,6 @@ import android.content.Context;
 import android.os.Looper;
 import android.os.PowerManager;
 
-import io.appium.uiautomator2.common.exceptions.UiAutomator2Exception;
 import io.appium.uiautomator2.utils.Logger;
 
 public class ServerInstrumentation {
@@ -64,7 +63,7 @@ public class ServerInstrumentation {
         Logger.info("io.appium.uiautomator2.server started:");
     }
 
-    private void stopServerThread() {
+    private void stopServerThread()  {
         if (serverThread == null) {
             return;
         }
@@ -78,8 +77,7 @@ public class ServerInstrumentation {
         serverThread.interrupt();
         try {
             serverThread.join();
-        } catch (InterruptedException e) {
-            throw new UiAutomator2Exception(e);
+        } catch (InterruptedException ignored) {
         }
         serverThread = null;
     }

--- a/app/src/main/java/io/appium/uiautomator2/server/ServerInstrumentation.java
+++ b/app/src/main/java/io/appium/uiautomator2/server/ServerInstrumentation.java
@@ -4,6 +4,7 @@ import android.content.Context;
 import android.os.Looper;
 import android.os.PowerManager;
 
+import io.appium.uiautomator2.common.exceptions.UiAutomator2Exception;
 import io.appium.uiautomator2.utils.Logger;
 
 public class ServerInstrumentation {
@@ -78,7 +79,7 @@ public class ServerInstrumentation {
         try {
             serverThread.join();
         } catch (InterruptedException e) {
-            throw new RuntimeException(e);
+            throw new UiAutomator2Exception(e);
         }
         serverThread = null;
     }

--- a/app/src/main/java/io/appium/uiautomator2/utils/Device.java
+++ b/app/src/main/java/io/appium/uiautomator2/utils/Device.java
@@ -24,7 +24,7 @@ public abstract class Device {
         return uiDevice;
     }
 
-    public static AndroidElement getAndroidElement(String id, Object element) {
+    public static AndroidElement getAndroidElement(String id, Object element) throws UiAutomator2Exception {
         if (element instanceof UiObject2) {
             return new UiObject2Element(id, (UiObject2) element);
         } else if (element instanceof UiObject) {

--- a/app/src/main/java/io/appium/uiautomator2/utils/Device.java
+++ b/app/src/main/java/io/appium/uiautomator2/utils/Device.java
@@ -9,6 +9,7 @@ import android.support.test.uiautomator.UiObjectNotFoundException;
 import android.support.test.uiautomator.UiScrollable;
 import android.support.test.uiautomator.UiSelector;
 
+import io.appium.uiautomator2.common.exceptions.UiAutomator2Exception;
 import io.appium.uiautomator2.model.AndroidElement;
 import io.appium.uiautomator2.model.UiObject2Element;
 import io.appium.uiautomator2.model.UiObjectElement;
@@ -29,7 +30,7 @@ public abstract class Device {
         } else if (element instanceof UiObject) {
             return new UiObjectElement(id, (UiObject) element);
         } else {
-            throw new RuntimeException("Unknown Element type: " + element.getClass().getName());
+            throw new UiAutomator2Exception("Unknown Element type: " + element.getClass().getName());
         }
     }
 

--- a/app/src/main/java/io/appium/uiautomator2/utils/ReflectionUtils.java
+++ b/app/src/main/java/io/appium/uiautomator2/utils/ReflectionUtils.java
@@ -21,6 +21,8 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.Arrays;
 
+import io.appium.uiautomator2.common.exceptions.UiAutomator2Exception;
+
 public class ReflectionUtils {
 
     /**
@@ -29,7 +31,7 @@ public class ReflectionUtils {
      * calls to public APIs such as `recycle` do not guarantee cached references get updated. See
      * the android.view.accessibility AIC and ANI source code for more information.
      */
-    public static boolean clearAccessibilityCache() {
+    public static boolean clearAccessibilityCache() throws UiAutomator2Exception {
         boolean success = false;
 
         try {
@@ -52,16 +54,16 @@ public class ReflectionUtils {
         return success;
     }
 
-    public static Class getClass(final String name) {
+    public static Class getClass(final String name) throws UiAutomator2Exception {
         try {
             return Class.forName(name);
         } catch (final ClassNotFoundException e) {
             final String msg = String.format("unable to find class %s", name);
-            throw new RuntimeException(msg, e);
+            throw new UiAutomator2Exception(msg, e);
         }
     }
 
-    public static Object getField(final Class clazz, final String fieldName, final Object object) {
+    public static Object getField(final Class clazz, final String fieldName, final Object object) throws UiAutomator2Exception {
         try {
             final Field field = clazz.getDeclaredField(fieldName);
             field.setAccessible(true);
@@ -70,29 +72,29 @@ public class ReflectionUtils {
         } catch (final Exception e) {
             final String msg = String.format("error while getting field %s from object %s", fieldName, object);
             Logger.error(msg + " " + e.getMessage());
-            throw new RuntimeException(msg, e);
+            throw new UiAutomator2Exception(msg, e);
         }
     }
 
-    public static Object getField(final String field, final Object object) {
+    public static Object getField(final String field, final Object object) throws UiAutomator2Exception {
         return getField(object.getClass(), field, object);
     }
 
-    public static Object getField(final String className, final String field, final Object object) {
+    public static Object getField(final String className, final String field, final Object object) throws UiAutomator2Exception {
         return getField(getClass(className), field, object);
     }
 
-    public static Object invoke(final Method method, final Object object, final Object... parameters) {
+    public static Object invoke(final Method method, final Object object, final Object... parameters) throws UiAutomator2Exception {
         try {
             return method.invoke(object, parameters);
         } catch (final Exception e) {
             final String msg = String.format("error while invoking method %s on object %s with parameters %s", method, object, Arrays.toString(parameters));
             Logger.error(msg + " " + e.getMessage());
-            throw new RuntimeException(msg, e);
+            throw new UiAutomator2Exception(msg, e);
         }
     }
 
-    public static Method method(final Class clazz, final String methodName, final Class... parameterTypes) {
+    public static Method method(final Class clazz, final String methodName, final Class... parameterTypes) throws UiAutomator2Exception {
         try {
             final Method method = clazz.getDeclaredMethod(methodName, parameterTypes);
             method.setAccessible(true);
@@ -101,11 +103,11 @@ public class ReflectionUtils {
         } catch (final Exception e) {
             final String msg = String.format("error while getting method %s from class %s with parameter types %s", methodName, clazz, Arrays.toString(parameterTypes));
             Logger.error(msg + " " + e.getMessage());
-            throw new RuntimeException(msg, e);
+            throw new UiAutomator2Exception(msg, e);
         }
     }
 
-    public static Method method(final String className, final String method, final Class... parameterTypes) {
+    public static Method method(final String className, final String method, final Class... parameterTypes) throws UiAutomator2Exception {
         return method(getClass(className), method, parameterTypes);
     }
 }

--- a/app/src/main/java/io/appium/uiautomator2/utils/XMLHierarchy.java
+++ b/app/src/main/java/io/appium/uiautomator2/utils/XMLHierarchy.java
@@ -38,6 +38,7 @@ import javax.xml.xpath.XPathFactory;
 import io.appium.uiautomator2.common.exceptions.ElementNotFoundException;
 import io.appium.uiautomator2.common.exceptions.InvalidSelectorException;
 import io.appium.uiautomator2.common.exceptions.PairCreationException;
+import io.appium.uiautomator2.common.exceptions.UiAutomator2Exception;
 import io.appium.uiautomator2.core.AccessibilityNodeInfoDumper;
 import io.appium.uiautomator2.core.AccessibilityNodeInfoGetter;
 import io.appium.uiautomator2.core.UiAutomatorBridge;
@@ -48,12 +49,12 @@ import io.appium.uiautomator2.model.internal.AndroidElementsHash;
 
 public abstract class XMLHierarchy {
 
-    public static ArrayList<ClassInstancePair> getClassInstancePairs(String xpathExpression) throws ElementNotFoundException, InvalidSelectorException, ParserConfigurationException {
+    public static ArrayList<ClassInstancePair> getClassInstancePairs(String xpathExpression) throws ElementNotFoundException, InvalidSelectorException, ParserConfigurationException, UiAutomator2Exception {
 
         return getClassInstancePairs(compileXpath(xpathExpression), getFormattedXMLDoc());
     }
 
-    public static ArrayList<ClassInstancePair> getClassInstancePairs(final String xpathExpression, final String contextId) throws InvalidSelectorException, ElementNotFoundException {
+    public static ArrayList<ClassInstancePair> getClassInstancePairs(final String xpathExpression, final String contextId) throws InvalidSelectorException, ElementNotFoundException, UiAutomator2Exception {
         AndroidElement contextElement = AndroidElementsHash.getInstance().getElement(contextId);
         AccessibilityNodeInfo contextNode = AccessibilityNodeInfoGetter.fromUiObject(contextElement.getUiObject());
 
@@ -94,17 +95,17 @@ public abstract class XMLHierarchy {
         return pairs;
     }
 
-    public static InputSource getRawXMLHierarchy() {
+    public static InputSource getRawXMLHierarchy() throws UiAutomator2Exception {
         AccessibilityNodeInfo root = getRootAccessibilityNode();
         return getRawXMLHierarchy(root);
     }
 
-    public static InputSource getRawXMLHierarchy(AccessibilityNodeInfo root) {
+    public static InputSource getRawXMLHierarchy(AccessibilityNodeInfo root) throws UiAutomator2Exception {
         String xmlDump = AccessibilityNodeInfoDumper.getWindowXMLHierarchy(root);
         return new InputSource(new StringReader(xmlDump));
     }
 
-    private static AccessibilityNodeInfo getRootAccessibilityNode() {
+    private static AccessibilityNodeInfo getRootAccessibilityNode() throws UiAutomator2Exception {
         while (true) {
             AccessibilityNodeInfo root = UiAutomatorBridge.getInstance().getQueryController().getAccessibilityRootNode();
             if (root != null) {
@@ -113,11 +114,11 @@ public abstract class XMLHierarchy {
         }
     }
 
-    public static Node getFormattedXMLDoc() {
+    public static Node getFormattedXMLDoc() throws UiAutomator2Exception {
         return formatXMLInput(getRawXMLHierarchy());
     }
 
-    public static Node getFormattedXMLDoc(AccessibilityNodeInfo root) {
+    public static Node getFormattedXMLDoc(AccessibilityNodeInfo root) throws UiAutomator2Exception {
         return formatXMLInput(getRawXMLHierarchy(root));
     }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "appium-uiautomator2-server-test-1",
-  "version": "0.0.47",
+  "version": "0.0.48",
   "description": "A netty server with uiautomator2 handlers",
   "main": "index.js",
   "windowsBuildDir":"c:/tmp",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "appium-uiautomator2-server-test-1",
-  "version": "0.0.45",
+  "version": "0.0.47",
   "description": "A netty server with uiautomator2 handlers",
   "main": "index.js",
   "windowsBuildDir":"c:/tmp",


### PR DESCRIPTION
- Updated throwing RuntimeException to more appropriate exceptions.
Reason for change: Netty server explicitly catching all RuntimeExceptions and throwing it's own custom messages like **server hangup** and external modules who calls server don't have control actual exception.

- Updated UiAutomator2Exception to extend Exception from RuntimeException

- Updated [CustomUIDevice](https://github.com/sravanmedarapu/appium-uiautomator2-server/blob/code_refactor/app/src/main/java/io/appium/uiautomator2/model/internal/CustomUiDevice.java#L178).
Reason for updated: `mInstrumentation.getUiAutomation().getRootInActiveWindow()` returning `null` randomly, need to figure out actual root cause, for time being repolling for maximum 5 times for getting root node for being non null.

