### PR TITLE
Shouln't use hardcoded timeout for waitForIdle().

### DIFF
--- a/app/src/main/java/io/appium/uiautomator2/model/XPathFinder.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/XPathFinder.java
@@ -231,7 +231,7 @@ public class XPathFinder implements Finder {
 
   public static AccessibilityNodeInfo getRootAccessibilityNode() throws UiAutomator2Exception {
     final long timeoutMillis = 10000;
-    Device.waitForIdle(timeoutMillis);
+    Device.waitForIdle();
 
     long end = SystemClock.uptimeMillis() + timeoutMillis;
     while (true) {


### PR DESCRIPTION
The `Device.waitForIdle` in `XPathFinder.java` shouldn't use hardcoded value 10*1000 ms. It should be UiAutomator who decide whether use default timeout value or read from user's setting. 

This also related to https://github.com/appium/appium/issues/9147. When there are some continues background animation, user may try to set a small `waitForIdleTimeout` to prevent it from hanging. But if he try to search XPath, it will seem like the setting has no effect.