### PR TITLE
set waitForIdleTimeout via settings

### DIFF
--- a/app/src/main/java/io/appium/uiautomator2/handler/UpdateSettings.java
+++ b/app/src/main/java/io/appium/uiautomator2/handler/UpdateSettings.java
@@ -6,6 +6,7 @@ import io.appium.uiautomator2.http.IHttpRequest;
 import io.appium.uiautomator2.model.AllowInvisibleElements;
 import io.appium.uiautomator2.model.CompressedLayoutHierarchy;
 import io.appium.uiautomator2.model.Session;
+import io.appium.uiautomator2.model.WaitForIdleTimeout;
 import io.appium.uiautomator2.server.WDStatus;
 import io.appium.uiautomator2.utils.Logger;
 import java.util.Map;
@@ -30,6 +31,10 @@ public class UpdateSettings extends SafeRequestHandler {
 
             if (settings.containsKey(CompressedLayoutHierarchy.SETTING_NAME)) {
                 CompressedLayoutHierarchy.updateSetting((boolean) settings.get(CompressedLayoutHierarchy.SETTING_NAME));
+            }
+
+            if (settings.containsKey(WaitForIdleTimeout.SETTING_NAME)) {
+                WaitForIdleTimeout.updateSetting((int) settings.get(WaitForIdleTimeout.SETTING_NAME));
             }
         } catch (Exception e) {
             Logger.error("error settings " + e.getMessage());

--- a/app/src/main/java/io/appium/uiautomator2/model/WaitForIdleTimeout.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/WaitForIdleTimeout.java
@@ -13,7 +13,7 @@ public class WaitForIdleTimeout {
       Configurator.getInstance().setWaitForIdleTimeout(timeout);
       Logger.debug("Set waitForIdleTimeout to: " + timeout);
     } catch (Exception e) {
-      Logger.error("error setting waitForIdleTimeout " + e.getMessage());
+      Logger.error("Error setting waitForIdleTimeout " + e.getMessage());
     }
   }
 }

--- a/app/src/main/java/io/appium/uiautomator2/model/WaitForIdleTimeout.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/WaitForIdleTimeout.java
@@ -1,0 +1,19 @@
+package io.appium.uiautomator2.model;
+
+import android.support.test.uiautomator.Configurator;
+
+import io.appium.uiautomator2.utils.Logger;
+
+public class WaitForIdleTimeout {
+
+  public static final String SETTING_NAME = "setWaitForIdleTimeout";
+
+  public static void updateSetting(int timeout) {
+    try {
+      Configurator.getInstance().setWaitForIdleTimeout(timeout);
+      Logger.debug("Set waitForIdleTimeout to: " + timeout);
+    } catch (Exception e) {
+      Logger.error("error setting waitForIdleTimeout " + e.getMessage());
+    }
+  }
+}

--- a/app/src/main/java/io/appium/uiautomator2/model/WaitForIdleTimeout.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/WaitForIdleTimeout.java
@@ -6,7 +6,7 @@ import io.appium.uiautomator2.utils.Logger;
 
 public class WaitForIdleTimeout {
 
-  public static final String SETTING_NAME = "setWaitForIdleTimeout";
+  public static final String SETTING_NAME = "waitForIdleTimeout";
 
   public static void updateSetting(int timeout) {
     try {


### PR DESCRIPTION
This is to set the waitForIdleTimeout via settings, which will help user to override the default Idle timeout(10 *1000).
For example, If there are elements which only appears in the screen for less than 5 seconds. In a video player, player controls overlay disappears in 5 seconds. UIAutomator2 waits for screen to become idle and failed to identify the element since there is a default idle timeout of 10 seconds.
This resolves the issue appium/appium#9147

From clients, We can set settings like driver.setSetting(Setting.WAIT_FOR_IDLE_TIMEOUT, 0);