### PR TITLE
Streamline publishing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,5 @@
 /build
 /captures
 /node_modules
-npm-debug.log
+*.log
+apks/

--- a/.npmignore
+++ b/.npmignore
@@ -1,2 +1,5 @@
-!app/build/outputs/apk
-!local.properties
+app
+build
+doc
+gradle
+local.properties

--- a/doc/release.md
+++ b/doc/release.md
@@ -1,34 +1,21 @@
 **Publishing:**
 
-Appium UIAutomator2 server and driver modules published as
-[appium-uiautomator2-server](https://www.npmjs.com/package/appium-uiautomator2-server)
-and [appium-uiautomator2-driver](https://www.npmjs.com/package/appium-uiautomator2-driver).
-
-
-[appium-uiautomator2-driver](https://github.com/appium/appium-uiautomator2-driver/blob/master/lib/installer.js#L6)
-depends on release version for downloading and installing of `appium-uiautomator2-server`
-apks, gradle [versionName](https://github.com/appium/appium-uiautomator2-server/blob/master/app/build.gradle#L33)
-should always be inline with npm [`version`](https://github.com/appium/appium-uiautomator2-server/blob/master/package.json#L3).
-
-**Server Release:**
-
-* appium-uiautomator2-server-v**x.x.x**.apk and appium-uiautomator2-server-debug-androidTest.apk needs to be attached for every release and **x.x.x**<apk version> should always be inline with npm release version.
-
-* `gradle clean assembleServerDebug assembleServerDebugAndroidTest` will generate
-  * `appium-uiautomator2-server-vx.x.x.apk` in `app/build/outputs/apk/server/debug`
-  * `appium-uiautomator2-server-debug-androidTest.apk` in `app/build/outputs/apk/androidTest/server/debug`
-* Upload APK files to [release](https://github.com/appium/appium-uiautomator2-server/releases)
-
-**Update Server apk version and SHAs in UiAutomator2 driver:**
-
-Once after you do the server release, you also need to specify the server apks
-SHA-512 hash and version in [UiAutomator2-Driver](https://github.com/appium/appium-uiautomator2-driver/blob/master/lib/installer.js#L10)
-Example:
-``` java
-const SERVER_DOWNLOAD_SHA512 = "server_apk_hash";
-
-const SERVER_TEST_DOWNLOAD_SHA512 = "androidTest_apk_hash"
+Publishing is a matter of running the [npm version command](https://docs.npmjs.com/cli/version):
+```shell
+npm version major|minor|patch
 ```
+which will
 
-Note:
-* You can use online file hash calculators like [md5file.com](https://md5file.com/calculator) to find SHA-512
+1. Update the appropriate npm version and tag in git.
+1. Update the `app/build.gradle` file with the npm package version.
+1. Build the server and test app.
+1. Put everything into the expected place.
+
+Followed by pushing the commit and running the [npm publish command](https://docs.npmjs.com/cli/publish):
+```shell
+git push --tags origin master
+npm publish
+```
+which will
+1. Push result to GitHub
+1. Publish to npm

--- a/index.js
+++ b/index.js
@@ -1,0 +1,10 @@
+const path = require('path');
+const version = require('./package.json').version;
+
+const SERVER_APK_PATH = path.resolve(__dirname, 'apks', `appium-uiautomator2-server-v${version}.apk`);
+const TEST_APK_PATH = path.resolve(__dirname, 'apks', 'appium-uiautomator2-server-debug-androidTest.apk');
+
+module.exports = {
+  SERVER_APK_PATH,
+  TEST_APK_PATH,
+};

--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
   "version": "0.4.1",
   "description": "A netty server with uiautomator2 handlers",
   "main": "index.js",
-  "windowsBuildDir":"c:/tmp",
-   "repository": {
+  "windowsBuildDir": "c:/tmp",
+  "repository": {
     "type": "git",
     "url": "https://github.com/appium/appium-uiautomator2-server"
   },
@@ -18,5 +18,17 @@
   "bugs": {
     "url": "https://github.com/appium/appium-uiautomator2-server/issues"
   },
-  "homepage": "https://github.com/appium/appium-uiautomator2-server"
+  "homepage": "https://github.com/appium/appium-uiautomator2-server",
+  "scripts": {
+    "bump-gradle-version": "node update-gradle-version.js --package-version=${npm_package_version} && git add app/build.gradle",
+    "build": "gradle clean assembleServerDebug assembleServerDebugAndroidTest",
+    "move-server": "cp app/build/outputs/apk/server/debug/appium-uiautomator2-server-v${npm_package_version}.apk ./apks",
+    "move-test": "cp app/build/outputs/apk/androidTest/server/debug/appium-uiautomator2-server-debug-androidTest.apk ./apks",
+    "move-apks": "rm -rf apks && mkdir -p apks && npm run move-server && npm run move-test",
+    "version": "npm run bump-gradle-version && npm run build && npm run move-apks"
+  },
+  "devDependencies": {
+    "replace-in-file": "^3.1.0",
+    "yargs": "^10.1.1"
+  }
 }

--- a/update-gradle-version.js
+++ b/update-gradle-version.js
@@ -1,0 +1,36 @@
+#!/usr/bin/env node
+
+const replace = require('replace-in-file');
+const path = require('path');
+const argv = require('yargs').argv
+
+
+const GRADLE_BUILD_FILE = path.resolve(__dirname, 'app', 'build.gradle');
+
+// specify the package version to update to using the `--package-version=XXX` flag
+const version = argv['package-version'];
+
+if (!version) {
+  console.error('No updated version specified');
+  process.exit(1);
+}
+if (!/\d+\.\d+\.\d+/.test(version)) {
+  console.error(`Invalid version specified '${version}'`);
+  console.error(`Version should be in the form '1.2.3'`);
+  process.exit(2);
+}
+
+console.log(`Updating gradle build file to version '${version}'`);
+replace({
+  files: GRADLE_BUILD_FILE,
+  from: /^\s+versionName\s"(.+)"$/gm,
+  to: (match, ...args) => {
+    // match will be like `versionName "1.2.3"`
+    return match.replace(/\d+\.\d+\.\d/, version);
+  },
+}).then((changes) => {
+  console.log(`Updated files: ${changes.join(', ')}`);
+}).catch((err) => {
+  console.error(`Unable to bump version: ${err.message}`);
+  process.exit(3);
+});


### PR DESCRIPTION
Publishing now becomes a matter of running the normal flow. `npm version major|minor|patch` will build the apks and put them in a place known to the index. `npm publish` will create a tarball that includes the corresponding apks for use.

Usage would become a matter of importing the package and getting the `SERVER_APK_PATH` and `TEST_APK_PATH`. E.g., in the `appium-uiautomator2-driver` package,
```js
// -import { UI2_SERVER_APK_PATH as apkPath, UI2_TEST_APK_PATH as testApkPath, UI2_VER} from './installer';
import { UI2_VER } from './installer';
import { SERVER_APK_PATH as apkPath, TEST_APK_PATH as testApkPath } from 'appium-uiautomator2-server';
```