### PR TITLE
Allow null values in JSON response

### DIFF
--- a/app/src/main/java/io/appium/uiautomator2/http/AppiumResponse.java
+++ b/app/src/main/java/io/appium/uiautomator2/http/AppiumResponse.java
@@ -45,9 +45,7 @@ public class AppiumResponse {
                 o.put("sessionId", sessionId);
             }
             o.put("status", status);
-            if (value != null) {
-                o.put("value", value);
-            }
+            o.put("value", value);
         } catch (JSONException e) {
             Logger.error("Unable to create JSON Object:", e);
         }


### PR DESCRIPTION
JSONWP proxy contains the following verification for JSON response:

```js
    resBody = util.safeJsonParse(resBody);
    if (_.includes(statusCodesWithRes, response.statusCode) &&
        (_.isUndefined(resBody.status) || _.isUndefined(resBody.value))) {
      throw new Error(`Did not get a valid response object. Object was: ${JSON.stringify(resBody)}`);
    }
```

This means we get an exception even in case of correct response, since the valid _null_ value is deliberately not included there inside server code. Now this is fixed.

Addresses https://github.com/appium/appium/issues/8810