### PR TITLE
Fix setting null to JSONObject's value

### DIFF
--- a/app/src/main/java/io/appium/uiautomator2/http/AppiumResponse.java
+++ b/app/src/main/java/io/appium/uiautomator2/http/AppiumResponse.java
@@ -41,11 +41,9 @@ public class AppiumResponse {
     public String render() {
         JSONObject o = new JSONObject();
         try {
-            if (sessionId != null) {
-                o.put("sessionId", sessionId);
-            }
+            o.put("sessionId", sessionId == null ? JSONObject.NULL : sessionId);
             o.put("status", status);
-            o.put("value", value);
+            o.put("value", value == null ? JSONObject.NULL : value);
         } catch (JSONException e) {
             Logger.error("Unable to create JSON Object:", e);
         }


### PR DESCRIPTION
It looks like JSONObject does not really like to contain Java _null_ values and requires JSONObject.NULL to be set instead.