### PR TITLE
Replace `clearTextField()` with `setText('')`

### DIFF
--- a/app/src/main/java/io/appium/uiautomator2/model/UiObjectElement.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/UiObjectElement.java
@@ -128,7 +128,7 @@ public class UiObjectElement implements AndroidElement {
     }
 
     public void clear() throws UiObjectNotFoundException {
-        element.clearTextField();
+        element.setText("");
     }
 
     public String getId() {


### PR DESCRIPTION
`UiObject.clearTextField()` method [can not clear password text field](https://android.googlesource.com/platform/frameworks/uiautomator/+/android-support-test/src/main/java/android/support/test/uiautomator/UiObject.java#693) because `getText()` returns empty string, but we can mimic [`UiObject2.clear()`](https://android.googlesource.com/platform/frameworks/uiautomator/+/android-support-test/src/main/java/android/support/test/uiautomator/UiObject2.java#337) behaviour.
Related to appium/appium-uiautomator2-driver#109