### PR TITLE
use getTargetContext to save file in allowed area for GetElementScreenshot 

### DIFF
--- a/app/src/main/java/io/appium/uiautomator2/handler/GetElementScreenshot.java
+++ b/app/src/main/java/io/appium/uiautomator2/handler/GetElementScreenshot.java
@@ -42,7 +42,7 @@ public class GetElementScreenshot extends SafeRequestHandler {
                 Logger.error("Element is not visible");
                 return new AppiumResponse(getSessionId(request), WDStatus.ELEMENT_NOT_VISIBLE);
             }
-            final Context context = InstrumentationRegistry.getInstrumentation().getContext();
+            final Context context = InstrumentationRegistry.getInstrumentation().getTargetContext();
             final File outputFile = File.createTempFile("screenshot", ".png",
                     context.getCacheDir());
             try {


### PR DESCRIPTION
~~I've checking again with `getContext`.~~ ✅ 

---

I encountered the following error when I ran https://github.com/appium/ruby_lib_core/pull/33/files .

`InstrumentationRegistry.getInstrumentation().getContext()`'s context is for `io.appium.uiautomator2.test`.
`InstrumentationRegistry.getInstrumentation().getTargetContext()`'s context is for `io.appium.uiautomator2`.

In this case, the file should store via `io.appium.uiautomator2`.
After the change, I could save the screenshot expectedly.

```
Selenium::WebDriver::Error::UnknownError: An unknown server-side error occurred while processing the command. Original error: java.io.IOException: Permission denied
        at java.io.UnixFileSystem.createFileExclusively0(Native Method)
        at java.io.UnixFileSystem.createFileExclusively(UnixFileSystem.java:280)
        at java.io.File.createNewFile(File.java:948)
        at java.io.File.createTempFile(File.java:1862)
        at io.appium.uiautomator2.handler.GetElementScreenshot.safeHandle(GetElementScreenshot.java:46)
        at io.appium.uiautomator2.handler.request.SafeRequestHandler.handle(SafeRequestHandler.java:56)
        at io.appium.uiautomator2.server.AppiumServlet.handleRequest(AppiumServlet.java:208)
        at io.appium.uiautomator2.server.AppiumServlet.handleHttpRequest(AppiumServlet.java:199)
        at io.appium.uiautomator2.http.ServerHandler.channelRead(ServerHandler.java:44)
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:366)
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:352)
        at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:345)
        at io.netty.handler.codec.MessageToMessageDecoder.channelRead(MessageToMessageDecoder.java:102)
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:366)
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:352)
        at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:345)
        at io.netty.channel.CombinedChannelDuplexHandler$DelegatingChannelHandlerContext.fireChannelRead(CombinedChannelDuplexHandler.java:435)
        at io.netty.handler.codec.ByteToMessageDecoder.fireChannelRead(ByteToMessageDecoder.java:293)
        at io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:267)
        at io.netty.channel.CombinedChannelDuplexHandler.channelRead(CombinedChannelDuplexHandler.java:250)
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:366)
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:352)
        at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:345)
        at io.netty.channel.DefaultChannelPipeline$HeadContext.channelRead(DefaultChannelPipeline.java:1294)
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:366)
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:352)
        at io.netty.channel.DefaultChannelPipeline.fireChannelRead(DefaultChannelPipeline.java:911)
        at io.netty.channel.nio.AbstractNioByteChannel$NioByteUnsafe.read(AbstractNioByteChannel.java:131)
        at io.netty.channel.nio.NioEventLoop.processSelectedKey(NioEventLoop.java:611)
        at io.netty.channel.nio.NioEventLoop.processSelectedKeysOptimized(NioEventLoop.java:552)
        at io.netty.channel.nio.NioEventLoop.processSelectedKeys(NioEventLoop.java:466)
        at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:438)
        at io.netty.util.concurrent.SingleThreadEventExecutor$2.run(SingleThreadEventExecutor.java:140)
        at io.netty.util.concurrent.DefaultThreadFactory$DefaultRunnableDecorator.run(DefaultThreadFactory.java:144)
        at java.lang.Thread.run(Thread.java:761)
```