### PR TITLE
touch/flick payload compliance

### DIFF
--- a/app/src/androidTestE2eTest/java/io/appium/uiautomator2/unittest/test/TestUtil.java
+++ b/app/src/androidTestE2eTest/java/io/appium/uiautomator2/unittest/test/TestUtil.java
@@ -292,7 +292,7 @@ public class TestUtil {
     public static String flickOnElement(String element) throws JSONException {
         String elementId = new JSONObject(element).getJSONObject("value").getString("ELEMENT");
         JSONObject jsonObject = new JSONObject();
-        jsonObject.put("elementId", elementId);
+        jsonObject.put("element", elementId);
         jsonObject.put("xoffset", 1);
         jsonObject.put("yoffset", 1);
         jsonObject.put("speed", 1000);

--- a/app/src/main/java/io/appium/uiautomator2/handler/Flick.java
+++ b/app/src/main/java/io/appium/uiautomator2/handler/Flick.java
@@ -32,8 +32,8 @@ public class Flick extends SafeRequestHandler {
         Double steps;
         try {
             JSONObject payload = getPayload(request);
-            if (payload.has("elementId")) {
-                String id = payload.getString("elementId");
+            if (payload.has("element")) {
+                String id = payload.getString("element");
                 AndroidElement element = KnownElements.getElementFromCache(id);
                 if (element == null) {
                     return new AppiumResponse(getSessionId(request), WDStatus.NO_SUCH_ELEMENT);


### PR DESCRIPTION
According to [the initial specification](https://github.com/SeleniumHQ/selenium/wiki/JsonWireProtocol#sessionsessionidtouchflick), `POST session/:sessionId/touch/flick` expects `element` as a JSON parameter instead of `elementId`.