### PR TITLE
Add task for cleaning device

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,11 +21,12 @@
   "homepage": "https://github.com/appium/appium-uiautomator2-server",
   "scripts": {
     "bump-gradle-version": "node update-gradle-version.js --package-version=${npm_package_version} && git add app/build.gradle",
-    "build": "./gradlew clean assembleServerDebug assembleServerDebugAndroidTest",
+    "build": "./gradlew clean assembleServerDebug assembleServerDebugAndroidTest && npm run move-apks",
     "move-server": "cp app/build/outputs/apk/server/debug/appium-uiautomator2-server-v${npm_package_version}.apk ./apks",
     "move-test": "cp app/build/outputs/apk/androidTest/server/debug/appium-uiautomator2-server-debug-androidTest.apk ./apks",
     "move-apks": "rm -rf apks && mkdir -p apks && npm run move-server && npm run move-test",
-    "version": "npm run bump-gradle-version && npm run build && npm run move-apks"
+    "version": "npm run bump-gradle-version && npm run build",
+    "clean-device": "adb uninstall io.appium.uiautomator2.server && adb uninstall io.appium.uiautomator2.server.test"
   },
   "devDependencies": {
     "replace-in-file": "^3.1.0",


### PR DESCRIPTION
Move the moving of apks into the build task, so that a user can run `npm run build` while working (say, while linking the package) and have everything in working order.

Also add `npm run clean-device` to do a rudimentary clean of the apks from the device (no handling of different devices connected, etc).