### PR TITLE
W3C Actions Support

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,20 +1,22 @@
 buildscript {
     repositories {
         jcenter()
+        google()
         maven { url 'https://jitpack.io' }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.1'
+        classpath 'com.android.tools.build:gradle:3.0.1'
         classpath 'com.github.JakeWharton:sdk-manager-plugin:0ce4cdf08009d79223850a59959d9d6e774d0f77'
+        classpath 'de.mobilej.unmock:UnMockPlugin:0.6.4'
     }
 }
 
-apply plugin: 'android-sdk-manager'
 apply plugin: 'com.android.application'
+apply plugin: 'de.mobilej.unmock'
 
 android {
     compileSdkVersion 24
-    buildToolsVersion '23.0.1'
+    buildToolsVersion '26.0.2'
     defaultConfig {
         applicationId "io.appium.uiautomator2"
         minSdkVersion 19
@@ -35,10 +37,12 @@ android {
             debuggable true
         }
         applicationVariants.all { variant ->
-            appendVersionNameVersionCode(variant, defaultConfig)
+            variant.outputs.all {
+                outputFileName = outputFileName.replace("debug.apk", "v${defaultConfig.versionName}.apk")
+            }
         }
     }
-
+    flavorDimensions "default"
     lintOptions {
         abortOnError false
     }
@@ -50,10 +54,20 @@ android {
             applicationId 'io.appium.uiautomator2.server'
         }
     }
+    testOptions {
+        unitTests.returnDefaultValues = true
+    }
     packagingOptions {
         exclude 'META-INF/maven/com.google.guava/guava/pom.properties'
         exclude 'META-INF/maven/com.google.guava/guava/pom.xml'
     }
+}
+
+unMock {
+    keepStartingWith "com.android.internal.util."
+    keepStartingWith "android.util."
+    keepStartingWith "android.view."
+    keepStartingWith "android.internal."
 }
 
 dependencies {
@@ -64,6 +78,8 @@ dependencies {
     compile 'com.android.support.test:runner:0.5'
     compile 'com.android.support:support-annotations:23.1.1'
     compile 'com.android.support.test.uiautomator:uiautomator-v18:2.1.2'
+    unmock 'org.robolectric:android-all:7.1.0_r7-robolectric-0'
+    testCompile "org.json:json:20160810"
     androidTestCompile 'junit:junit:4.12'
     androidTestCompile 'com.android.support:support-annotations:23.1.1'
     androidTestCompile 'com.android.support.test.uiautomator:uiautomator-v18:2.1.2'
@@ -90,13 +106,3 @@ afterEvaluate {
         }
     }
 }
-
-def appendVersionNameVersionCode(variant, defaultConfig) {
-    variant.outputs.each { output ->
-        def file = output.packageApplication.outputFile
-        def fileName = file.name.replace("debug.apk", "v${defaultConfig.versionName}.apk")
-        output.packageApplication.outputFile = new File(file.parent, fileName)
-    }
-}
-
-

--- a/app/src/main/java/io/appium/uiautomator2/handler/W3CActions.java
+++ b/app/src/main/java/io/appium/uiautomator2/handler/W3CActions.java
@@ -84,10 +84,8 @@ public class W3CActions extends SafeRequestHandler {
      * {@link KeyEvent#META_CTRL_LEFT_ON}. Meta key codes are also applied to pointer
      * events, which are happening at the same moment.
      * <p>
-     * Button codes for <b>mouse</b> and <b>pen</b> input tools can be found in
-     * {@link MotionEvent} documentation.
      *
-     * @param request JSON request formatted according to W3C action endpoint compilation rules.
+     * @param request JSON request formatted according to W3C actions endpoint compilation rules.
      * @return The standard {@link AppiumResponse} instance with return value or error code inside.
      */
     @Override

--- a/app/src/main/java/io/appium/uiautomator2/handler/W3CActions.java
+++ b/app/src/main/java/io/appium/uiautomator2/handler/W3CActions.java
@@ -62,7 +62,7 @@ public class W3CActions extends SafeRequestHandler {
     /**
      * Android handler for <a href="https://github.com/jlipps/simple-wd-spec#perform-actions">W3C actions endpoint</a>
      * <p>
-     * All inout source types are supported as well as multi-touch gestures.
+     * All input source types are supported as well as multi-touch gestures.
      * <p>
      * The following additional item options are supported for <b>pointer</b> source:
      * <ul>

--- a/app/src/main/java/io/appium/uiautomator2/handler/W3CActions.java
+++ b/app/src/main/java/io/appium/uiautomator2/handler/W3CActions.java
@@ -1,0 +1,278 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.appium.uiautomator2.handler;
+
+import android.os.SystemClock;
+import android.util.LongSparseArray;
+import android.view.InputDevice;
+import android.view.InputEvent;
+import android.view.KeyCharacterMap;
+import android.view.KeyEvent;
+import android.view.MotionEvent;
+import android.view.MotionEvent.PointerCoords;
+import android.view.MotionEvent.PointerProperties;
+
+import org.json.JSONArray;
+import org.json.JSONException;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import io.appium.uiautomator2.core.UiAutomatorBridge;
+import io.appium.uiautomator2.handler.request.SafeRequestHandler;
+import io.appium.uiautomator2.http.AppiumResponse;
+import io.appium.uiautomator2.http.IHttpRequest;
+import io.appium.uiautomator2.server.WDStatus;
+import io.appium.uiautomator2.utils.API;
+import io.appium.uiautomator2.utils.Logger;
+import io.appium.uiautomator2.utils.w3c.ActionsHelpers;
+import io.appium.uiautomator2.utils.w3c.ActionsHelpers.InputEventParams;
+import io.appium.uiautomator2.utils.w3c.ActionsHelpers.KeyInputEventParams;
+import io.appium.uiautomator2.utils.w3c.ActionsHelpers.MotionInputEventParams;
+import io.appium.uiautomator2.utils.w3c.ActionsParseException;
+
+import static io.appium.uiautomator2.utils.w3c.ActionsHelpers.actionsToInputEventsMapping;
+import static io.appium.uiautomator2.utils.w3c.ActionsHelpers.getPointerAction;
+import static io.appium.uiautomator2.utils.w3c.ActionsHelpers.metaKeysToState;
+import static io.appium.uiautomator2.utils.w3c.ActionsHelpers.toolTypeToInputSource;
+
+public class W3CActions extends SafeRequestHandler {
+    public W3CActions(String mappedUri) {
+        super(mappedUri);
+    }
+
+    /**
+     * Android handler for <a href="https://github.com/jlipps/simple-wd-spec#perform-actions">W3C actions endpoint</a>
+     * <p>
+     * All inout source types are supported as well as multi-touch gestures.
+     * <p>
+     * The following additional item options are supported for <b>pointer</b> source:
+     * <ul>
+     * <li>pressure - A value in range [0.0, 1.0], which defines pointer pressure,
+     * where 1.0 is the normal pressure (the default value) and 0.0 means no pressure.</li>
+     * <li>size - A normalized value that describes the approximate size of the pointer touch area
+     * in relation to the maximum detectable size of the device.
+     * It represents some approximation of the area of the screen being
+     * pressed; the actual value in pixels corresponding to the
+     * touch is normalized with the device specific range of values
+     * and scaled to a value between 0 and 1 (the default value).
+     * The value of size can be used to determine fat touch events.</li>
+     * </ul>
+     * <p>
+     * Applicable key and meta key codes for <b>key</b> input source can be found in
+     * {@link KeyEvent} documentation. Value transformation to a numeric key code is
+     * done via {@link String#charAt(int)} method call, which means, for example,
+     * that the value <em>"\\u2000"</em> equals to meta key code 0x2000
+     * {@link KeyEvent#META_CTRL_LEFT_ON}. Meta key codes are also applied to pointer
+     * events, which are happening at the same moment.
+     * <p>
+     * Button codes for <b>mouse</b> and <b>pen</b> input tools can be found in
+     * {@link MotionEvent} documentation.
+     *
+     * @param request JSON request formatted according to W3C action endpoint compilation rules.
+     * @return The standard {@link AppiumResponse} instance with return value or error code inside.
+     */
+    @Override
+    public AppiumResponse safeHandle(IHttpRequest request) {
+        try {
+            final JSONArray actions = ActionsHelpers.preprocessActions(
+                    (JSONArray) getPayload(request).get("actions")
+            );
+
+            if (API.API_18) {
+                if (executeActions(actions)) {
+                    return new AppiumResponse(getSessionId(request), WDStatus.SUCCESS, "OK");
+                }
+                return new AppiumResponse(getSessionId(request), WDStatus.UNKNOWN_ERROR,
+                        "Unable to perform W3C actions. Check the logcat output " +
+                                "for possible error reports and make sure your input actions chain is valid.");
+            }
+            Logger.error("Device does not support API < 18!");
+            return new AppiumResponse(getSessionId(request), WDStatus.UNKNOWN_ERROR,
+                    "Cannot perform W3C actions on device below API level 18");
+        } catch (JSONException | ActionsParseException e) {
+            Logger.error("Exception while reading JSON: ", e);
+            return new AppiumResponse(getSessionId(request), WDStatus.JSON_DECODER_ERROR, e);
+        } catch (Exception e) {
+            Logger.error("Exception while performing W3C action: ", e);
+            return new AppiumResponse(getSessionId(request), WDStatus.UNKNOWN_ERROR, e);
+        }
+    }
+
+    private boolean injectEventSync(InputEvent event) {
+        return UiAutomatorBridge.getInstance().getInteractionController().injectEventSync(event);
+    }
+
+    private static final List<Integer> HOVERING_ACTIONS = Arrays.asList(
+            MotionEvent.ACTION_HOVER_ENTER, MotionEvent.ACTION_HOVER_EXIT, MotionEvent.ACTION_HOVER_MOVE
+    );
+
+    private static PointerProperties[] filterPointerProperties(
+            final List<MotionInputEventParams> motionEventsParams, final boolean shouldHovering) {
+        final List<PointerProperties> result = new ArrayList<>();
+        for (final MotionInputEventParams eventParams : motionEventsParams) {
+            if (shouldHovering && HOVERING_ACTIONS.contains(eventParams.actionCode)) {
+                result.add(eventParams.properties);
+            } else if (!shouldHovering && !HOVERING_ACTIONS.contains(eventParams.actionCode)) {
+                result.add(eventParams.properties);
+            }
+        }
+        return result.toArray(new PointerProperties[result.size()]);
+    }
+
+    private static PointerCoords[] filterPointerCoordinates(
+            final List<MotionInputEventParams> motionEventsParams, final boolean shouldHovering) {
+        final List<PointerCoords> result = new ArrayList<>();
+        for (final MotionInputEventParams eventParams : motionEventsParams) {
+            if (shouldHovering && HOVERING_ACTIONS.contains(eventParams.actionCode)) {
+                result.add(eventParams.coordinates);
+            } else if (!shouldHovering && !HOVERING_ACTIONS.contains(eventParams.actionCode)) {
+                result.add(eventParams.coordinates);
+            }
+        }
+        return result.toArray(new PointerCoords[result.size()]);
+    }
+
+    private boolean executeActions(final JSONArray actions) throws JSONException {
+        final LongSparseArray<List<InputEventParams>> inputEventsMapping = actionsToInputEventsMapping(actions);
+        final List<Long> allDeltas = new ArrayList<>();
+        for (int i = 0; i < inputEventsMapping.size(); i++) {
+            allDeltas.add(inputEventsMapping.keyAt(i));
+        }
+        Collections.sort(allDeltas);
+
+        long recentTimeDelta = 0;
+        boolean result = true;
+        final Set<Integer> depressedMetaKeys = new HashSet<>();
+        final long startTimestamp = SystemClock.uptimeMillis();
+        final LongSparseArray<Integer> motionEventsBalanceByInputSource = new LongSparseArray<>();
+        for (final Long currentTimeDelta : allDeltas) {
+            final List<InputEventParams> eventParams = inputEventsMapping.get(currentTimeDelta);
+            final LongSparseArray<List<MotionInputEventParams>> motionParamsByInputSource = new LongSparseArray<>();
+            for (final InputEventParams eventParam : eventParams) {
+                if (eventParam instanceof KeyInputEventParams) {
+                    final int keyCode = ((KeyInputEventParams) eventParam).keyCode;
+                    final int keyAction = ((KeyInputEventParams) eventParam).keyAction;
+                    if (keyCode > KeyEvent.getMaxKeyCode()) {
+                        if (keyAction == KeyEvent.ACTION_DOWN) {
+                            depressedMetaKeys.add(keyCode);
+                        } else {
+                            depressedMetaKeys.remove(keyCode);
+                        }
+                    } else {
+                        result &= injectEventSync(new KeyEvent(startTimestamp + eventParam.startDelta,
+                                SystemClock.uptimeMillis(), keyAction, keyCode, metaKeysToState(depressedMetaKeys),
+                                KeyCharacterMap.VIRTUAL_KEYBOARD, 0, 0, InputDevice.SOURCE_KEYBOARD));
+                    }
+                } else if (eventParam instanceof MotionInputEventParams) {
+                    final int inputSource = toolTypeToInputSource(((MotionInputEventParams) eventParam).properties.toolType);
+                    final List<MotionInputEventParams> events = (motionParamsByInputSource.get(inputSource) == null) ?
+                            new ArrayList<MotionInputEventParams>() :
+                            motionParamsByInputSource.get(inputSource);
+                    events.add((MotionInputEventParams) eventParam);
+                    motionParamsByInputSource.put(inputSource, events);
+                }
+            }
+
+            for (int i = 0; i < motionParamsByInputSource.size(); i++) {
+                final int inputSource = (int) motionParamsByInputSource.keyAt(i);
+                final List<MotionInputEventParams> motionEventsParams = motionParamsByInputSource.valueAt(i);
+                final PointerProperties[] nonHoveringProps = filterPointerProperties(motionEventsParams,
+                        false);
+                final PointerProperties[] hoveringProps = filterPointerProperties(motionEventsParams,
+                        true);
+                final PointerCoords[] nonHoveringCoords = filterPointerCoordinates(motionEventsParams,
+                        false);
+                final PointerCoords[] hoveringCoords = filterPointerCoordinates(motionEventsParams,
+                        true);
+
+                for (final MotionInputEventParams motionEventParams : motionEventsParams) {
+                    final int actionCode = motionEventParams.actionCode;
+                    Integer upDownBalance = motionEventsBalanceByInputSource.get(inputSource);
+                    if (upDownBalance == null) {
+                        upDownBalance = 0;
+                    }
+                    switch (actionCode) {
+                        case MotionEvent.ACTION_DOWN: {
+                            ++upDownBalance;
+                            motionEventsBalanceByInputSource.put(inputSource, upDownBalance);
+                            if (upDownBalance == 1) {
+                                result &= injectEventSync(MotionEvent.obtain(startTimestamp + motionEventParams.startDelta,
+                                        SystemClock.uptimeMillis(), MotionEvent.ACTION_DOWN,
+                                        1, nonHoveringProps, nonHoveringCoords, metaKeysToState(depressedMetaKeys),
+                                        motionEventParams.button, 1, 1, 0, 0, inputSource, 0)
+                                );
+                            } else {
+                                result &= injectEventSync(MotionEvent.obtain(startTimestamp + motionEventParams.startDelta,
+                                        SystemClock.uptimeMillis(), getPointerAction(MotionEvent.ACTION_POINTER_DOWN, upDownBalance - 1),
+                                        upDownBalance, nonHoveringProps, nonHoveringCoords, metaKeysToState(depressedMetaKeys),
+                                        motionEventParams.button, 1, 1, 0, 0, inputSource, 0)
+                                );
+                            }
+                        }
+                        break;
+                        case MotionEvent.ACTION_UP: {
+                            if (upDownBalance > 0) {
+                                --upDownBalance;
+                            }
+                            motionEventsBalanceByInputSource.put(inputSource, upDownBalance);
+                            if (upDownBalance == 0) {
+                                result &= injectEventSync(MotionEvent.obtain(startTimestamp + motionEventParams.startDelta,
+                                        SystemClock.uptimeMillis(), MotionEvent.ACTION_UP, 1,
+                                        nonHoveringProps, nonHoveringCoords, metaKeysToState(depressedMetaKeys), motionEventParams.button,
+                                        1, 1, 0, 0, inputSource, 0)
+                                );
+                            } else {
+                                result &= injectEventSync(MotionEvent.obtain(startTimestamp + motionEventParams.startDelta,
+                                        SystemClock.uptimeMillis(), getPointerAction(MotionEvent.ACTION_POINTER_UP, upDownBalance - 1),
+                                        upDownBalance, nonHoveringProps, nonHoveringCoords, metaKeysToState(depressedMetaKeys),
+                                        motionEventParams.button, 1, 1, 0, 0, inputSource, 0)
+                                );
+                            }
+                        }
+                        break;
+                        case MotionEvent.ACTION_MOVE: {
+                            result &= injectEventSync(MotionEvent.obtain(startTimestamp + motionEventParams.startDelta,
+                                    SystemClock.uptimeMillis(), actionCode, upDownBalance,
+                                    nonHoveringProps, nonHoveringCoords, metaKeysToState(depressedMetaKeys),
+                                    motionEventParams.button, 1, 1, 0, 0, inputSource, 0)
+                            );
+                        }
+                        break;
+                        case MotionEvent.ACTION_HOVER_ENTER:
+                        case MotionEvent.ACTION_HOVER_EXIT:
+                        case MotionEvent.ACTION_HOVER_MOVE: {
+                            result &= injectEventSync(MotionEvent.obtain(startTimestamp + motionEventParams.startDelta,
+                                    SystemClock.uptimeMillis(), actionCode, hoveringProps.length,
+                                    hoveringProps, hoveringCoords, metaKeysToState(depressedMetaKeys),
+                                    0, 1, 1, 0, 0, inputSource, 0)
+                            );
+                        }
+                        break;
+                    } // switch
+                } // motionEventParams : motionEventsParams
+            } // for i < motionParamsByInputSource.size()
+            SystemClock.sleep(currentTimeDelta - recentTimeDelta);
+            recentTimeDelta = currentTimeDelta;
+        } // currentTimeDelta : allDeltas
+        return result;
+    }
+}

--- a/app/src/main/java/io/appium/uiautomator2/handler/W3CActions.java
+++ b/app/src/main/java/io/appium/uiautomator2/handler/W3CActions.java
@@ -212,38 +212,29 @@ public class W3CActions extends SafeRequestHandler {
                         case MotionEvent.ACTION_DOWN: {
                             ++upDownBalance;
                             motionEventsBalanceByInputSource.put(inputSource, upDownBalance);
-                            if (upDownBalance == 1) {
-                                result &= injectEventSync(MotionEvent.obtain(startTimestamp + motionEventParams.startDelta,
-                                        SystemClock.uptimeMillis(), MotionEvent.ACTION_DOWN,
-                                        1, nonHoveringProps, nonHoveringCoords, metaKeysToState(depressedMetaKeys),
-                                        motionEventParams.button, 1, 1, 0, 0, inputSource, 0)
-                                );
-                            } else {
-                                result &= injectEventSync(MotionEvent.obtain(startTimestamp + motionEventParams.startDelta,
-                                        SystemClock.uptimeMillis(), getPointerAction(MotionEvent.ACTION_POINTER_DOWN, upDownBalance - 1),
-                                        upDownBalance, nonHoveringProps, nonHoveringCoords, metaKeysToState(depressedMetaKeys),
-                                        motionEventParams.button, 1, 1, 0, 0, inputSource, 0)
-                                );
-                            }
+                            final int action = upDownBalance == 1 ? MotionEvent.ACTION_DOWN :
+                                    getPointerAction(MotionEvent.ACTION_POINTER_DOWN, upDownBalance - 1);
+                            result &= injectEventSync(MotionEvent.obtain(startTimestamp + motionEventParams.startDelta,
+                                    SystemClock.uptimeMillis(), action,
+                                    action == MotionEvent.ACTION_DOWN ? 1 : upDownBalance, nonHoveringProps, nonHoveringCoords,
+                                    metaKeysToState(depressedMetaKeys), motionEventParams.button,
+                                    1, 1, 0, 0, inputSource, 0));
                         }
                         break;
                         case MotionEvent.ACTION_UP: {
-                            if (upDownBalance > 0) {
-                                --upDownBalance;
+                            if (upDownBalance <= 0) {
+                                // ignore unbalanced pointer up actions
+                                break;
                             }
                             motionEventsBalanceByInputSource.put(inputSource, upDownBalance);
-                            if (upDownBalance == 0) {
-                                result &= injectEventSync(MotionEvent.obtain(startTimestamp + motionEventParams.startDelta,
-                                        SystemClock.uptimeMillis(), MotionEvent.ACTION_UP, 1,
-                                        nonHoveringProps, nonHoveringCoords, metaKeysToState(depressedMetaKeys), motionEventParams.button,
-                                        1, 1, 0, 0, inputSource, 0)
-                                );
-                            } else {
-                                result &= injectEventSync(MotionEvent.obtain(startTimestamp + motionEventParams.startDelta,
-                                        SystemClock.uptimeMillis(), getPointerAction(MotionEvent.ACTION_POINTER_UP, upDownBalance - 1),
-                                        upDownBalance, nonHoveringProps, nonHoveringCoords, metaKeysToState(depressedMetaKeys),
-                                        motionEventParams.button, 1, 1, 0, 0, inputSource, 0)
-                                );
+                            final int action = upDownBalance <= 1 ? MotionEvent.ACTION_UP :
+                                    getPointerAction(MotionEvent.ACTION_POINTER_UP, upDownBalance - 1);
+                            result &= injectEventSync(MotionEvent.obtain(startTimestamp + motionEventParams.startDelta,
+                                    SystemClock.uptimeMillis(), action, action == MotionEvent.ACTION_UP ? 1 : upDownBalance,
+                                    nonHoveringProps, nonHoveringCoords, metaKeysToState(depressedMetaKeys), motionEventParams.button,
+                                    1, 1, 0, 0, inputSource, 0));
+                            if (upDownBalance > 0) {
+                                --upDownBalance;
                             }
                         }
                         break;

--- a/app/src/main/java/io/appium/uiautomator2/server/AppiumServlet.java
+++ b/app/src/main/java/io/appium/uiautomator2/server/AppiumServlet.java
@@ -45,6 +45,7 @@ import io.appium.uiautomator2.handler.TouchDown;
 import io.appium.uiautomator2.handler.TouchLongClick;
 import io.appium.uiautomator2.handler.TouchMove;
 import io.appium.uiautomator2.handler.TouchUp;
+import io.appium.uiautomator2.handler.W3CActions;
 import io.appium.uiautomator2.handler.request.BaseRequestHandler;
 import io.appium.uiautomator2.handler.UpdateSettings;
 import io.appium.uiautomator2.http.AppiumResponse;
@@ -101,6 +102,7 @@ public class AppiumServlet implements IHttpServlet {
         register(postHandler, new Flick("/wd/hub/session/:sessionId/touch/flick"));
         register(postHandler, new ScrollTo("/wd/hub/session/:sessionId/touch/scroll"));
         register(postHandler, new MultiPointerGesture("/wd/hub/session/:sessionId/touch/multi/perform"));
+        register(postHandler, new W3CActions("/wd/hub/session/:sessionId/actions"));
         register(postHandler, new TouchDown("/wd/hub/session/:sessionId/touch/down"));
         register(postHandler, new TouchUp("/wd/hub/session/:sessionId/touch/up"));
         register(postHandler, new TouchMove("/wd/hub/session/:sessionId/touch/move"));

--- a/app/src/main/java/io/appium/uiautomator2/test/W3CActionsPreprocessingTests.java
+++ b/app/src/main/java/io/appium/uiautomator2/test/W3CActionsPreprocessingTests.java
@@ -1,0 +1,183 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.appium.uiautomator2.test;
+
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+import io.appium.uiautomator2.utils.w3c.ActionsParseException;
+
+import static io.appium.uiautomator2.utils.w3c.ActionsHelpers.preprocessActions;
+import static junit.framework.Assert.fail;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class W3CActionsPreprocessingTests {
+    @Test
+    public void verifyInvalidActionChainsPreprocessing() throws JSONException {
+        final List<String> invalidActions = Arrays.asList(
+                // missing action id
+        "[ {" +
+                "\"type\": \"pointer\"," +
+                "\"parameters\": {\"pointerType\": \"touch\"}," +
+                "\"actions\": [" +
+                "{\"type\": \"pointerMove\", \"duration\": 0, \"x\": 100, \"y\": 100}," +
+                "{\"type\": \"pointerDown\", \"button\": 0}," +
+                "{\"type\": \"pause\", \"duration\": 500}," +
+                "{\"type\": \"pointerMove\", \"duration\": 1000, \"origin\": \"pointer\", \"x\": -50, \"y\": 0}," +
+                "{\"type\": \"pointerUp\", \"button\": 0}]" +
+                "} ]",
+
+                // missing type
+                "[ {" +
+                "\"id\": \"finger1\"," +
+                "\"parameters\": {\"pointerType\": \"touch\"}," +
+                "\"actions\": [" +
+                "{\"type\": \"pointerMove\", \"duration\": 0, \"x\": 100, \"y\": 100}," +
+                "{\"type\": \"pointerDown\", \"button\": 0}," +
+                "{\"type\": \"pause\", \"duration\": 500}," +
+                "{\"type\": \"pointerMove\", \"duration\": 1000, \"origin\": \"pointer\", \"x\": -50, \"y\": 0}," +
+                "{\"type\": \"pointerUp\", \"button\": 0}]" +
+                "} ]",
+
+                // unknown type
+                "[ {" +
+                "\"type\": \"bla\"," +
+                "\"id\": \"finger1\"," +
+                "\"parameters\": {\"pointerType\": \"touch\"}," +
+                "\"actions\": [" +
+                "{\"type\": \"pointerMove\", \"duration\": 0, \"x\": 100, \"y\": 100}," +
+                "{\"type\": \"pointerDown\", \"button\": 0}," +
+                "{\"type\": \"pause\", \"duration\": 500}," +
+                "{\"type\": \"pointerMove\", \"duration\": 1000, \"origin\": \"pointer\", \"x\": -50, \"y\": 0}," +
+                "{\"type\": \"pointerUp\", \"button\": 0}]" +
+                "} ]",
+
+                // missing action items
+                "[ {" +
+                "\"type\": \"bla\"," +
+                "\"id\": \"finger1\"," +
+                "\"parameters\": {\"pointerType\": \"touch\"}" +
+                "} ]",
+
+                // unknown pointer type
+                "[ {" +
+                "\"type\": \"pointer\"," +
+                "\"id\": \"finger1\"," +
+                "\"parameters\": {\"pointerType\": \"bla\"}," +
+                "\"actions\": [" +
+                "{\"type\": \"pointerMove\", \"duration\": 0, \"x\": 100, \"y\": 100}," +
+                "{\"type\": \"pointerDown\", \"button\": 0}," +
+                "{\"type\": \"pause\", \"duration\": 500}," +
+                "{\"type\": \"pointerMove\", \"duration\": 1000, \"origin\": \"pointer\", \"x\": -50, \"y\": 0}," +
+                "{\"type\": \"pointerUp\", \"button\": 0}]" +
+                "} ]",
+
+                // non-matching pointer type
+                "[ {" +
+                "\"type\": \"key\"," +
+                "\"id\": \"finger1\"," +
+                "\"parameters\": {\"pointerType\": \"touch\"}," +
+                "\"actions\": [" +
+                "{\"type\": \"pointerMove\", \"duration\": 0, \"x\": 100, \"y\": 100}," +
+                "{\"type\": \"pointerDown\", \"button\": 0}," +
+                "{\"type\": \"pause\", \"duration\": 500}," +
+                "{\"type\": \"pointerMove\", \"duration\": 1000, \"origin\": \"pointer\", \"x\": -50, \"y\": 0}," +
+                "{\"type\": \"pointerUp\", \"button\": 0}]" +
+                "} ]",
+
+                // duplicated action id
+                "[ {" +
+                "\"id\": \"finger1\"," +
+                "\"type\": \"pointer\"," +
+                "\"parameters\": {\"pointerType\": \"touch\"}," +
+                "\"actions\": [" +
+                "{\"type\": \"pointerMove\", \"duration\": 0, \"x\": 100, \"y\": 100}," +
+                "{\"type\": \"pointerDown\", \"button\": 0}," +
+                "{\"type\": \"pause\", \"duration\": 500}," +
+                "{\"type\": \"pointerMove\", \"duration\": 1000, \"origin\": \"pointer\", \"x\": -50, \"y\": 0}," +
+                "{\"type\": \"pointerUp\", \"button\": 0}]" +
+                "}, {" +
+                "\"id\": \"finger1\"," +
+                "\"type\": \"pointer\"," +
+                "\"parameters\": {\"pointerType\": \"touch\"}," +
+                "\"actions\": [" +
+                "{\"type\": \"pointerMove\", \"duration\": 0, \"x\": 100, \"y\": 100}," +
+                "{\"type\": \"pointerDown\", \"button\": 0}," +
+                "{\"type\": \"pause\", \"duration\": 500}," +
+                "{\"type\": \"pointerMove\", \"duration\": 1000, \"origin\": \"pointer\", \"x\": -50, \"y\": 0}," +
+                "{\"type\": \"pointerUp\", \"button\": 0}]" +
+                "} ]"
+        );
+        for (final String invalidAction : invalidActions) {
+            final JSONArray invalidActionJson = new JSONArray(invalidAction);
+            try {
+                preprocessActions(invalidActionJson);
+                fail(String.format("'%s' should throw an exception", invalidAction));
+            } catch (JSONException | ActionsParseException e) {
+                // expected
+            }
+        }
+    }
+
+    @Test
+    public void verifyValidActionChainPreprocessingWithoutChange() throws JSONException {
+        final JSONArray actionJson = new JSONArray("[ {" +
+                "\"type\": \"pointer\"," +
+                "\"id\": \"finger1\"," +
+                "\"parameters\": {\"pointerType\": \"touch\"}," +
+                "\"actions\": [" +
+                "{\"type\": \"pointerMove\", \"duration\": 0, \"x\": 100, \"y\": 100}," +
+                "{\"type\": \"pointerDown\", \"button\": 0}," +
+                "{\"type\": \"pause\", \"duration\": 500}," +
+                "{\"type\": \"pointerMove\", \"duration\": 1000, \"origin\": \"pointer\", \"x\": -50, \"y\": 0}," +
+                "{\"type\": \"pointerUp\", \"button\": 0}]" +
+                "} ]");
+        assertThat(preprocessActions(actionJson).toString(), is(equalTo(actionJson.toString())));
+    }
+
+    @Test
+    public void verifyValidActionChainPreprocessingWithCancelChange() throws JSONException {
+        final JSONArray actionJson = new JSONArray("[ {" +
+                "\"type\": \"pointer\"," +
+                "\"id\": \"finger1\"," +
+                "\"parameters\": {\"pointerType\": \"touch\"}," +
+                "\"actions\": [" +
+                "{\"type\": \"pointerMove\", \"duration\": 0, \"x\": 100, \"y\": 100}," +
+                "{\"type\": \"pointerCancel\"}," +
+                "{\"type\": \"pause\", \"duration\": 500}," +
+                "{\"type\": \"pointerMove\", \"duration\": 1000, \"origin\": \"pointer\", \"x\": -50, \"y\": 0}," +
+                "{\"type\": \"pointerUp\", \"button\": 0}]" +
+                "} ]");
+        final JSONArray processedJson = new JSONArray("[ {" +
+                "\"type\": \"pointer\"," +
+                "\"id\": \"finger1\"," +
+                "\"parameters\": {\"pointerType\": \"touch\"}," +
+                "\"actions\": [" +
+                "{\"type\": \"pause\", \"duration\": 500}," +
+                "{\"type\": \"pointerMove\", \"duration\": 1000, \"origin\": \"pointer\", \"x\": -50, \"y\": 0}," +
+                "{\"type\": \"pointerUp\", \"button\": 0}]" +
+                "} ]");
+        assertThat(preprocessActions(actionJson).toString(), is(equalTo(processedJson.toString())));
+    }
+
+}

--- a/app/src/main/java/io/appium/uiautomator2/test/W3CActionsTransformationTests.java
+++ b/app/src/main/java/io/appium/uiautomator2/test/W3CActionsTransformationTests.java
@@ -1,0 +1,728 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.appium.uiautomator2.test;
+
+import android.util.LongSparseArray;
+import android.view.KeyEvent;
+import android.view.MotionEvent;
+
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.junit.Test;
+
+import java.util.List;
+
+import io.appium.uiautomator2.utils.w3c.ActionsHelpers.InputEventParams;
+import io.appium.uiautomator2.utils.w3c.ActionsHelpers.KeyInputEventParams;
+import io.appium.uiautomator2.utils.w3c.ActionsHelpers.MotionInputEventParams;
+import io.appium.uiautomator2.utils.w3c.ActionsParseException;
+
+import static io.appium.uiautomator2.utils.w3c.ActionsHelpers.actionsToInputEventsMapping;
+import static io.appium.uiautomator2.utils.w3c.ActionsHelpers.preprocessActions;
+import static junit.framework.Assert.assertEquals;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class W3CActionsTransformationTests {
+
+    @Test
+    public void verifyValidInputEventsChainIsCompiledForNoneAction() throws JSONException {
+        final JSONArray actionJson = new JSONArray("[ {" +
+                "\"type\": \"none\"," +
+                "\"id\": \"none1\"," +
+                "\"actions\": [" +
+                "{\"type\": \"pause\", \"duration\": 200}," +
+                "{\"type\": \"pause\", \"duration\": 20}]" +
+                "} ]");
+        final LongSparseArray<List<InputEventParams>> eventsChain = actionsToInputEventsMapping(
+                preprocessActions(actionJson)
+        );
+        assertThat(eventsChain.size(), equalTo(2));
+
+        assertThat(eventsChain.keyAt(0), equalTo(200L));
+        assertThat(eventsChain.valueAt(0).size(), equalTo(0));
+
+        assertThat(eventsChain.keyAt(1), equalTo(220L));
+        assertThat(eventsChain.valueAt(1).size(), equalTo(0));
+    }
+
+
+    @Test
+    public void verifyValidInputEventsChainIsCompiledForSingleKeysGesture() throws JSONException {
+        final JSONArray actionJson = new JSONArray("[ {" +
+                "\"type\": \"key\"," +
+                "\"id\": \"keyboard\"," +
+                "\"actions\": [" +
+                "{\"type\": \"keyDown\", \"value\": \"\u2000\"}," +
+                "{\"type\": \"keyDown\", \"value\": \"A\"}," +
+                "{\"type\": \"keyUp\", \"value\": \"A\"}," +
+                "{\"type\": \"keyUp\", \"value\": \"\u2000\"}]" +
+                "} ]");
+        final LongSparseArray<List<InputEventParams>> eventsChain = actionsToInputEventsMapping(
+                preprocessActions(actionJson)
+        );
+        assertThat(eventsChain.size(), equalTo(1));
+        final List<InputEventParams> generatedParams = eventsChain.valueAt(0);
+        assertThat(generatedParams.size(), equalTo(4));
+
+        for (final InputEventParams params : generatedParams) {
+            assertThat(params.startDelta, equalTo(0L));
+            assertThat(params, is(instanceOf(KeyInputEventParams.class)));
+        }
+
+        assertThat(((KeyInputEventParams) generatedParams.get(0)).keyAction,
+                equalTo(KeyEvent.ACTION_DOWN));
+        assertThat(((KeyInputEventParams) generatedParams.get(0)).keyCode, equalTo(0x2000));
+
+        assertThat(((KeyInputEventParams) generatedParams.get(1)).keyAction,
+                equalTo(KeyEvent.ACTION_DOWN));
+        assertThat(((KeyInputEventParams) generatedParams.get(1)).keyCode, equalTo(65));
+
+        assertThat(((KeyInputEventParams) generatedParams.get(2)).keyAction,
+                equalTo(KeyEvent.ACTION_UP));
+        assertThat(((KeyInputEventParams) generatedParams.get(2)).keyCode, equalTo(65));
+
+        assertThat(((KeyInputEventParams) generatedParams.get(3)).keyAction,
+                equalTo(KeyEvent.ACTION_UP));
+        assertThat(((KeyInputEventParams) generatedParams.get(3)).keyCode, equalTo(0x2000));
+    }
+
+    @Test
+    public void verifyValidInputEventsChainIsCompiledForSingleKeysGestureWithPause() throws JSONException {
+        final JSONArray actionJson = new JSONArray("[ {" +
+                "\"type\": \"key\"," +
+                "\"id\": \"keyboard\"," +
+                "\"actions\": [" +
+                "{\"type\": \"keyDown\", \"value\": \"A\"}," +
+                "{\"type\": \"pause\", \"duration\": 500}," +
+                "{\"type\": \"keyUp\", \"value\": \"A\"}]" +
+                "} ]");
+        final LongSparseArray<List<InputEventParams>> eventsChain = actionsToInputEventsMapping(
+                preprocessActions(actionJson)
+        );
+        assertThat(eventsChain.size(), equalTo(2));
+
+        final List<InputEventParams> paramSet1 = eventsChain.valueAt(0);
+        assertThat(paramSet1.size(), equalTo(1));
+        final KeyInputEventParams downParams = (KeyInputEventParams) paramSet1.get(0);
+        assertThat(downParams.startDelta, equalTo(0L));
+        assertThat(downParams.keyAction, equalTo(KeyEvent.ACTION_DOWN));
+        assertThat(downParams.keyCode, equalTo(65));
+
+
+        assertThat(eventsChain.keyAt(1), equalTo(500L));
+        final List<InputEventParams> paramSet2 = eventsChain.valueAt(1);
+        assertThat(paramSet2.size(), equalTo(1));
+        final KeyInputEventParams upParams = (KeyInputEventParams) paramSet2.get(0);
+        assertThat(upParams.startDelta, equalTo(0L));
+        assertThat(upParams.keyAction, equalTo(KeyEvent.ACTION_UP));
+        assertThat(upParams.keyCode, equalTo(65));
+    }
+
+    @Test
+    public void verifyValidInputEventsChainIsCompiledForSingleFingerGestureWithKeys() throws JSONException {
+        final JSONArray actionJson = new JSONArray("[ {" +
+                "\"type\": \"pointer\"," +
+                "\"id\": \"finger1\"," +
+                "\"parameters\": {\"pointerType\": \"touch\"}," +
+                "\"actions\": [" +
+                "{\"type\": \"pointerMove\", \"duration\": 0, \"x\": 100, \"y\": 100}," +
+                "{\"type\": \"pointerDown\"}," +
+                "{\"type\": \"pause\", \"duration\": 10}," +
+                "{\"type\": \"pointerMove\", \"duration\": 10, \"origin\": \"pointer\", \"x\": -50, \"y\": 0}," +
+                "{\"type\": \"pointerUp\"}]" +
+                "}, {" +
+                "\"type\": \"key\"," +
+                "\"id\": \"keyboard\"," +
+                "\"actions\": [" +
+                "{\"type\": \"pause\", \"duration\": 10}," +
+                "{\"type\": \"keyDown\", \"value\": \"\u2000\"}," +
+                "{\"type\": \"pause\", \"duration\": 20}," +
+                "{\"type\": \"keyUp\", \"value\": \"\u2000\"}]" +
+                "} ]");
+        final LongSparseArray<List<InputEventParams>> eventsChain = actionsToInputEventsMapping(
+                preprocessActions(actionJson)
+        );
+        assertThat(eventsChain.size(), equalTo(5));
+
+        final List<InputEventParams> paramSet1 = eventsChain.valueAt(0);
+        assertThat(eventsChain.keyAt(0), equalTo(0L));
+        assertThat(paramSet1.size(), equalTo(1));
+
+        final MotionInputEventParams downParams = (MotionInputEventParams) paramSet1.get(0);
+        assertThat(downParams.startDelta, equalTo(0L));
+        assertThat(downParams.actionCode, equalTo(MotionEvent.ACTION_DOWN));
+        assertThat(downParams.button, equalTo(0));
+        assertEquals(downParams.coordinates.x, 100.0, Math.ulp(1.0));
+        assertEquals(downParams.coordinates.y, 100.0, Math.ulp(1.0));
+        assertThat(downParams.properties.id, is(equalTo(0)));
+        assertThat(downParams.properties.toolType, equalTo(MotionEvent.TOOL_TYPE_FINGER));
+
+        final List<InputEventParams> paramSet2 = eventsChain.valueAt(1);
+        assertThat(eventsChain.keyAt(1), equalTo(10L));
+        assertThat(paramSet2.size(), equalTo(2));
+
+        final MotionInputEventParams move1Params = (MotionInputEventParams) paramSet2.get(0);
+        assertThat(move1Params.startDelta, equalTo(0L));
+        assertThat(move1Params.actionCode, equalTo(MotionEvent.ACTION_MOVE));
+        assertThat(move1Params.button, equalTo(0));
+        assertEquals(move1Params.coordinates.x, 100.0, Math.ulp(1.0));
+        assertEquals(move1Params.coordinates.y, 100.0, Math.ulp(1.0));
+        assertThat(move1Params.properties.id, is(equalTo(0)));
+        assertThat(move1Params.properties.toolType, equalTo(MotionEvent.TOOL_TYPE_FINGER));
+
+        final KeyInputEventParams keyDownParams = (KeyInputEventParams) paramSet2.get(1);
+        assertThat(keyDownParams.startDelta, equalTo(10L));
+        assertThat(keyDownParams.keyAction, equalTo(KeyEvent.ACTION_DOWN));
+        assertThat(keyDownParams.keyCode, equalTo(0x2000));
+
+        final List<InputEventParams> paramSet3 = eventsChain.valueAt(2);
+        assertThat(eventsChain.keyAt(2), equalTo(15L));
+        assertThat(paramSet3.size(), equalTo(1));
+
+        final MotionInputEventParams move2Params = (MotionInputEventParams) paramSet3.get(0);
+        assertThat(move2Params.startDelta, equalTo(0L));
+        assertThat(move2Params.actionCode, equalTo(MotionEvent.ACTION_MOVE));
+        assertThat(move2Params.button, equalTo(0));
+        assertEquals(move2Params.coordinates.x, 75.0, Math.ulp(1.0));
+        assertEquals(move2Params.coordinates.y, 100.0, Math.ulp(1.0));
+        assertThat(move2Params.properties.id, is(equalTo(0)));
+        assertThat(move2Params.properties.toolType, equalTo(MotionEvent.TOOL_TYPE_FINGER));
+
+        final List<InputEventParams> paramSet4 = eventsChain.valueAt(3);
+        assertThat(eventsChain.keyAt(3), equalTo(20L));
+        assertThat(paramSet4.size(), equalTo(1));
+
+        final MotionInputEventParams upParams = (MotionInputEventParams) paramSet4.get(0);
+        assertThat(upParams.startDelta, equalTo(0L));
+        assertThat(upParams.actionCode, equalTo(MotionEvent.ACTION_UP));
+        assertThat(upParams.button, equalTo(0));
+        assertEquals(upParams.coordinates.x, 50.0, Math.ulp(1.0));
+        assertEquals(upParams.coordinates.y, 100.0, Math.ulp(1.0));
+        assertThat(upParams.properties.id, is(equalTo(0)));
+        assertThat(upParams.properties.toolType, equalTo(MotionEvent.TOOL_TYPE_FINGER));
+
+        final List<InputEventParams> paramSet5 = eventsChain.valueAt(4);
+        assertThat(eventsChain.keyAt(4), equalTo(30L));
+        assertThat(paramSet5.size(), equalTo(1));
+
+        final KeyInputEventParams keyUpParams = (KeyInputEventParams) paramSet5.get(0);
+        assertThat(keyUpParams.startDelta, equalTo(10L));
+        assertThat(keyUpParams.keyAction, equalTo(KeyEvent.ACTION_UP));
+        assertThat(keyUpParams.keyCode, equalTo(0x2000));
+    }
+
+    @Test
+    public void verifyValidInputEventsChainIsCompiledForSingleFingerGesture() throws JSONException {
+        final JSONArray actionJson = new JSONArray("[ {" +
+                "\"type\": \"pointer\"," +
+                "\"id\": \"finger1\"," +
+                "\"parameters\": {\"pointerType\": \"touch\"}," +
+                "\"actions\": [" +
+                "{\"type\": \"pointerMove\", \"duration\": 0, \"x\": 100, \"y\": 100}," +
+                "{\"type\": \"pointerDown\"}," +
+                "{\"type\": \"pause\", \"duration\": 10}," +
+                "{\"type\": \"pointerMove\", \"duration\": 10, \"origin\": \"pointer\", \"x\": -50, \"y\": 0}," +
+                "{\"type\": \"pointerUp\"}]" +
+                "} ]");
+        final LongSparseArray<List<InputEventParams>> eventsChain = actionsToInputEventsMapping(
+                preprocessActions(actionJson)
+        );
+        assertThat(eventsChain.size(), equalTo(4));
+
+        final List<InputEventParams> paramSet1 = eventsChain.valueAt(0);
+        assertThat(eventsChain.keyAt(0), equalTo(0L));
+        assertThat(paramSet1.size(), equalTo(1));
+
+        final MotionInputEventParams downParams = (MotionInputEventParams) paramSet1.get(0);
+        assertThat(downParams.startDelta, equalTo(0L));
+        assertThat(downParams.actionCode, equalTo(MotionEvent.ACTION_DOWN));
+        assertThat(downParams.button, equalTo(0));
+        assertEquals(downParams.coordinates.x, 100.0, Math.ulp(1.0));
+        assertEquals(downParams.coordinates.y, 100.0, Math.ulp(1.0));
+        assertThat(downParams.properties.id, is(equalTo(0)));
+        assertThat(downParams.properties.toolType, equalTo(MotionEvent.TOOL_TYPE_FINGER));
+
+        final List<InputEventParams> paramSet2 = eventsChain.valueAt(1);
+        assertThat(eventsChain.keyAt(1), equalTo(10L));
+        assertThat(paramSet2.size(), equalTo(1));
+
+        final MotionInputEventParams move1Params = (MotionInputEventParams) paramSet2.get(0);
+        assertThat(move1Params.startDelta, equalTo(0L));
+        assertThat(move1Params.actionCode, equalTo(MotionEvent.ACTION_MOVE));
+        assertThat(move1Params.button, equalTo(0));
+        assertEquals(move1Params.coordinates.x, 100.0, Math.ulp(1.0));
+        assertEquals(move1Params.coordinates.y, 100.0, Math.ulp(1.0));
+        assertThat(move1Params.properties.id, is(equalTo(0)));
+        assertThat(move1Params.properties.toolType, equalTo(MotionEvent.TOOL_TYPE_FINGER));
+
+        final List<InputEventParams> paramSet3 = eventsChain.valueAt(2);
+        assertThat(eventsChain.keyAt(2), equalTo(15L));
+        assertThat(paramSet3.size(), equalTo(1));
+
+        final MotionInputEventParams move2Params = (MotionInputEventParams) paramSet3.get(0);
+        assertThat(move2Params.startDelta, equalTo(0L));
+        assertThat(move2Params.actionCode, equalTo(MotionEvent.ACTION_MOVE));
+        assertThat(move2Params.button, equalTo(0));
+        assertEquals(move2Params.coordinates.x, 75.0, Math.ulp(1.0));
+        assertEquals(move2Params.coordinates.y, 100.0, Math.ulp(1.0));
+        assertThat(move2Params.properties.id, is(equalTo(0)));
+        assertThat(move2Params.properties.toolType, equalTo(MotionEvent.TOOL_TYPE_FINGER));
+
+        final List<InputEventParams> paramSet4 = eventsChain.valueAt(3);
+        assertThat(eventsChain.keyAt(3), equalTo(20L));
+        assertThat(paramSet4.size(), equalTo(1));
+
+        final MotionInputEventParams upParams = (MotionInputEventParams) paramSet4.get(0);
+        assertThat(upParams.startDelta, equalTo(0L));
+        assertThat(upParams.actionCode, equalTo(MotionEvent.ACTION_UP));
+        assertThat(upParams.button, equalTo(0));
+        assertEquals(upParams.coordinates.x, 50.0, Math.ulp(1.0));
+        assertEquals(upParams.coordinates.y, 100.0, Math.ulp(1.0));
+        assertThat(upParams.properties.id, is(equalTo(0)));
+        assertThat(upParams.properties.toolType, equalTo(MotionEvent.TOOL_TYPE_FINGER));
+    }
+
+    @Test
+    public void verifyValidInputEventsChainIsCompiledForMouseGestureWithMultipleMoves()
+            throws JSONException {
+        final JSONArray actionJson = new JSONArray("[ {" +
+                "\"type\": \"pointer\"," +
+                "\"id\": \"mouse1\"," +
+                "\"actions\": [" +
+                "{\"type\": \"pointerMove\", \"duration\": 0, \"x\": 100, \"y\": 100}," +
+                "{\"type\": \"pointerDown\", \"button\": 2}," +
+                "{\"type\": \"pointerMove\", \"duration\": 10, \"origin\": \"pointer\", \"x\": -50, \"y\": 0}," +
+                "{\"type\": \"pointerMove\", \"duration\": 10, \"origin\": \"pointer\", \"x\": 100, \"y\": 0}," +
+                "{\"type\": \"pointerMove\", \"duration\": 10, \"x\": 0, \"y\": 0}," +
+                "{\"type\": \"pointerUp\", \"button\": 2}]" +
+                "} ]");
+        final LongSparseArray<List<InputEventParams>> eventsChain = actionsToInputEventsMapping(
+                preprocessActions(actionJson)
+        );
+        assertThat(eventsChain.size(), equalTo(7));
+
+        final List<InputEventParams> paramSet1 = eventsChain.valueAt(0);
+        assertThat(eventsChain.keyAt(0), equalTo(0L));
+        assertThat(paramSet1.size(), equalTo(2));
+
+        final MotionInputEventParams downParams = (MotionInputEventParams) paramSet1.get(0);
+        assertThat(downParams.startDelta, equalTo(0L));
+        assertThat(downParams.actionCode, equalTo(MotionEvent.ACTION_DOWN));
+        assertThat(downParams.button, equalTo(MotionEvent.BUTTON_SECONDARY));
+        assertEquals(downParams.coordinates.x, 100.0, Math.ulp(1.0));
+        assertEquals(downParams.coordinates.y, 100.0, Math.ulp(1.0));
+        assertThat(downParams.properties.id, is(equalTo(0)));
+        assertThat(downParams.properties.toolType, equalTo(MotionEvent.TOOL_TYPE_MOUSE));
+
+        final MotionInputEventParams move1Params = (MotionInputEventParams) paramSet1.get(1);
+        assertThat(move1Params.startDelta, equalTo(0L));
+        assertThat(move1Params.actionCode, equalTo(MotionEvent.ACTION_MOVE));
+        assertThat(move1Params.button, equalTo(MotionEvent.BUTTON_SECONDARY));
+        assertEquals(move1Params.coordinates.x, 100.0, Math.ulp(1.0));
+        assertEquals(move1Params.coordinates.y, 100.0, Math.ulp(1.0));
+        assertThat(move1Params.properties.id, is(equalTo(0)));
+        assertThat(move1Params.properties.toolType, equalTo(MotionEvent.TOOL_TYPE_MOUSE));
+
+        final List<InputEventParams> paramSet2 = eventsChain.valueAt(1);
+        assertThat(eventsChain.keyAt(1), equalTo(5L));
+        assertThat(paramSet2.size(), equalTo(1));
+
+        final MotionInputEventParams move2Params = (MotionInputEventParams) paramSet2.get(0);
+        assertThat(move2Params.startDelta, equalTo(0L));
+        assertThat(move2Params.actionCode, equalTo(MotionEvent.ACTION_MOVE));
+        assertThat(move2Params.button, equalTo(MotionEvent.BUTTON_SECONDARY));
+        assertEquals(move2Params.coordinates.x, 75.0, Math.ulp(1.0));
+        assertEquals(move2Params.coordinates.y, 100.0, Math.ulp(1.0));
+        assertThat(move2Params.properties.id, is(equalTo(0)));
+        assertThat(move2Params.properties.toolType, equalTo(MotionEvent.TOOL_TYPE_MOUSE));
+
+        final List<InputEventParams> paramSet3 = eventsChain.valueAt(2);
+        assertThat(eventsChain.keyAt(2), equalTo(10L));
+        assertThat(paramSet3.size(), equalTo(1));
+
+        final MotionInputEventParams move3Params = (MotionInputEventParams) paramSet3.get(0);
+        assertThat(move3Params.startDelta, equalTo(0L));
+        assertThat(move3Params.actionCode, equalTo(MotionEvent.ACTION_MOVE));
+        assertThat(move3Params.button, equalTo(MotionEvent.BUTTON_SECONDARY));
+        assertEquals(move3Params.coordinates.x, 50.0, Math.ulp(1.0));
+        assertEquals(move3Params.coordinates.y, 100.0, Math.ulp(1.0));
+        assertThat(move3Params.properties.id, is(equalTo(0)));
+        assertThat(move3Params.properties.toolType, equalTo(MotionEvent.TOOL_TYPE_MOUSE));
+
+        final List<InputEventParams> paramSet4 = eventsChain.valueAt(3);
+        assertThat(eventsChain.keyAt(3), equalTo(15L));
+        assertThat(paramSet4.size(), equalTo(1));
+
+        final MotionInputEventParams move4Params = (MotionInputEventParams) paramSet4.get(0);
+        assertThat(move4Params.startDelta, equalTo(0L));
+        assertThat(move4Params.actionCode, equalTo(MotionEvent.ACTION_MOVE));
+        assertThat(move4Params.button, equalTo(MotionEvent.BUTTON_SECONDARY));
+        assertEquals(move4Params.coordinates.x, 100.0, Math.ulp(1.0));
+        assertEquals(move4Params.coordinates.y, 100.0, Math.ulp(1.0));
+        assertThat(move4Params.properties.id, is(equalTo(0)));
+        assertThat(move4Params.properties.toolType, equalTo(MotionEvent.TOOL_TYPE_MOUSE));
+
+        final List<InputEventParams> paramSet5 = eventsChain.valueAt(4);
+        assertThat(eventsChain.keyAt(4), equalTo(20L));
+        assertThat(paramSet5.size(), equalTo(1));
+
+        final MotionInputEventParams move5Params = (MotionInputEventParams) paramSet5.get(0);
+        assertThat(move5Params.startDelta, equalTo(0L));
+        assertThat(move5Params.actionCode, equalTo(MotionEvent.ACTION_MOVE));
+        assertThat(move5Params.button, equalTo(MotionEvent.BUTTON_SECONDARY));
+        assertEquals(move5Params.coordinates.x, 150.0, Math.ulp(1.0));
+        assertEquals(move5Params.coordinates.y, 100.0, Math.ulp(1.0));
+        assertThat(move5Params.properties.id, is(equalTo(0)));
+        assertThat(move5Params.properties.toolType, equalTo(MotionEvent.TOOL_TYPE_MOUSE));
+
+        final List<InputEventParams> paramSet6 = eventsChain.valueAt(5);
+        assertThat(eventsChain.keyAt(5), equalTo(25L));
+        assertThat(paramSet6.size(), equalTo(1));
+
+        final MotionInputEventParams move6Params = (MotionInputEventParams) paramSet6.get(0);
+        assertThat(move6Params.startDelta, equalTo(0L));
+        assertThat(move6Params.actionCode, equalTo(MotionEvent.ACTION_MOVE));
+        assertThat(move6Params.button, equalTo(MotionEvent.BUTTON_SECONDARY));
+        assertEquals(move6Params.coordinates.x, 75.0, Math.ulp(1.0));
+        assertEquals(move6Params.coordinates.y, 50.0, Math.ulp(1.0));
+        assertThat(move6Params.properties.id, is(equalTo(0)));
+        assertThat(move6Params.properties.toolType, equalTo(MotionEvent.TOOL_TYPE_MOUSE));
+
+        final List<InputEventParams> paramSet7 = eventsChain.valueAt(6);
+        assertThat(eventsChain.keyAt(6), equalTo(30L));
+        assertThat(paramSet7.size(), equalTo(1));
+
+        final MotionInputEventParams upParams = (MotionInputEventParams) paramSet7.get(0);
+        assertThat(upParams.startDelta, equalTo(0L));
+        assertThat(upParams.actionCode, equalTo(MotionEvent.ACTION_UP));
+        assertThat(upParams.button, equalTo(MotionEvent.BUTTON_SECONDARY));
+        assertEquals(upParams.coordinates.x, 0.0, Math.ulp(1.0));
+        assertEquals(upParams.coordinates.y, 0.0, Math.ulp(1.0));
+        assertThat(upParams.properties.id, is(equalTo(0)));
+        assertThat(upParams.properties.toolType, equalTo(MotionEvent.TOOL_TYPE_MOUSE));
+    }
+
+    @Test
+    public void verifyValidInputEventsChainIsCompiledForMouseGestureWithHoverGesture()
+            throws JSONException {
+        final JSONArray actionJson = new JSONArray("[ {" +
+                "\"type\": \"pointer\"," +
+                "\"id\": \"mouse1\"," +
+                "\"actions\": [" +
+                "{\"type\": \"pointerMove\", \"duration\": 0, \"x\": 100, \"y\": 100}," +
+                "{\"type\": \"pointerMove\", \"duration\": 10, \"x\": 0, \"y\": 0}]" +
+                "} ]");
+        final LongSparseArray<List<InputEventParams>> eventsChain = actionsToInputEventsMapping(
+                preprocessActions(actionJson)
+        );
+        assertThat(eventsChain.size(), equalTo(3));
+
+        final List<InputEventParams> paramSet1 = eventsChain.valueAt(0);
+        assertThat(eventsChain.keyAt(0), equalTo(0L));
+        assertThat(paramSet1.size(), equalTo(2));
+
+        final MotionInputEventParams enterParams = (MotionInputEventParams) paramSet1.get(0);
+        assertThat(enterParams.startDelta, equalTo(0L));
+        assertThat(enterParams.actionCode, equalTo(MotionEvent.ACTION_HOVER_ENTER));
+        assertThat(enterParams.button, equalTo(0));
+        assertEquals(enterParams.coordinates.x, 100.0, Math.ulp(1.0));
+        assertEquals(enterParams.coordinates.y, 100.0, Math.ulp(1.0));
+        assertThat(enterParams.properties.id, is(equalTo(0)));
+        assertThat(enterParams.properties.toolType, equalTo(MotionEvent.TOOL_TYPE_MOUSE));
+
+        final MotionInputEventParams move1Params = (MotionInputEventParams) paramSet1.get(1);
+        assertThat(move1Params.startDelta, equalTo(0L));
+        assertThat(move1Params.actionCode, equalTo(MotionEvent.ACTION_HOVER_MOVE));
+        assertThat(move1Params.button, equalTo(0));
+        assertEquals(move1Params.coordinates.x, 100.0, Math.ulp(1.0));
+        assertEquals(move1Params.coordinates.y, 100.0, Math.ulp(1.0));
+        assertThat(move1Params.properties.id, is(equalTo(0)));
+        assertThat(move1Params.properties.toolType, equalTo(MotionEvent.TOOL_TYPE_MOUSE));
+
+        final List<InputEventParams> paramSet2 = eventsChain.valueAt(1);
+        assertThat(eventsChain.keyAt(1), equalTo(5L));
+        assertThat(paramSet2.size(), equalTo(1));
+
+        final MotionInputEventParams move2Params = (MotionInputEventParams) paramSet2.get(0);
+        assertThat(move2Params.startDelta, equalTo(0L));
+        assertThat(move2Params.actionCode, equalTo(MotionEvent.ACTION_HOVER_MOVE));
+        assertThat(move2Params.button, equalTo(0));
+        assertEquals(move2Params.coordinates.x, 50.0, Math.ulp(1.0));
+        assertEquals(move2Params.coordinates.y, 50.0, Math.ulp(1.0));
+        assertThat(move2Params.properties.id, is(equalTo(0)));
+        assertThat(move2Params.properties.toolType, equalTo(MotionEvent.TOOL_TYPE_MOUSE));
+
+        final List<InputEventParams> paramSet3 = eventsChain.valueAt(2);
+        assertThat(eventsChain.keyAt(2), equalTo(10L));
+        assertThat(paramSet3.size(), equalTo(1));
+
+        final MotionInputEventParams exitParams = (MotionInputEventParams) paramSet3.get(0);
+        assertThat(exitParams.startDelta, equalTo(0L));
+        assertThat(exitParams.actionCode, equalTo(MotionEvent.ACTION_HOVER_EXIT));
+        assertThat(exitParams.button, equalTo(0));
+        assertEquals(exitParams.coordinates.x, 0.0, Math.ulp(1.0));
+        assertEquals(exitParams.coordinates.y, 0.0, Math.ulp(1.0));
+        assertThat(exitParams.properties.id, is(equalTo(0)));
+        assertThat(exitParams.properties.toolType, equalTo(MotionEvent.TOOL_TYPE_MOUSE));
+    }
+
+    @Test
+    public void verifyValidInputEventsChainIsCompiledForMultipleFingersGesture() throws JSONException {
+        final JSONArray actionJson = new JSONArray("[ {" +
+                "\"type\": \"pointer\"," +
+                "\"id\": \"finger1\"," +
+                "\"parameters\": {\"pointerType\": \"touch\"}," +
+                "\"actions\": [" +
+                "{\"type\": \"pointerMove\", \"duration\": 0, \"x\": 0, \"y\": 0}," +
+                "{\"type\": \"pointerDown\"}," +
+                "{\"type\": \"pause\", \"duration\": 10}," +
+                "{\"type\": \"pointerMove\", \"duration\": 10, \"origin\": \"pointer\", \"x\": 50, \"y\": 50}," +
+                "{\"type\": \"pointerUp\"}]" +
+                "}, { " +
+                "\"type\": \"pointer\"," +
+                "\"id\": \"finger2\"," +
+                "\"parameters\": {\"pointerType\": \"touch\"}," +
+                "\"actions\": [" +
+                "{\"type\": \"pointerMove\", \"duration\": 0, \"x\": 100, \"y\": 100}," +
+                "{\"type\": \"pointerDown\"}," +
+                "{\"type\": \"pause\", \"duration\": 10}," +
+                "{\"type\": \"pointerMove\", \"duration\": 10, \"origin\": \"pointer\", \"x\": -50, \"y\": -50}," +
+                "{\"type\": \"pointerUp\"}]" +
+                "} ]");
+        final LongSparseArray<List<InputEventParams>> eventsChain = actionsToInputEventsMapping(
+                preprocessActions(actionJson)
+        );
+        assertThat(eventsChain.size(), equalTo(4));
+
+        final List<InputEventParams> paramSet1 = eventsChain.valueAt(0);
+        assertThat(eventsChain.keyAt(0), equalTo(0L));
+        assertThat(paramSet1.size(), equalTo(2));
+
+        final MotionInputEventParams down1Params = (MotionInputEventParams) paramSet1.get(0);
+        assertThat(down1Params.startDelta, equalTo(0L));
+        assertThat(down1Params.actionCode, equalTo(MotionEvent.ACTION_DOWN));
+        assertThat(down1Params.button, equalTo(0));
+        assertEquals(down1Params.coordinates.x, 0.0, Math.ulp(1.0));
+        assertEquals(down1Params.coordinates.y, 0.0, Math.ulp(1.0));
+        assertThat(down1Params.properties.id, is(equalTo(0)));
+        assertThat(down1Params.properties.toolType, equalTo(MotionEvent.TOOL_TYPE_FINGER));
+
+        final MotionInputEventParams down2Params = (MotionInputEventParams) paramSet1.get(1);
+        assertThat(down2Params.startDelta, equalTo(0L));
+        assertThat(down2Params.actionCode, equalTo(MotionEvent.ACTION_DOWN));
+        assertThat(down2Params.button, equalTo(0));
+        assertEquals(down2Params.coordinates.x, 100.0, Math.ulp(1.0));
+        assertEquals(down2Params.coordinates.y, 100.0, Math.ulp(1.0));
+        assertThat(down2Params.properties.id, is(equalTo(1)));
+        assertThat(down2Params.properties.toolType, equalTo(MotionEvent.TOOL_TYPE_FINGER));
+
+        final List<InputEventParams> paramSet2 = eventsChain.valueAt(1);
+        assertThat(eventsChain.keyAt(1), equalTo(10L));
+        assertThat(paramSet2.size(), equalTo(2));
+
+        final MotionInputEventParams move11Params = (MotionInputEventParams) paramSet2.get(0);
+        assertThat(move11Params.startDelta, equalTo(0L));
+        assertThat(move11Params.actionCode, equalTo(MotionEvent.ACTION_MOVE));
+        assertThat(move11Params.button, equalTo(0));
+        assertEquals(move11Params.coordinates.x, 0.0, Math.ulp(1.0));
+        assertEquals(move11Params.coordinates.y, 0.0, Math.ulp(1.0));
+        assertThat(move11Params.properties.id, is(equalTo(0)));
+        assertThat(move11Params.properties.toolType, equalTo(MotionEvent.TOOL_TYPE_FINGER));
+
+        final MotionInputEventParams move12Params = (MotionInputEventParams) paramSet2.get(1);
+        assertThat(move12Params.startDelta, equalTo(0L));
+        assertThat(move12Params.actionCode, equalTo(MotionEvent.ACTION_MOVE));
+        assertThat(move12Params.button, equalTo(0));
+        assertEquals(move12Params.coordinates.x, 100.0, Math.ulp(1.0));
+        assertEquals(move12Params.coordinates.y, 100.0, Math.ulp(1.0));
+        assertThat(move12Params.properties.id, is(equalTo(1)));
+        assertThat(move12Params.properties.toolType, equalTo(MotionEvent.TOOL_TYPE_FINGER));
+
+        final List<InputEventParams> paramSet3 = eventsChain.valueAt(2);
+        assertThat(eventsChain.keyAt(2), equalTo(15L));
+        assertThat(paramSet3.size(), equalTo(2));
+
+        final MotionInputEventParams move21Params = (MotionInputEventParams) paramSet3.get(0);
+        assertThat(move21Params.startDelta, equalTo(0L));
+        assertThat(move21Params.actionCode, equalTo(MotionEvent.ACTION_MOVE));
+        assertThat(move21Params.button, equalTo(0));
+        assertEquals(move21Params.coordinates.x, 25.0, Math.ulp(1.0));
+        assertEquals(move21Params.coordinates.y, 25.0, Math.ulp(1.0));
+        assertThat(move21Params.properties.id, is(equalTo(0)));
+        assertThat(move21Params.properties.toolType, equalTo(MotionEvent.TOOL_TYPE_FINGER));
+
+        final MotionInputEventParams move22Params = (MotionInputEventParams) paramSet3.get(1);
+        assertThat(move22Params.startDelta, equalTo(0L));
+        assertThat(move22Params.actionCode, equalTo(MotionEvent.ACTION_MOVE));
+        assertThat(move22Params.button, equalTo(0));
+        assertEquals(move22Params.coordinates.x, 75.0, Math.ulp(1.0));
+        assertEquals(move22Params.coordinates.y, 75.0, Math.ulp(1.0));
+        assertThat(move22Params.properties.id, is(equalTo(1)));
+        assertThat(move22Params.properties.toolType, equalTo(MotionEvent.TOOL_TYPE_FINGER));
+
+        final List<InputEventParams> paramSet4 = eventsChain.valueAt(3);
+        assertThat(eventsChain.keyAt(3), equalTo(20L));
+        assertThat(paramSet4.size(), equalTo(2));
+
+        final MotionInputEventParams up1Params = (MotionInputEventParams) paramSet4.get(0);
+        assertThat(up1Params.startDelta, equalTo(0L));
+        assertThat(up1Params.actionCode, equalTo(MotionEvent.ACTION_UP));
+        assertThat(up1Params.button, equalTo(0));
+        assertEquals(up1Params.coordinates.x, 50.0, Math.ulp(1.0));
+        assertEquals(up1Params.coordinates.y, 50.0, Math.ulp(1.0));
+        assertThat(up1Params.properties.id, is(equalTo(0)));
+        assertThat(up1Params.properties.toolType, equalTo(MotionEvent.TOOL_TYPE_FINGER));
+
+        final MotionInputEventParams up2Params = (MotionInputEventParams) paramSet4.get(1);
+        assertThat(up2Params.startDelta, equalTo(0L));
+        assertThat(up2Params.actionCode, equalTo(MotionEvent.ACTION_UP));
+        assertThat(up2Params.button, equalTo(0));
+        assertEquals(up2Params.coordinates.x, 50.0, Math.ulp(1.0));
+        assertEquals(up2Params.coordinates.y, 50.0, Math.ulp(1.0));
+        assertThat(up2Params.properties.id, is(equalTo(1)));
+        assertThat(up2Params.properties.toolType, equalTo(MotionEvent.TOOL_TYPE_FINGER));
+    }
+
+    @Test(expected = ActionsParseException.class)
+    public void verifyChainCompilationFailsIfDurationIsNegative() throws JSONException {
+        final JSONArray actionJson = new JSONArray("[ {" +
+                "\"type\": \"pointer\"," +
+                "\"id\": \"mouse1\"," +
+                "\"actions\": [" +
+                "{\"type\": \"pointerMove\", \"duration\": 0, \"x\": 100, \"y\": 100}," +
+                "{\"type\": \"pointerDown\", \"button\": 1}," +
+                "{\"type\": \"pointerMove\", \"duration\": -1, \"origin\": \"pointer\", \"x\": -50, \"y\": 0}," +
+                "{\"type\": \"pointerUp\", \"button\": 1}]" +
+                "} ]");
+        actionsToInputEventsMapping(preprocessActions(actionJson));
+    }
+
+    @Test(expected = ActionsParseException.class)
+    public void verifyChainCompilationFailsIfNoStaringCoordinatesAreProvided() throws JSONException {
+        final JSONArray actionJson = new JSONArray("[ {" +
+                "\"type\": \"pointer\"," +
+                "\"id\": \"mouse1\"," +
+                "\"actions\": [" +
+                "{\"type\": \"pointerDown\", \"button\": 1}," +
+                "{\"type\": \"pointerMove\", \"duration\": 10, \"x\": -50, \"y\": 0}," +
+                "{\"type\": \"pointerUp\", \"button\": 1}]" +
+                "} ]");
+        actionsToInputEventsMapping(preprocessActions(actionJson));
+    }
+
+    @Test(expected = ActionsParseException.class)
+    public void verifyChainCompilationFailsIfInvalidPointerActionTypeIsProvided()
+            throws JSONException {
+        final JSONArray actionJson = new JSONArray("[ {" +
+                "\"type\": \"pointer\"," +
+                "\"id\": \"mouse1\"," +
+                "\"actions\": [" +
+                "{\"type\": \"pointerMove\", \"duration\": 0, \"x\": 0, \"y\": 0}," +
+                "{\"type\": \"pointerBla\", \"button\": 1}," +
+                "{\"type\": \"pointerMove\", \"duration\": 10, \"x\": -50, \"y\": 0}," +
+                "{\"type\": \"pointerUp\", \"button\": 1}]" +
+                "} ]");
+        actionsToInputEventsMapping(preprocessActions(actionJson));
+    }
+
+    @Test(expected = ActionsParseException.class)
+    public void verifyChainCompilationFailsIfInvalidKeyActionTypeIsProvided()
+            throws JSONException {
+        final JSONArray actionJson = new JSONArray("[ {" +
+                "\"type\": \"key\"," +
+                "\"id\": \"keyboard\"," +
+                "\"actions\": [" +
+                "{\"type\": \"keyDown\", \"value\": \"\u2000\"}," +
+                "{\"type\": \"keyBla\", \"value\": \"A\"}," +
+                "{\"type\": \"keyUp\", \"value\": \"A\"}," +
+                "{\"type\": \"keyUp\", \"value\": \"\u2000\"}]" +
+                "} ]");
+        actionsToInputEventsMapping(preprocessActions(actionJson));
+    }
+
+    @Test(expected = ActionsParseException.class)
+    public void verifyChainCompilationFailsIfKeyValueIsMissing() throws JSONException {
+        final JSONArray actionJson = new JSONArray("[ {" +
+                "\"type\": \"key\"," +
+                "\"id\": \"keyboard\"," +
+                "\"actions\": [" +
+                "{\"type\": \"keyDown\", \"value\": \"\u2000\"}," +
+                "{\"type\": \"keyUp\"}," +
+                "{\"type\": \"keyUp\", \"value\": \"A\"}," +
+                "{\"type\": \"keyUp\", \"value\": \"\u2000\"}]" +
+                "} ]");
+        actionsToInputEventsMapping(preprocessActions(actionJson));
+    }
+
+    @Test(expected = ActionsParseException.class)
+    public void verifyChainCompilationFailsIfKeyValueIsEmpty() throws JSONException {
+        final JSONArray actionJson = new JSONArray("[ {" +
+                "\"type\": \"key\"," +
+                "\"id\": \"keyboard\"," +
+                "\"actions\": [" +
+                "{\"type\": \"keyDown\", \"value\": \"\u2000\"}," +
+                "{\"type\": \"keyUp\", \"value\": \"\"}," +
+                "{\"type\": \"keyUp\", \"value\": \"A\"}," +
+                "{\"type\": \"keyUp\", \"value\": \"\u2000\"}]" +
+                "} ]");
+        actionsToInputEventsMapping(preprocessActions(actionJson));
+    }
+
+    @Test(expected = ActionsParseException.class)
+    public void verifyChainCompilationFailsIfInvalidNoneActionTypeIsProvided()
+            throws JSONException {
+        final JSONArray actionJson = new JSONArray("[ {" +
+                "\"type\": \"none\"," +
+                "\"id\": \"none1\"," +
+                "\"actions\": [" +
+                "{\"type\": \"pause\", \"duration\": 200}," +
+                "{\"type\": \"bla\", \"duration\": 20}]" +
+                "} ]");
+        actionsToInputEventsMapping(preprocessActions(actionJson));
+    }
+
+    @Test(expected = ActionsParseException.class)
+    public void verifyChainCompilationFailsIfNoDurationIsProvided() throws JSONException {
+        final JSONArray actionJson = new JSONArray("[ {" +
+                "\"type\": \"pointer\"," +
+                "\"id\": \"mouse1\"," +
+                "\"actions\": [" +
+                "{\"type\": \"pointerMove\", \"x\": 100, \"y\": 100}," +
+                "{\"type\": \"pointerDown\", \"button\": 1}," +
+                "{\"type\": \"pointerMove\", \"duration\": 10, \"origin\": \"pointer\", \"x\": -50, \"y\": 0}," +
+                "{\"type\": \"pointerUp\", \"button\": 1}]" +
+                "} ]");
+        actionsToInputEventsMapping(preprocessActions(actionJson));
+    }
+
+    @Test(expected = ActionsParseException.class)
+    public void verifyChainCompilationFailsIfCoordinateIsMissing() throws JSONException {
+        final JSONArray actionJson = new JSONArray("[ {" +
+                "\"type\": \"pointer\"," +
+                "\"id\": \"mouse1\"," +
+                "\"actions\": [" +
+                "{\"type\": \"pointerMove\", \"duration\": 0, \"y\": 100}," +
+                "{\"type\": \"pointerDown\", \"button\": 1}," +
+                "{\"type\": \"pointerMove\", \"duration\": 10, \"origin\": \"pointer\", \"x\": -50, \"y\": 0}," +
+                "{\"type\": \"pointerUp\", \"button\": 1}]" +
+                "} ]");
+        actionsToInputEventsMapping(preprocessActions(actionJson));
+    }
+}

--- a/app/src/main/java/io/appium/uiautomator2/utils/w3c/ActionsConstants.java
+++ b/app/src/main/java/io/appium/uiautomator2/utils/w3c/ActionsConstants.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.appium.uiautomator2.utils.w3c;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+public class ActionsConstants {
+    public static final String ACTION_KEY_TYPE = "type";
+    public static final String ACTION_TYPE_POINTER = "pointer";
+    public static final String ACTION_TYPE_KEY = "key";
+    public static final String ACTION_TYPE_NONE = "none";
+    public static final List<String> ACTION_TYPES = Arrays.asList(ACTION_TYPE_POINTER,
+            ACTION_TYPE_KEY, ACTION_TYPE_NONE);
+
+    public static final String ACTION_KEY_ID = "id";
+
+    public static final String ACTION_KEY_PARAMETERS = "parameters";
+    public static final String PARAMETERS_KEY_POINTER_TYPE = "pointerType";
+    public static final String POINTER_TYPE_MOUSE = "mouse";
+    public static final String POINTER_TYPE_PEN = "pen";
+    public static final String POINTER_TYPE_TOUCH = "touch";
+    public static final List<String> POINTER_TYPES = Arrays.asList(POINTER_TYPE_MOUSE,
+            POINTER_TYPE_PEN, POINTER_TYPE_TOUCH);
+
+    public static final String ACTION_KEY_ACTIONS = "actions";
+
+    public static final String ACTION_ITEM_TYPE_KEY = "type";
+    public static final String ACTION_ITEM_TYPE_POINTER_MOVE = "pointerMove";
+    public static final String ACTION_ITEM_TYPE_POINTER_UP = "pointerUp";
+    public static final String ACTION_ITEM_TYPE_POINTER_DOWN = "pointerDown";
+    public static final String ACTION_ITEM_TYPE_POINTER_CANCEL = "pointerCancel";
+    public static final String ACTION_ITEM_TYPE_PAUSE = "pause";
+    public static final String ACTION_ITEM_TYPE_KEY_UP = "keyUp";
+    public static final String ACTION_ITEM_TYPE_KEY_DOWN = "keyDown";
+    public static final List<String> POINTER_ITEM_TYPES = Arrays.asList(
+            ACTION_ITEM_TYPE_POINTER_MOVE, ACTION_ITEM_TYPE_POINTER_UP,
+            ACTION_ITEM_TYPE_POINTER_DOWN, ACTION_ITEM_TYPE_POINTER_CANCEL, ACTION_ITEM_TYPE_PAUSE);
+    public static final List<String> KEY_ITEM_TYPES = Arrays.asList(
+            ACTION_ITEM_TYPE_KEY_UP, ACTION_ITEM_TYPE_KEY_DOWN, ACTION_ITEM_TYPE_PAUSE);
+    public static final List<String> NONE_ITEM_TYPES =
+            Collections.singletonList(ACTION_ITEM_TYPE_PAUSE);
+
+    public static final String ACTION_ITEM_VALUE_KEY = "value";
+    public static final String ACTION_ITEM_PRESSURE_KEY = "pressure";
+    public static final String ACTION_ITEM_SIZE_KEY = "size";
+    public static final String ACTION_ITEM_BUTTON_KEY = "button";
+    public static final String ACTION_ITEM_DURATION_KEY = "duration";
+
+    public static final int MOUSE_BUTTON_LEFT = 0;
+    public static final int MOUSE_BUTTON_MIDDLE = 1;
+    public static final int MOUSE_BUTTON_RIGHT = 2;
+
+    public static final String ACTION_ITEM_ORIGIN_KEY = "origin";
+    public static final String ACTION_ITEM_ORIGIN_VIEWPORT = "viewport";
+    public static final String ACTION_ITEM_ORIGIN_POINTER = "pointer";
+
+    public static final String ACTION_ITEM_X_KEY = "x";
+    public static final String ACTION_ITEM_Y_KEY = "y";
+
+    public static final int MOTION_EVENT_INJECTION_DELAY_MS = 5;
+}

--- a/app/src/main/java/io/appium/uiautomator2/utils/w3c/ActionsHelpers.java
+++ b/app/src/main/java/io/appium/uiautomator2/utils/w3c/ActionsHelpers.java
@@ -36,6 +36,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 
+import io.appium.uiautomator2.model.AndroidElement;
 import io.appium.uiautomator2.model.KnownElements;
 
 import static io.appium.uiautomator2.utils.w3c.ActionsConstants.ACTION_ITEM_BUTTON_KEY;
@@ -161,10 +162,16 @@ public class ActionsHelpers {
         final PointerCoords result = new PointerCoords();
         Rect bounds;
         try {
-            bounds = KnownElements.getElementFromCache(elementId).getBounds();
+            final AndroidElement element = KnownElements.getElementFromCache(elementId);
+            bounds = element.getBounds();
+            if (bounds.width() == 0 || bounds.height() == 0) {
+                throw new ActionsParseException(String.format(
+                        "The element with id '%s' has zero width/height in the action item '%s' of action '%s'",
+                        elementId, actionItem, actionId));
+            }
         } catch (NullPointerException | UiObjectNotFoundException e) {
             throw new ActionsParseException(String.format(
-                    "An unknown element id '%s' is set for action item '%s' of action '%s'",
+                    "An unknown element id '%s' is set for the action item '%s' of action '%s'",
                     elementId, actionItem, actionId));
         }
         // https://w3c.github.io/webdriver/webdriver-spec.html#pointer-actions

--- a/app/src/main/java/io/appium/uiautomator2/utils/w3c/ActionsHelpers.java
+++ b/app/src/main/java/io/appium/uiautomator2/utils/w3c/ActionsHelpers.java
@@ -161,22 +161,23 @@ public class ActionsHelpers {
         final PointerCoords result = new PointerCoords();
         Rect bounds;
         try {
-            // TODO: is there a special method to calculate element hitpoint coordinates?
             bounds = KnownElements.getElementFromCache(elementId).getBounds();
         } catch (NullPointerException | UiObjectNotFoundException e) {
             throw new ActionsParseException(String.format(
                     "An unknown element id '%s' is set for action item '%s' of action '%s'",
                     elementId, actionItem, actionId));
         }
+        // https://w3c.github.io/webdriver/webdriver-spec.html#pointer-actions
+        // > Let x element and y element be the result of calculating the in-view center point of element.
+        result.x = bounds.left + bounds.width() / 2;
+        result.y = bounds.top + bounds.height() / 2;
         if (actionItem.has(ACTION_ITEM_X_KEY)) {
-            result.x = (float) (bounds.left + actionItem.getDouble(ACTION_ITEM_X_KEY));
-        } else {
-            result.x = bounds.centerX();
+            result.x += (float) actionItem.getDouble(ACTION_ITEM_X_KEY);
+            // TODO: Shall we throw an exception if result.x is outside of bounds rect?
         }
         if (actionItem.has(ACTION_ITEM_Y_KEY)) {
-            result.y = (float) (bounds.top + actionItem.getDouble(ACTION_ITEM_Y_KEY));
-        } else {
-            result.y = bounds.centerY();
+            result.y += (float) actionItem.getDouble(ACTION_ITEM_Y_KEY);
+            // TODO: Shall we throw an exception if result.y is outside of bounds rect?
         }
         return result;
     }

--- a/app/src/main/java/io/appium/uiautomator2/utils/w3c/ActionsHelpers.java
+++ b/app/src/main/java/io/appium/uiautomator2/utils/w3c/ActionsHelpers.java
@@ -1,0 +1,641 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.appium.uiautomator2.utils.w3c;
+
+import android.graphics.Rect;
+import android.os.Build;
+import android.support.annotation.Nullable;
+import android.support.test.uiautomator.UiObjectNotFoundException;
+import android.util.LongSparseArray;
+import android.view.InputDevice;
+import android.view.KeyEvent;
+import android.view.MotionEvent;
+import android.view.MotionEvent.PointerCoords;
+import android.view.MotionEvent.PointerProperties;
+
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
+
+import io.appium.uiautomator2.model.KnownElements;
+
+import static io.appium.uiautomator2.utils.w3c.ActionsConstants.ACTION_ITEM_BUTTON_KEY;
+import static io.appium.uiautomator2.utils.w3c.ActionsConstants.ACTION_ITEM_DURATION_KEY;
+import static io.appium.uiautomator2.utils.w3c.ActionsConstants.ACTION_ITEM_ORIGIN_KEY;
+import static io.appium.uiautomator2.utils.w3c.ActionsConstants.ACTION_ITEM_ORIGIN_POINTER;
+import static io.appium.uiautomator2.utils.w3c.ActionsConstants.ACTION_ITEM_ORIGIN_VIEWPORT;
+import static io.appium.uiautomator2.utils.w3c.ActionsConstants.ACTION_ITEM_PRESSURE_KEY;
+import static io.appium.uiautomator2.utils.w3c.ActionsConstants.ACTION_ITEM_SIZE_KEY;
+import static io.appium.uiautomator2.utils.w3c.ActionsConstants.ACTION_ITEM_TYPE_KEY;
+import static io.appium.uiautomator2.utils.w3c.ActionsConstants.ACTION_ITEM_TYPE_KEY_DOWN;
+import static io.appium.uiautomator2.utils.w3c.ActionsConstants.ACTION_ITEM_TYPE_KEY_UP;
+import static io.appium.uiautomator2.utils.w3c.ActionsConstants.ACTION_ITEM_TYPE_PAUSE;
+import static io.appium.uiautomator2.utils.w3c.ActionsConstants.ACTION_ITEM_TYPE_POINTER_CANCEL;
+import static io.appium.uiautomator2.utils.w3c.ActionsConstants.ACTION_ITEM_TYPE_POINTER_DOWN;
+import static io.appium.uiautomator2.utils.w3c.ActionsConstants.ACTION_ITEM_TYPE_POINTER_MOVE;
+import static io.appium.uiautomator2.utils.w3c.ActionsConstants.ACTION_ITEM_TYPE_POINTER_UP;
+import static io.appium.uiautomator2.utils.w3c.ActionsConstants.ACTION_ITEM_VALUE_KEY;
+import static io.appium.uiautomator2.utils.w3c.ActionsConstants.ACTION_ITEM_X_KEY;
+import static io.appium.uiautomator2.utils.w3c.ActionsConstants.ACTION_ITEM_Y_KEY;
+import static io.appium.uiautomator2.utils.w3c.ActionsConstants.ACTION_KEY_ACTIONS;
+import static io.appium.uiautomator2.utils.w3c.ActionsConstants.ACTION_KEY_ID;
+import static io.appium.uiautomator2.utils.w3c.ActionsConstants.ACTION_KEY_PARAMETERS;
+import static io.appium.uiautomator2.utils.w3c.ActionsConstants.ACTION_KEY_TYPE;
+import static io.appium.uiautomator2.utils.w3c.ActionsConstants.ACTION_TYPES;
+import static io.appium.uiautomator2.utils.w3c.ActionsConstants.ACTION_TYPE_KEY;
+import static io.appium.uiautomator2.utils.w3c.ActionsConstants.ACTION_TYPE_NONE;
+import static io.appium.uiautomator2.utils.w3c.ActionsConstants.ACTION_TYPE_POINTER;
+import static io.appium.uiautomator2.utils.w3c.ActionsConstants.KEY_ITEM_TYPES;
+import static io.appium.uiautomator2.utils.w3c.ActionsConstants.MOTION_EVENT_INJECTION_DELAY_MS;
+import static io.appium.uiautomator2.utils.w3c.ActionsConstants.MOUSE_BUTTON_LEFT;
+import static io.appium.uiautomator2.utils.w3c.ActionsConstants.MOUSE_BUTTON_MIDDLE;
+import static io.appium.uiautomator2.utils.w3c.ActionsConstants.MOUSE_BUTTON_RIGHT;
+import static io.appium.uiautomator2.utils.w3c.ActionsConstants.NONE_ITEM_TYPES;
+import static io.appium.uiautomator2.utils.w3c.ActionsConstants.PARAMETERS_KEY_POINTER_TYPE;
+import static io.appium.uiautomator2.utils.w3c.ActionsConstants.POINTER_ITEM_TYPES;
+import static io.appium.uiautomator2.utils.w3c.ActionsConstants.POINTER_TYPES;
+import static io.appium.uiautomator2.utils.w3c.ActionsConstants.POINTER_TYPE_MOUSE;
+import static io.appium.uiautomator2.utils.w3c.ActionsConstants.POINTER_TYPE_PEN;
+import static io.appium.uiautomator2.utils.w3c.ActionsConstants.POINTER_TYPE_TOUCH;
+
+public class ActionsHelpers {
+    private static JSONArray preprocessActionItems(final String actionId,
+                                                   final String actionType,
+                                                   final JSONArray actionItems) throws JSONException {
+        final JSONArray processedItems = new JSONArray();
+
+        boolean shouldSkipNextItem = false;
+        for (int i = actionItems.length() - 1; i >= 0; i--) {
+            final JSONObject actionItem = actionItems.getJSONObject(i);
+            if (!actionItem.has(ACTION_ITEM_TYPE_KEY)) {
+                throw new ActionsParseException(
+                        String.format("All items of '%s' action must have the %s key set",
+                                actionId, ACTION_ITEM_TYPE_KEY));
+            }
+            final String actionItemType = actionItem.getString(ACTION_ITEM_TYPE_KEY);
+            List<String> allowedItemTypes;
+            switch (actionType) {
+                case ACTION_TYPE_POINTER:
+                    allowedItemTypes = POINTER_ITEM_TYPES;
+                    break;
+                case ACTION_TYPE_KEY:
+                    allowedItemTypes = KEY_ITEM_TYPES;
+                    break;
+                case ACTION_TYPE_NONE:
+                    allowedItemTypes = NONE_ITEM_TYPES;
+                    break;
+                default:
+                    throw new ActionsParseException(
+                            String.format("Unknown action type '%s' is set for '%s' action",
+                                    actionType, actionId));
+            }
+            if (!allowedItemTypes.contains(actionItemType)) {
+                throw new ActionsParseException(String.format(
+                        "Only %s item type values are supported for action type '%s'. " +
+                                "'%s' is passed instead for action '%s'",
+                        allowedItemTypes, actionType, actionItemType, actionId));
+            }
+
+            if (actionItemType.equals(ACTION_ITEM_TYPE_POINTER_CANCEL)) {
+                shouldSkipNextItem = true;
+                continue;
+            }
+            if (shouldSkipNextItem) {
+                shouldSkipNextItem = false;
+                continue;
+            }
+
+            processedItems.put(actionItem);
+        }
+
+        final JSONArray result = new JSONArray();
+        for (int i = processedItems.length() - 1; i >= 0; i--) {
+            result.put(processedItems.getJSONObject(i));
+        }
+        return result;
+    }
+
+    private static PointerCoords extractElementCoordinates(
+            final String actionId, final JSONObject actionItem, final Object originValue)
+            throws JSONException {
+        String elementId = null;
+        if (originValue instanceof String) {
+            elementId = (String) originValue;
+        } else if (originValue instanceof JSONObject) {
+            // It's how this is defined in WebDriver source:
+            //
+            // if isinstance(origin, WebElement):
+            //    action["origin"] = {"element-6066-11e4-a52e-4f735466cecf": origin.id}
+            final Iterator<String> keys = ((JSONObject) originValue).keys();
+            if (keys.hasNext()) {
+                final String name = keys.next();
+                if (name.toLowerCase().startsWith("element")) {
+                    elementId = String.valueOf(((JSONObject) originValue).get(name));
+                }
+            }
+        }
+        if (elementId == null) {
+            throw new ActionsParseException(String.format(
+                    "An unknown element '%s' is set for action item '%s' of action '%s'",
+                    originValue, actionItem, actionId));
+        }
+        final PointerCoords result = new PointerCoords();
+        Rect bounds;
+        try {
+            // TODO: is there a special method to calculate element hitpoint coordinates?
+            bounds = KnownElements.getElementFromCache(elementId).getBounds();
+        } catch (NullPointerException | UiObjectNotFoundException e) {
+            throw new ActionsParseException(String.format(
+                    "An unknown element id '%s' is set for action item '%s' of action '%s'",
+                    elementId, actionItem, actionId));
+        }
+        if (actionItem.has(ACTION_ITEM_X_KEY)) {
+            result.x = (float) (bounds.left + actionItem.getDouble(ACTION_ITEM_X_KEY));
+        } else {
+            result.x = bounds.centerX();
+        }
+        if (actionItem.has(ACTION_ITEM_Y_KEY)) {
+            result.y = (float) (bounds.top + actionItem.getDouble(ACTION_ITEM_Y_KEY));
+        } else {
+            result.y = bounds.centerY();
+        }
+        return result;
+    }
+
+    private static PointerCoords extractCoordinates(final String actionId, final JSONArray allItems,
+                                                    final int itemIdx) throws JSONException {
+        if (itemIdx < 0) {
+            throw new ActionsParseException(String.format(
+                    "The first item of action '%s' cannot define HOVER move, " +
+                            "because its start coordinates are not set", actionId));
+        }
+        final JSONObject actionItem = allItems.getJSONObject(itemIdx);
+        final String actionType = actionItem.getString(ACTION_ITEM_TYPE_KEY);
+        if (!actionType.equals(ACTION_ITEM_TYPE_POINTER_MOVE)) {
+            if (itemIdx > 0) {
+                return extractCoordinates(actionId, allItems, itemIdx - 1);
+            }
+            throw new ActionsParseException(String.format(
+                    "Action item '%s' of action '%s' should be preceded with at least one item " +
+                            "with coordinates", actionItem, actionId));
+        }
+        Object origin = ACTION_ITEM_ORIGIN_VIEWPORT;
+        if (actionItem.has(ACTION_ITEM_ORIGIN_KEY)) {
+            origin = actionItem.get(ACTION_ITEM_ORIGIN_KEY);
+        }
+        final PointerCoords result = new PointerCoords();
+        result.size = actionItem.has(ACTION_ITEM_SIZE_KEY) ?
+                (float) actionItem.getDouble(ACTION_ITEM_SIZE_KEY) : 1;
+        result.pressure = actionItem.has(ACTION_ITEM_PRESSURE_KEY) ?
+                (float) actionItem.getDouble(ACTION_ITEM_PRESSURE_KEY) : 1;
+        if (origin instanceof String) {
+            if (origin.equals(ACTION_ITEM_ORIGIN_VIEWPORT)) {
+                if (!actionItem.has(ACTION_ITEM_X_KEY) || !actionItem.has(ACTION_ITEM_Y_KEY)) {
+                    throw new ActionsParseException(String.format(
+                            "Both coordinates must be be set for action item '%s' of action '%s'",
+                            actionItem, actionId));
+                }
+                result.x = (float) actionItem.getDouble(ACTION_ITEM_X_KEY);
+                result.y = (float) actionItem.getDouble(ACTION_ITEM_Y_KEY);
+                return result;
+            } else if (origin.equals(ACTION_ITEM_ORIGIN_POINTER)) {
+                if (itemIdx > 0) {
+                    final PointerCoords recentCoords = extractCoordinates(actionId, allItems, itemIdx - 1);
+                    result.x = recentCoords.x;
+                    result.y = recentCoords.y;
+                    if (actionItem.has(ACTION_ITEM_X_KEY)) {
+                        result.x += (float) actionItem.getDouble(ACTION_ITEM_X_KEY);
+                    }
+                    if (actionItem.has(ACTION_ITEM_Y_KEY)) {
+                        result.y += (float) actionItem.getDouble(ACTION_ITEM_Y_KEY);
+                    }
+                    return result;
+                }
+                throw new ActionsParseException(String.format(
+                        "Action item '%s' of action '%s' should be preceded with at least one item " +
+                                "containing absolute coordinates", actionItem, actionId));
+            }
+        }
+        return extractElementCoordinates(actionId, actionItem, origin);
+    }
+
+    public static JSONArray preprocessActions(final JSONArray actions) throws JSONException {
+        final List<String> actionIds = new ArrayList<>();
+        for (int i = 0; i < actions.length(); i++) {
+            final JSONObject action = actions.getJSONObject(i);
+
+            if (!action.has(ACTION_KEY_ID)) {
+                throw new ActionsParseException(
+                        String.format("All actions must have the %s key set", ACTION_KEY_ID));
+            }
+            final String actionId = action.getString(ACTION_KEY_ID);
+            if (actionIds.contains(actionId)) {
+                throw new ActionsParseException(
+                        String.format("The action %s '%s' has one one or more duplicates",
+                                ACTION_KEY_ID, actionId));
+            }
+
+            actionIds.add(actionId);
+            if (!action.has(ACTION_KEY_TYPE)) {
+                throw new ActionsParseException(
+                        String.format("'%s' action must have the %s key set",
+                                actionId, ACTION_KEY_TYPE));
+            }
+            final String actionType = action.getString(ACTION_KEY_TYPE);
+            if (!ACTION_TYPES.contains(actionType)) {
+                throw new ActionsParseException(String.format(
+                        "Only %s values are supported for %s key. "
+                                + "'%s' is passed instead for action '%s'",
+                        ACTION_TYPES, ACTION_KEY_TYPE, actionType, actionId));
+            }
+
+            if (action.has(ACTION_KEY_PARAMETERS)) {
+                final JSONObject params = action.getJSONObject(ACTION_KEY_PARAMETERS);
+                if (params.has(PARAMETERS_KEY_POINTER_TYPE)) {
+                    final String pointerType = params.getString(PARAMETERS_KEY_POINTER_TYPE);
+                    if (!POINTER_TYPES.contains(pointerType)) {
+                        throw new ActionsParseException(String.format(
+                                "Only %s values are supported for %s key. " +
+                                        "'%s' is passed instead for action '%s'",
+                                POINTER_TYPES, PARAMETERS_KEY_POINTER_TYPE,
+                                pointerType, actionId));
+                    }
+                    if (!actionType.equals(ACTION_TYPE_POINTER)) {
+                        throw new ActionsParseException(String.format(
+                                "%s parameter is only supported for action type '%s' in '%s' action",
+                                PARAMETERS_KEY_POINTER_TYPE, ACTION_TYPE_POINTER, actionId));
+                    }
+                }
+            }
+
+            if (!action.has(ACTION_KEY_ACTIONS)) {
+                throw new ActionsParseException(String.format(
+                        "'%s' action should contain at least one item", actionId));
+            }
+            final JSONArray actionItems = action.getJSONArray(ACTION_KEY_ACTIONS);
+            action.put(ACTION_KEY_ACTIONS,
+                    preprocessActionItems(actionId, actionType, actionItems));
+        }
+        return actions;
+    }
+
+    public static int getPointerAction(int motionEnvent, int index) {
+        return motionEnvent + (index << MotionEvent.ACTION_POINTER_INDEX_SHIFT);
+    }
+
+    private static int actionToToolType(final JSONObject action) throws JSONException {
+        if (action.has(ACTION_KEY_PARAMETERS)) {
+            final JSONObject params = action.getJSONObject(ACTION_KEY_PARAMETERS);
+            if (params.has(PARAMETERS_KEY_POINTER_TYPE)) {
+                switch (params.getString(PARAMETERS_KEY_POINTER_TYPE)) {
+                    case POINTER_TYPE_MOUSE:
+                        return MotionEvent.TOOL_TYPE_MOUSE;
+                    case POINTER_TYPE_PEN:
+                        return MotionEvent.TOOL_TYPE_STYLUS;
+                    case POINTER_TYPE_TOUCH:
+                        return MotionEvent.TOOL_TYPE_FINGER;
+                }
+            }
+        }
+        return MotionEvent.TOOL_TYPE_MOUSE;
+    }
+
+    public static int toolTypeToInputSource(final int toolType) {
+        switch (toolType) {
+            case MotionEvent.TOOL_TYPE_MOUSE:
+                return InputDevice.SOURCE_MOUSE;
+            case MotionEvent.TOOL_TYPE_STYLUS:
+                return InputDevice.SOURCE_STYLUS;
+            case MotionEvent.TOOL_TYPE_FINGER:
+                return InputDevice.SOURCE_TOUCHSCREEN;
+        }
+        return InputDevice.SOURCE_MOUSE;
+    }
+
+    private static List<JSONObject> filterActionsByType(final JSONArray actions,
+                                                        final String type) throws JSONException {
+        final List<JSONObject> result = new ArrayList<>();
+        for (int i = 0; i < actions.length(); i++) {
+            final JSONObject action = actions.getJSONObject(i);
+            final String actionType = action.getString(ACTION_KEY_TYPE);
+            if (actionType.equals(type)) {
+                result.add(action);
+            }
+        }
+        return result;
+    }
+
+    private static void recordEventParams(final long timeDeltaMs,
+                                          final LongSparseArray<List<InputEventParams>> mapping,
+                                          @Nullable final InputEventParams newParams) {
+        final List<InputEventParams> allParams = mapping.get(timeDeltaMs);
+        if (allParams == null) {
+            final List<InputEventParams> params = new ArrayList<>();
+            if (newParams != null) {
+                params.add(newParams);
+            }
+            mapping.put(timeDeltaMs, params);
+        } else if (newParams != null) {
+            allParams.add(newParams);
+        }
+    }
+
+    private static MotionInputEventParams toMotionEventInputParams(
+            final int actionCode, final PointerCoords coordinates, final int button,
+            final PointerProperties properties, final long startDelta) {
+        final MotionInputEventParams evtParams = new MotionInputEventParams();
+        evtParams.actionCode = actionCode;
+        evtParams.coordinates = coordinates;
+        evtParams.button = button;
+        evtParams.properties = properties;
+        evtParams.startDelta = startDelta;
+        return evtParams;
+    }
+
+    private static void applyPointerActionToEventsMapping(
+            final JSONObject action, final int pointerIndex,
+            final LongSparseArray<List<InputEventParams>> mapping) throws JSONException {
+        final String actionId = action.getString(ACTION_KEY_ID);
+        final PointerProperties props = new PointerProperties();
+        props.id = pointerIndex;
+        props.toolType = actionToToolType(action);
+        long timeDelta = 0;
+        long chainEntryPointDelta = 0;
+        boolean isPointerDown = false;
+        boolean isPointerHovering = false;
+        int recentButton = 0;
+        final JSONArray actionItems = action.getJSONArray(ACTION_KEY_ACTIONS);
+        for (int i = 0; i < actionItems.length(); i++) {
+            final JSONObject actionItem = actionItems.getJSONObject(i);
+            final String itemType = actionItem.getString(ACTION_ITEM_TYPE_KEY);
+            switch (itemType) {
+                case ACTION_ITEM_TYPE_PAUSE: {
+                    timeDelta += extractDuration(action, actionItem);
+                    recordEventParams(timeDelta, mapping, null);
+                }
+                break;
+                case ACTION_ITEM_TYPE_POINTER_DOWN: {
+                    chainEntryPointDelta = timeDelta;
+                    if (isPointerHovering) {
+                        recordEventParams(timeDelta, mapping,
+                                toMotionEventInputParams(MotionEvent.ACTION_HOVER_EXIT,
+                                        extractCoordinates(actionId, actionItems, i),
+                                        0, props, chainEntryPointDelta));
+                        isPointerHovering = false;
+                    }
+                    recentButton = extractButton(actionItem, props.toolType);
+                    recordEventParams(timeDelta, mapping, toMotionEventInputParams(
+                            MotionEvent.ACTION_DOWN, extractCoordinates(actionId, actionItems, i),
+                            recentButton, props, chainEntryPointDelta));
+                    isPointerDown = true;
+                }
+                break;
+                case ACTION_ITEM_TYPE_POINTER_UP: {
+                    recentButton = extractButton(actionItem, props.toolType);
+                    recordEventParams(timeDelta, mapping, toMotionEventInputParams(
+                            MotionEvent.ACTION_UP, extractCoordinates(actionId, actionItems, i),
+                            recentButton, props, chainEntryPointDelta));
+                    isPointerDown = false;
+                    recentButton = 0;
+                    chainEntryPointDelta = timeDelta;
+                }
+                break;
+                case ACTION_ITEM_TYPE_POINTER_MOVE: {
+                    final long duration = extractDuration(action, actionItem);
+                    if (duration < MOTION_EVENT_INJECTION_DELAY_MS) {
+                        break;
+                    }
+                    if (i == 0) {
+                        // FIXME: Selenium client sets the default move duration
+                        // to 250 ms, but it won't work if this is the very first
+                        // action item, since gesture start coordinate is undefined.
+                        // It would be better to set the default duration to zero.
+                        timeDelta += duration;
+                        recordEventParams(timeDelta, mapping, null);
+                        break;
+                    }
+                    int actionCode = MotionEvent.ACTION_MOVE;
+                    final PointerCoords startCoordinates = extractCoordinates(actionId, actionItems, i - 1);
+                    if (!isPointerDown) {
+                        if (!isPointerHovering) {
+                            recordEventParams(timeDelta, mapping, toMotionEventInputParams(
+                                    MotionEvent.ACTION_HOVER_ENTER, startCoordinates,
+                                    0, props, chainEntryPointDelta));
+                            isPointerHovering = true;
+                        }
+                        actionCode = MotionEvent.ACTION_HOVER_MOVE;
+                    }
+                    // `stepsCount` is never going to be equal to zero, because of the
+                    // `if (duration < MOTION_EVENT_INJECTION_DELAY_MS)` condition above
+                    final long stepsCount = duration / MOTION_EVENT_INJECTION_DELAY_MS;
+                    final PointerCoords endCoordinates = extractCoordinates(actionId, actionItems, i);
+                    for (long step = 0; step < stepsCount; ++step) {
+                        final PointerCoords currentCoordinates = new PointerCoords();
+                        currentCoordinates.x = startCoordinates.x +
+                                (endCoordinates.x - startCoordinates.x) / stepsCount * step;
+                        currentCoordinates.y = startCoordinates.y +
+                                (endCoordinates.y - startCoordinates.y) / stepsCount * step;
+                        recordEventParams(timeDelta, mapping, toMotionEventInputParams(actionCode,
+                                currentCoordinates, recentButton, props, chainEntryPointDelta));
+                        timeDelta += MOTION_EVENT_INJECTION_DELAY_MS;
+                    }
+                }
+                break;
+                default:
+                    throw new ActionsParseException(String.format(
+                            "Unexpected action item %s '%s' in action with id '%s'",
+                            ACTION_ITEM_TYPE_KEY, itemType, action.getString(ACTION_KEY_ID)));
+            }
+        }
+        if (isPointerHovering) {
+            recordEventParams(timeDelta, mapping, toMotionEventInputParams(
+                    MotionEvent.ACTION_HOVER_EXIT,
+                    extractCoordinates(actionId, actionItems, actionItems.length() - 1),
+                    0, props, chainEntryPointDelta));
+            //noinspection UnusedAssignment
+            isPointerHovering = false;
+        }
+    }
+
+    private static long extractDuration(final JSONObject action,
+                                        final JSONObject actionItem) throws JSONException {
+        if (!actionItem.has(ACTION_ITEM_DURATION_KEY)) {
+            throw new ActionsParseException(String.format(
+                    "Missing %s key for action item '%s' of action with id '%s'",
+                    ACTION_ITEM_DURATION_KEY, action, action.getString(ACTION_KEY_ID)));
+        }
+        final long duration = actionItem.getLong(ACTION_ITEM_DURATION_KEY);
+        if (duration < 0) {
+            throw new ActionsParseException(String.format(
+                    "%s key cannot be negative for action item '%s' of action with id '%s'",
+                    ACTION_ITEM_DURATION_KEY, action, action.getString(ACTION_KEY_ID)));
+        }
+        return duration;
+    }
+
+    private static int extractButton(final JSONObject actionItem, final int toolType)
+            throws JSONException {
+        if (toolType == MotionEvent.TOOL_TYPE_FINGER) {
+            // Ignore button code conversion for the unsupported tool type
+            if (actionItem.has(ACTION_ITEM_BUTTON_KEY)) {
+                return actionItem.getInt(ACTION_ITEM_BUTTON_KEY);
+            }
+            return 0;
+        }
+
+        int button = MOUSE_BUTTON_LEFT;
+        if (actionItem.has(ACTION_ITEM_BUTTON_KEY)) {
+            button = actionItem.getInt(ACTION_ITEM_BUTTON_KEY);
+        }
+        // W3C button codes are different from Android constants. Converting...
+        switch (button) {
+            case MOUSE_BUTTON_LEFT:
+                if (toolType == MotionEvent.TOOL_TYPE_STYLUS && Build.VERSION.SDK_INT >= 23) {
+                    return MotionEvent.BUTTON_STYLUS_PRIMARY;
+                }
+                return MotionEvent.BUTTON_PRIMARY;
+            case MOUSE_BUTTON_MIDDLE:
+                return MotionEvent.BUTTON_TERTIARY;
+            case MOUSE_BUTTON_RIGHT:
+                if (toolType == MotionEvent.TOOL_TYPE_STYLUS && Build.VERSION.SDK_INT >= 23) {
+                    return MotionEvent.BUTTON_STYLUS_SECONDARY;
+                }
+                return MotionEvent.BUTTON_SECONDARY;
+        }
+        return button;
+    }
+
+    private static void applyKeyActionToEventsMapping(
+            final JSONObject action, final LongSparseArray<List<InputEventParams>> mapping)
+            throws JSONException {
+        final JSONArray actionItems = action.getJSONArray(ACTION_KEY_ACTIONS);
+        long timeDelta = 0;
+        long chainEntryPointDelta = 0;
+        for (int i = 0; i < actionItems.length(); i++) {
+            final JSONObject actionItem = actionItems.getJSONObject(i);
+            final String itemType = actionItem.getString(ACTION_ITEM_TYPE_KEY);
+            switch (itemType) {
+                case ACTION_ITEM_TYPE_PAUSE:
+                    timeDelta += extractDuration(action, actionItem);
+                    recordEventParams(timeDelta, mapping, null);
+                    break;
+                case ACTION_ITEM_TYPE_KEY_DOWN:
+                    chainEntryPointDelta = timeDelta;
+                case ACTION_ITEM_TYPE_KEY_UP:
+                    if (!actionItem.has(ACTION_ITEM_VALUE_KEY)) {
+                        throw new ActionsParseException(String.format(
+                                "Missing %s key for action item '%s' of action with id '%s'",
+                                ACTION_ITEM_VALUE_KEY, action, action.getString(ACTION_KEY_ID)));
+                    }
+                    final String value = actionItem.getString(ACTION_ITEM_VALUE_KEY);
+                    if (value.isEmpty()) {
+                        throw new ActionsParseException(String.format(
+                                "%s key cannot be empty for action item '%s' of action with id '%s'",
+                                ACTION_ITEM_VALUE_KEY, action, action.getString(ACTION_KEY_ID)));
+                    }
+                    final KeyInputEventParams evtParams = new KeyInputEventParams();
+                    evtParams.keyCode = value.charAt(0);
+                    evtParams.keyAction = itemType.equals(ACTION_ITEM_TYPE_KEY_DOWN) ?
+                            KeyEvent.ACTION_DOWN : KeyEvent.ACTION_UP;
+                    evtParams.startDelta = chainEntryPointDelta;
+                    recordEventParams(timeDelta, mapping, evtParams);
+                    chainEntryPointDelta = timeDelta;
+                    break;
+                default:
+                    throw new ActionsParseException(String.format(
+                            "Unexpected action item %s '%s' in action with id '%s'",
+                            ACTION_ITEM_TYPE_KEY, itemType, action.getString(ACTION_KEY_ID)));
+            }
+        }
+    }
+
+    private static void applyEmptyActionToEventsMapping(
+            final JSONObject action, final LongSparseArray<List<InputEventParams>> mapping)
+            throws JSONException {
+        final JSONArray actionItems = action.getJSONArray(ACTION_KEY_ACTIONS);
+        long timeDelta = 0;
+        for (int i = 0; i < actionItems.length(); i++) {
+            final JSONObject actionItem = actionItems.getJSONObject(i);
+            final String itemType = actionItem.getString(ACTION_ITEM_TYPE_KEY);
+            if (!itemType.equals(ACTION_ITEM_TYPE_PAUSE)) {
+                throw new ActionsParseException(String.format(
+                        "Unexpected action item %s '%s' in action with id '%s'",
+                        ACTION_ITEM_TYPE_KEY, itemType, action.getString(ACTION_KEY_ID)));
+            }
+            timeDelta += extractDuration(action, actionItem);
+            recordEventParams(timeDelta, mapping, null);
+        }
+    }
+
+    public static LongSparseArray<List<InputEventParams>> actionsToInputEventsMapping(
+            final JSONArray actions) throws JSONException {
+        final LongSparseArray<List<InputEventParams>> result = new LongSparseArray<>();
+        final List<JSONObject> pointerActions = filterActionsByType(actions, ACTION_TYPE_POINTER);
+        for (int pointerIdx = 0; pointerIdx < pointerActions.size(); pointerIdx++) {
+            applyPointerActionToEventsMapping(pointerActions.get(pointerIdx), pointerIdx, result);
+        }
+        final List<JSONObject> keyInputActions = filterActionsByType(actions, ACTION_TYPE_KEY);
+        for (final JSONObject keyAction : keyInputActions) {
+            applyKeyActionToEventsMapping(keyAction, result);
+        }
+        final List<JSONObject> emptyActions = filterActionsByType(actions, ACTION_TYPE_NONE);
+        for (final JSONObject emptyAction : emptyActions) {
+            applyEmptyActionToEventsMapping(emptyAction, result);
+        }
+        return result;
+    }
+
+    public static abstract class InputEventParams {
+        public long startDelta = 0;
+
+        InputEventParams() {
+        }
+    }
+
+    public static class KeyInputEventParams extends InputEventParams {
+        public int keyAction;
+        public int keyCode;
+
+        KeyInputEventParams() {
+            super();
+        }
+    }
+
+    public static class MotionInputEventParams extends InputEventParams {
+        public PointerProperties properties;
+        public PointerCoords coordinates;
+        public int actionCode;
+        public int button = 0;
+
+        MotionInputEventParams() {
+            super();
+        }
+    }
+
+    public static int metaKeysToState(final Set<Integer> metaKeys) {
+        int result = 0;
+        for (final int metaKey : metaKeys) {
+            result |= metaKey;
+        }
+        return result;
+    }
+}

--- a/app/src/main/java/io/appium/uiautomator2/utils/w3c/ActionsParseException.java
+++ b/app/src/main/java/io/appium/uiautomator2/utils/w3c/ActionsParseException.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.appium.uiautomator2.utils.w3c;
+
+public class ActionsParseException extends RuntimeException {
+    ActionsParseException(String message) {
+        super(message);
+    }
+}

--- a/build.gradle
+++ b/build.gradle
@@ -7,9 +7,10 @@ import org.apache.tools.ant.taskdefs.condition.Os
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.1'
+        classpath 'com.android.tools.build:gradle:3.0.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
@@ -34,6 +35,7 @@ allprojects {
     }
     repositories {
         jcenter()
+        google()
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon Oct 17 12:08:02 IST 2016
+#Mon Nov 13 19:24:57 CET 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip


### PR DESCRIPTION
This PR implements extended support of [W3C Actions spec](https://github.com/jlipps/simple-wd-spec#perform-actions) with UIA2 framework. Not all of things have been tested "in the wild" yet - only the basic set touch actions.

I've also updated Gradle setup to be able to work with the source in the recent Android Studio and to execute basic integration tests directly in the IDE.

I can say the implementation has reached beta stage and can be merged, however the feedback from end users needs to be extensively monitored and potential issues should be reviewed and addressed There are two most important things there we have to pay attention to:
- Client library implementation details (this is done on Selenium side and cannot be controlled by us, at least directly)
- Actions translation to native Android calls. There might be edge cases, since this stuff is tricky and is not documented properly.