### PR TITLE
Speed up screenshoting

### DIFF
--- a/app/src/main/java/io/appium/uiautomator2/handler/CaptureScreenshot.java
+++ b/app/src/main/java/io/appium/uiautomator2/handler/CaptureScreenshot.java
@@ -1,17 +1,44 @@
 package io.appium.uiautomator2.handler;
 
-import android.os.Environment;
+import android.app.UiAutomation;
+import android.graphics.Bitmap;
+import android.support.annotation.Nullable;
+import android.util.Base64;
 
-import java.io.File;
+import java.io.ByteArrayOutputStream;
 
 import io.appium.uiautomator2.handler.request.SafeRequestHandler;
 import io.appium.uiautomator2.http.AppiumResponse;
 import io.appium.uiautomator2.http.IHttpRequest;
+import io.appium.uiautomator2.model.internal.CustomUiDevice;
 import io.appium.uiautomator2.server.WDStatus;
-import io.appium.uiautomator2.utils.Device;
 import io.appium.uiautomator2.utils.Logger;
 
+
 public class CaptureScreenshot extends SafeRequestHandler {
+    static final int SCREENSHOT_COMPRESSION_QUALITY = 80;
+
+    private static final UiAutomation uia = CustomUiDevice.getInstance()
+            .getInstrumentation()
+            .getUiAutomation();
+
+    @Nullable
+    private static String takeScreenshot() {
+        final Bitmap screenshot = uia.takeScreenshot();
+        if (screenshot == null) {
+            return null;
+        }
+        try {
+            final ByteArrayOutputStream stream = new ByteArrayOutputStream();
+            if (!screenshot.compress(Bitmap.CompressFormat.PNG, SCREENSHOT_COMPRESSION_QUALITY,
+                    stream)) {
+                return null;
+            }
+            return Base64.encodeToString(stream.toByteArray(), Base64.DEFAULT);
+        } finally {
+            screenshot.recycle();
+        }
+    }
 
     public CaptureScreenshot(String mappedUri) {
         super(mappedUri);
@@ -20,20 +47,11 @@ public class CaptureScreenshot extends SafeRequestHandler {
     @Override
     public AppiumResponse safeHandle(IHttpRequest request) {
         Logger.info("Capture screenshot command");
-        boolean isActionPerformed;
-        String actionMsg;
-        final File screenshot = new File(Environment.getExternalStorageDirectory() + File.separator + "screenshot.png");
-        screenshot.getParentFile().mkdirs();
-        if (screenshot.exists()) {
-            screenshot.delete();
+        final String result = takeScreenshot();
+        if (null == result) {
+            return new AppiumResponse(getSessionId(request), WDStatus.UNKNOWN_ERROR,
+                    "Failed to capture a screenshot. Does the current view have 'secure' flag set?");
         }
-        isActionPerformed = Device.getUiDevice().takeScreenshot(screenshot);
-        if (isActionPerformed) {
-            actionMsg = "Captured Screen Successfully";
-            Logger.info("ScreenShot captured at location: " + screenshot, actionMsg);
-        } else {
-            actionMsg = "Failed to capture Screen Shot";
-        }
-        return new AppiumResponse(getSessionId(request), WDStatus.SUCCESS, actionMsg);
+        return new AppiumResponse(getSessionId(request), WDStatus.SUCCESS, result);
     }
 }

--- a/app/src/main/java/io/appium/uiautomator2/handler/CaptureScreenshot.java
+++ b/app/src/main/java/io/appium/uiautomator2/handler/CaptureScreenshot.java
@@ -16,8 +16,6 @@ import io.appium.uiautomator2.utils.Logger;
 
 
 public class CaptureScreenshot extends SafeRequestHandler {
-    static final int SCREENSHOT_COMPRESSION_QUALITY = 80;
-
     private static final UiAutomation uia = CustomUiDevice.getInstance()
             .getInstrumentation()
             .getUiAutomation();
@@ -30,8 +28,7 @@ public class CaptureScreenshot extends SafeRequestHandler {
         }
         try {
             final ByteArrayOutputStream stream = new ByteArrayOutputStream();
-            if (!screenshot.compress(Bitmap.CompressFormat.PNG, SCREENSHOT_COMPRESSION_QUALITY,
-                    stream)) {
+            if (!screenshot.compress(Bitmap.CompressFormat.PNG, 100, stream)) {
                 return null;
             }
             return Base64.encodeToString(stream.toByteArray(), Base64.DEFAULT);

--- a/app/src/main/java/io/appium/uiautomator2/handler/GetElementScreenshot.java
+++ b/app/src/main/java/io/appium/uiautomator2/handler/GetElementScreenshot.java
@@ -1,28 +1,29 @@
 package io.appium.uiautomator2.handler;
 
-import android.content.Context;
+import android.app.UiAutomation;
 import android.graphics.Bitmap;
-import android.graphics.BitmapFactory;
 import android.graphics.Rect;
-import android.support.test.InstrumentationRegistry;
 import android.support.test.uiautomator.UiObjectNotFoundException;
 import android.util.Base64;
 
 import java.io.ByteArrayOutputStream;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.IOException;
 
 import io.appium.uiautomator2.handler.request.SafeRequestHandler;
 import io.appium.uiautomator2.http.AppiumResponse;
 import io.appium.uiautomator2.http.IHttpRequest;
 import io.appium.uiautomator2.model.AndroidElement;
 import io.appium.uiautomator2.model.KnownElements;
+import io.appium.uiautomator2.model.internal.CustomUiDevice;
 import io.appium.uiautomator2.server.WDStatus;
-import io.appium.uiautomator2.utils.Device;
 import io.appium.uiautomator2.utils.Logger;
 
+import static io.appium.uiautomator2.handler.CaptureScreenshot.SCREENSHOT_COMPRESSION_QUALITY;
+
 public class GetElementScreenshot extends SafeRequestHandler {
+
+    private static final UiAutomation uia = CustomUiDevice.getInstance()
+            .getInstrumentation()
+            .getUiAutomation();
 
     public GetElementScreenshot(String mappedUri) {
         super(mappedUri);
@@ -42,27 +43,34 @@ public class GetElementScreenshot extends SafeRequestHandler {
                 Logger.error("Element is not visible");
                 return new AppiumResponse(getSessionId(request), WDStatus.ELEMENT_NOT_VISIBLE);
             }
-            final Context context = InstrumentationRegistry.getInstrumentation().getTargetContext();
-            final File outputFile = File.createTempFile("screenshot", ".png",
-                    context.getCacheDir());
+            final Bitmap screenshot = uia.takeScreenshot();
+            if (screenshot == null) {
+                return new AppiumResponse(getSessionId(request), WDStatus.UNKNOWN_ERROR,
+                        "Failed to capture a screenshot. Does the current view have 'secure' flag set?");
+            }
             try {
-                if (!Device.getUiDevice().takeScreenshot(outputFile)) {
-                    return new AppiumResponse(getSessionId(request), WDStatus.UNKNOWN_ERROR,
-                            "Cannot capture a screenshot");
+                final Rect screenRect = new Rect(0, 0,
+                        screenshot.getWidth(), screenshot.getHeight());
+                final Rect intersectionRect = new Rect();
+                if (!intersectionRect.setIntersect(elementRect, screenRect)) {
+                    Logger.error("Element is not visible inside screen rect");
+                    return new AppiumResponse(getSessionId(request), WDStatus.ELEMENT_NOT_VISIBLE);
                 }
-                Logger.info("ScreenShot captured at location: " + outputFile.getAbsolutePath());
-                Bitmap elementBmpScreenshot;
-                try (FileInputStream fis = new FileInputStream(outputFile)) {
-                    elementBmpScreenshot = Bitmap.createBitmap(BitmapFactory.decodeStream(fis),
-                            elementRect.left, elementRect.top, elementRect.width(), elementRect.height());
+
+                final Bitmap elementScreenshot = Bitmap.createBitmap(screenshot,
+                        intersectionRect.left, intersectionRect.top,
+                        intersectionRect.width(), intersectionRect.height());
+                try {
+                    final ByteArrayOutputStream elementPngScreenshot = new ByteArrayOutputStream();
+                    elementScreenshot.compress(Bitmap.CompressFormat.PNG,
+                            SCREENSHOT_COMPRESSION_QUALITY, elementPngScreenshot);
+                    return new AppiumResponse(getSessionId(request), WDStatus.SUCCESS,
+                            Base64.encodeToString(elementPngScreenshot.toByteArray(), Base64.DEFAULT));
+                } finally {
+                    elementScreenshot.recycle();
                 }
-                final ByteArrayOutputStream elementPngScreenshot = new ByteArrayOutputStream();
-                elementBmpScreenshot.compress(Bitmap.CompressFormat.PNG, 100, elementPngScreenshot);
-                return new AppiumResponse(getSessionId(request), WDStatus.SUCCESS,
-                        Base64.encodeToString(elementPngScreenshot.toByteArray(), Base64.DEFAULT));
             } finally {
-                //noinspection ResultOfMethodCallIgnored
-                outputFile.delete();
+                screenshot.recycle();
             }
         } catch (UiObjectNotFoundException e) {
             Logger.error("Element not found: ", e);

--- a/app/src/main/java/io/appium/uiautomator2/handler/GetElementScreenshot.java
+++ b/app/src/main/java/io/appium/uiautomator2/handler/GetElementScreenshot.java
@@ -53,7 +53,7 @@ public class GetElementScreenshot extends SafeRequestHandler {
                         screenshot.getWidth(), screenshot.getHeight());
                 final Rect intersectionRect = new Rect();
                 if (!intersectionRect.setIntersect(elementRect, screenRect)) {
-                    Logger.error("Element is not visible inside screen rect");
+                    Logger.error("Element is not visible inside the screen rect");
                     return new AppiumResponse(getSessionId(request), WDStatus.ELEMENT_NOT_VISIBLE);
                 }
 
@@ -62,8 +62,11 @@ public class GetElementScreenshot extends SafeRequestHandler {
                         intersectionRect.width(), intersectionRect.height());
                 try {
                     final ByteArrayOutputStream elementPngScreenshot = new ByteArrayOutputStream();
-                    elementScreenshot.compress(Bitmap.CompressFormat.PNG,
-                            SCREENSHOT_COMPRESSION_QUALITY, elementPngScreenshot);
+                    if (!elementScreenshot.compress(Bitmap.CompressFormat.PNG,
+                            SCREENSHOT_COMPRESSION_QUALITY, elementPngScreenshot)) {
+                        return new AppiumResponse(getSessionId(request), WDStatus.UNKNOWN_ERROR,
+                                "Element screenshot cannot be compressed to PNG format");
+                    }
                     return new AppiumResponse(getSessionId(request), WDStatus.SUCCESS,
                             Base64.encodeToString(elementPngScreenshot.toByteArray(), Base64.DEFAULT));
                 } finally {

--- a/app/src/main/java/io/appium/uiautomator2/handler/GetElementScreenshot.java
+++ b/app/src/main/java/io/appium/uiautomator2/handler/GetElementScreenshot.java
@@ -17,10 +17,7 @@ import io.appium.uiautomator2.model.internal.CustomUiDevice;
 import io.appium.uiautomator2.server.WDStatus;
 import io.appium.uiautomator2.utils.Logger;
 
-import static io.appium.uiautomator2.handler.CaptureScreenshot.SCREENSHOT_COMPRESSION_QUALITY;
-
 public class GetElementScreenshot extends SafeRequestHandler {
-
     private static final UiAutomation uia = CustomUiDevice.getInstance()
             .getInstrumentation()
             .getUiAutomation();
@@ -62,8 +59,8 @@ public class GetElementScreenshot extends SafeRequestHandler {
                         intersectionRect.width(), intersectionRect.height());
                 try {
                     final ByteArrayOutputStream elementPngScreenshot = new ByteArrayOutputStream();
-                    if (!elementScreenshot.compress(Bitmap.CompressFormat.PNG,
-                            SCREENSHOT_COMPRESSION_QUALITY, elementPngScreenshot)) {
+                    if (!elementScreenshot.compress(Bitmap.CompressFormat.PNG, 100,
+                            elementPngScreenshot)) {
                         return new AppiumResponse(getSessionId(request), WDStatus.UNKNOWN_ERROR,
                                 "Element screenshot cannot be compressed to PNG format");
                     }


### PR DESCRIPTION
Actually, the previous screenshoting endpoint was not working properly at all, since it was not returning Base64-encoded screenshot string. Now it's fixed. Also, I've get rid of unnecessary files creation, so the process should be much faster now.

@vmaxim Please take a look when you have time