### PR TITLE
expose data about last scroll

### DIFF
--- a/app/src/main/java/io/appium/uiautomator2/core/EventRegister.java
+++ b/app/src/main/java/io/appium/uiautomator2/core/EventRegister.java
@@ -1,0 +1,42 @@
+package io.appium.uiautomator2.core;
+
+
+import android.app.UiAutomation;
+import android.support.test.uiautomator.Configurator;
+import android.view.accessibility.AccessibilityEvent;
+
+import io.appium.uiautomator2.model.AppiumUiAutomatorDriver;
+import io.appium.uiautomator2.utils.Logger;
+
+public abstract class EventRegister {
+
+    public static Boolean runAndRegisterScrollEvents (ReturningRunnable<Boolean> runnable) {
+        AccessibilityEvent event = null;
+        UiAutomation.AccessibilityEventFilter eventFilter = new UiAutomation.AccessibilityEventFilter() {
+            @Override
+            public boolean accept(AccessibilityEvent event) {
+                return event.getEventType() == AccessibilityEvent.TYPE_VIEW_SCROLLED;
+            }
+        };
+
+        try {
+            //wait for AccessibilityEvent filter
+            event = UiAutomatorBridge.getInstance().getUiAutomation().executeAndWaitForEvent(runnable,
+                    eventFilter, Configurator.getInstance().getScrollAcknowledgmentTimeout());
+        } catch (Exception ignore) {}
+
+        if (event != null) {
+            AppiumUiAutomatorDriver.getInstance().getSession().setLastScrollData(
+                    event.getScrollX(),
+                    event.getMaxScrollX(),
+                    event.getScrollY(),
+                    event.getMaxScrollY(),
+                    event.getFromIndex(),
+                    event.getToIndex(),
+                    event.getItemCount()
+            );
+        }
+        Logger.error("!!!! did not get event after waiting for " + Configurator.getInstance().getScrollAcknowledgmentTimeout() + " timeout");
+        return runnable.getResult();
+    }
+}

--- a/app/src/main/java/io/appium/uiautomator2/core/EventRegister.java
+++ b/app/src/main/java/io/appium/uiautomator2/core/EventRegister.java
@@ -6,7 +6,6 @@ import android.support.test.uiautomator.Configurator;
 import android.view.accessibility.AccessibilityEvent;
 
 import io.appium.uiautomator2.model.AppiumUiAutomatorDriver;
-import io.appium.uiautomator2.utils.Logger;
 
 public abstract class EventRegister {
 
@@ -36,7 +35,6 @@ public abstract class EventRegister {
                     event.getItemCount()
             );
         }
-        Logger.error("!!!! did not get event after waiting for " + Configurator.getInstance().getScrollAcknowledgmentTimeout() + " timeout");
         return runnable.getResult();
     }
 }

--- a/app/src/main/java/io/appium/uiautomator2/core/EventRegister.java
+++ b/app/src/main/java/io/appium/uiautomator2/core/EventRegister.java
@@ -7,6 +7,7 @@ import android.view.accessibility.AccessibilityEvent;
 
 import java.util.concurrent.TimeoutException;
 
+import io.appium.uiautomator2.model.AccessibilityScrollData;
 import io.appium.uiautomator2.model.AppiumUiAutomatorDriver;
 import io.appium.uiautomator2.model.Session;
 import io.appium.uiautomator2.utils.Logger;
@@ -33,17 +34,9 @@ public abstract class EventRegister {
         Session session = AppiumUiAutomatorDriver.getInstance().getSession();
 
         if (event == null) {
-            session.clearLastScrollData();
+            session.setLastScrollData(null);
         } else {
-            AppiumUiAutomatorDriver.getInstance().getSession().setLastScrollData(
-                    event.getScrollX(),
-                    event.getMaxScrollX(),
-                    event.getScrollY(),
-                    event.getMaxScrollY(),
-                    event.getFromIndex(),
-                    event.getToIndex(),
-                    event.getItemCount()
-            );
+            session.setLastScrollData(new AccessibilityScrollData(event));
         }
         return runnable.getResult();
     }

--- a/app/src/main/java/io/appium/uiautomator2/core/InteractionController.java
+++ b/app/src/main/java/io/appium/uiautomator2/core/InteractionController.java
@@ -19,6 +19,7 @@ import android.view.InputEvent;
 import android.view.MotionEvent.PointerCoords;
 
 import io.appium.uiautomator2.common.exceptions.UiAutomator2Exception;
+import io.appium.uiautomator2.utils.Logger;
 
 import static io.appium.uiautomator2.utils.ReflectionUtils.invoke;
 import static io.appium.uiautomator2.utils.ReflectionUtils.method;
@@ -42,23 +43,59 @@ public class InteractionController {
         return (Boolean) invoke(method(CLASS_INTERACTION_CONTROLLER, METHOD_SEND_KEY, int.class, int.class), interactionController, keyCode, metaState);
     }
 
-    public boolean injectEventSync(InputEvent event) throws UiAutomator2Exception {
-        return (Boolean) invoke(method(CLASS_INTERACTION_CONTROLLER, METHOD_INJECT_EVENT_SYNC, InputEvent.class), interactionController, event);
+    public boolean injectEventSync(final InputEvent event) throws UiAutomator2Exception {
+        return EventRegister.runAndRegisterScrollEvents(new ReturningRunnable<Boolean>() {
+            @Override
+            public void run() {
+                Boolean result = (Boolean) invoke(method(CLASS_INTERACTION_CONTROLLER,
+                        METHOD_INJECT_EVENT_SYNC, InputEvent.class), interactionController, event);
+                setResult(result);
+            }
+        });
     }
 
-    public boolean touchDown(int x, int y) throws UiAutomator2Exception {
-        return (Boolean) invoke(method(CLASS_INTERACTION_CONTROLLER, METHOD_TOUCH_DOWN, int.class, int.class), interactionController, x, y);
+    public boolean touchDown(final int x, final int y) throws UiAutomator2Exception {
+        return EventRegister.runAndRegisterScrollEvents(new ReturningRunnable<Boolean>() {
+            @Override
+            public void run() {
+                Boolean result = (Boolean) invoke(method(CLASS_INTERACTION_CONTROLLER,
+                        METHOD_TOUCH_DOWN, int.class, int.class), interactionController, x, y);
+                setResult(result);
+            }
+        });
     }
 
-    public boolean touchUp(int x, int y) throws UiAutomator2Exception {
-        return (Boolean) invoke(method(CLASS_INTERACTION_CONTROLLER, METHOD_TOUCH_UP, int.class, int.class), interactionController, x, y);
+    public boolean touchUp(final int x, final int y) throws UiAutomator2Exception {
+        return EventRegister.runAndRegisterScrollEvents(new ReturningRunnable<Boolean>() {
+            @Override
+            public void run() {
+                Boolean result = (Boolean) invoke(method(CLASS_INTERACTION_CONTROLLER, METHOD_TOUCH_UP,
+                        int.class, int.class), interactionController, x, y);
+                setResult(result);
+            }
+        });
     }
 
-    public boolean touchMove(int x, int y) throws UiAutomator2Exception {
-        return (Boolean) invoke(method(CLASS_INTERACTION_CONTROLLER, METHOD_TOUCH_MOVE, int.class, int.class), interactionController, x, y);
+    public boolean touchMove(final int x, final int y) throws UiAutomator2Exception {
+        return EventRegister.runAndRegisterScrollEvents(new ReturningRunnable<Boolean>() {
+            @Override
+            public void run() {
+                Boolean result = (Boolean) invoke(method(CLASS_INTERACTION_CONTROLLER,
+                        METHOD_TOUCH_MOVE, int.class, int.class), interactionController, x, y);
+                setResult(result);
+            }
+        });
     }
 
-    public Boolean performMultiPointerGesture(PointerCoords[][] pcs) throws UiAutomator2Exception {
-        return (Boolean) invoke(method(CLASS_INTERACTION_CONTROLLER, METHOD_PERFORM_MULTI_POINTER_GESTURE, PointerCoords[][].class), interactionController, (Object) pcs);
+    public Boolean performMultiPointerGesture(final PointerCoords[][] pcs) throws UiAutomator2Exception {
+        return EventRegister.runAndRegisterScrollEvents(new ReturningRunnable<Boolean>() {
+            @Override
+            public void run() {
+                Boolean result = (Boolean) invoke(method(CLASS_INTERACTION_CONTROLLER,
+                        METHOD_PERFORM_MULTI_POINTER_GESTURE, PointerCoords[][].class),
+                        interactionController, (Object) pcs);
+                setResult(result);
+            }
+        });
     }
 }

--- a/app/src/main/java/io/appium/uiautomator2/core/ReturningRunnable.java
+++ b/app/src/main/java/io/appium/uiautomator2/core/ReturningRunnable.java
@@ -1,0 +1,18 @@
+package io.appium.uiautomator2.core;
+
+public abstract class ReturningRunnable<T> implements Runnable {
+
+    public T result;
+
+    public ReturningRunnable() {
+        result = null;
+    }
+
+    protected void setResult(T value) {
+        result = value;
+    }
+
+    public T getResult() {
+        return result;
+    }
+}

--- a/app/src/main/java/io/appium/uiautomator2/handler/GetSessionDetails.java
+++ b/app/src/main/java/io/appium/uiautomator2/handler/GetSessionDetails.java
@@ -10,33 +10,37 @@ import io.appium.uiautomator2.http.AppiumResponse;
 import io.appium.uiautomator2.http.IHttpRequest;
 import io.appium.uiautomator2.model.AccessibilityScrollData;
 import io.appium.uiautomator2.model.AppiumUiAutomatorDriver;
+import io.appium.uiautomator2.model.Session;
 import io.appium.uiautomator2.server.WDStatus;
 import io.appium.uiautomator2.utils.Logger;
 
 public class GetSessionDetails extends SafeRequestHandler {
 
-        public GetSessionDetails(String mappedUri) {
-            super(mappedUri);
-        }
+    private Session session;
 
-        @Override
-        public AppiumResponse safeHandle(IHttpRequest request) {
-            try {
-                JSONObject result = new JSONObject();
-                AccessibilityScrollData scrollData = AppiumUiAutomatorDriver.getInstance().getSession().getLastScrollData();
-                HashMap<String, Integer> scrollDataMap;
-                if (scrollData == null) {
-                    scrollDataMap = null;
-                } else {
-                    scrollDataMap = scrollData.getAsMap();
-                }
-                JSONObject lastScrollData = new JSONObject(scrollDataMap);
-                result.put("lastScrollData", lastScrollData);
-                return new AppiumResponse(getSessionId(request), WDStatus.SUCCESS, result);
-            } catch (JSONException e) {
-                Logger.error("Exception while reading JSON: ", e);
-                Logger.error(WDStatus.JSON_DECODER_ERROR, e);
-                return new AppiumResponse(getSessionId(request), WDStatus.JSON_DECODER_ERROR, e);
+    public GetSessionDetails(String mappedUri) {
+        super(mappedUri);
+        session = AppiumUiAutomatorDriver.getInstance().getSession();
+    }
+
+    @Override
+    public AppiumResponse safeHandle(IHttpRequest request) {
+        try {
+            JSONObject result = new JSONObject();
+            AccessibilityScrollData scrollData = session.getLastScrollData();
+            HashMap<String, Integer> scrollDataMap;
+            if (scrollData == null) {
+                scrollDataMap = null;
+            } else {
+                scrollDataMap = scrollData.getAsMap();
             }
+            JSONObject lastScrollData = new JSONObject(scrollDataMap);
+            result.put("lastScrollData", lastScrollData);
+            return new AppiumResponse(getSessionId(request), WDStatus.SUCCESS, result);
+        } catch (JSONException e) {
+            Logger.error("Exception while reading JSON: ", e);
+            Logger.error(WDStatus.JSON_DECODER_ERROR, e);
+            return new AppiumResponse(getSessionId(request), WDStatus.JSON_DECODER_ERROR, e);
         }
+    }
 }

--- a/app/src/main/java/io/appium/uiautomator2/handler/GetSessionDetails.java
+++ b/app/src/main/java/io/appium/uiautomator2/handler/GetSessionDetails.java
@@ -1,0 +1,34 @@
+package io.appium.uiautomator2.handler;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.util.HashMap;
+
+import io.appium.uiautomator2.handler.request.SafeRequestHandler;
+import io.appium.uiautomator2.http.AppiumResponse;
+import io.appium.uiautomator2.http.IHttpRequest;
+import io.appium.uiautomator2.model.AppiumUiAutomatorDriver;
+import io.appium.uiautomator2.server.WDStatus;
+import io.appium.uiautomator2.utils.Logger;
+
+public class GetSessionDetails extends SafeRequestHandler {
+
+        public GetSessionDetails(String mappedUri) {
+            super(mappedUri);
+        }
+
+        @Override
+        public AppiumResponse safeHandle(IHttpRequest request) {
+            try {
+                JSONObject result = new JSONObject();
+                JSONObject lastScrollData = new JSONObject(AppiumUiAutomatorDriver.getInstance().getSession().getLastScrollData());
+                result.put("lastScrollData", lastScrollData);
+                return new AppiumResponse(getSessionId(request), WDStatus.SUCCESS, result);
+            } catch (JSONException e) {
+                Logger.error("Exception while reading JSON: ", e);
+                Logger.error(WDStatus.JSON_DECODER_ERROR, e);
+                return new AppiumResponse(getSessionId(request), WDStatus.JSON_DECODER_ERROR, e);
+            }
+        }
+}

--- a/app/src/main/java/io/appium/uiautomator2/handler/GetSessionDetails.java
+++ b/app/src/main/java/io/appium/uiautomator2/handler/GetSessionDetails.java
@@ -8,6 +8,7 @@ import java.util.HashMap;
 import io.appium.uiautomator2.handler.request.SafeRequestHandler;
 import io.appium.uiautomator2.http.AppiumResponse;
 import io.appium.uiautomator2.http.IHttpRequest;
+import io.appium.uiautomator2.model.AccessibilityScrollData;
 import io.appium.uiautomator2.model.AppiumUiAutomatorDriver;
 import io.appium.uiautomator2.server.WDStatus;
 import io.appium.uiautomator2.utils.Logger;
@@ -22,7 +23,14 @@ public class GetSessionDetails extends SafeRequestHandler {
         public AppiumResponse safeHandle(IHttpRequest request) {
             try {
                 JSONObject result = new JSONObject();
-                JSONObject lastScrollData = new JSONObject(AppiumUiAutomatorDriver.getInstance().getSession().getLastScrollData());
+                AccessibilityScrollData scrollData = AppiumUiAutomatorDriver.getInstance().getSession().getLastScrollData();
+                HashMap<String, Integer> scrollDataMap;
+                if (scrollData == null) {
+                    scrollDataMap = null;
+                } else {
+                    scrollDataMap = scrollData.getAsMap();
+                }
+                JSONObject lastScrollData = new JSONObject(scrollDataMap);
                 result.put("lastScrollData", lastScrollData);
                 return new AppiumResponse(getSessionId(request), WDStatus.SUCCESS, result);
             } catch (JSONException e) {

--- a/app/src/main/java/io/appium/uiautomator2/handler/NewSession.java
+++ b/app/src/main/java/io/appium/uiautomator2/handler/NewSession.java
@@ -28,7 +28,7 @@ public class NewSession extends SafeRequestHandler {
         String sessionID;
         try {
             Session.capabilities = getPayload(request, "desiredCapabilities");
-            sessionID = new AppiumUiAutomatorDriver().initializeSession();
+            sessionID = AppiumUiAutomatorDriver.getInstance().initializeSession();
             Logger.info("Session Created with SessionID:" + sessionID);
         } catch (JSONException e) {
             Logger.error("Exception while reading JSON: ", e);

--- a/app/src/main/java/io/appium/uiautomator2/handler/Swipe.java
+++ b/app/src/main/java/io/appium/uiautomator2/handler/Swipe.java
@@ -6,6 +6,8 @@ import org.json.JSONException;
 import org.json.JSONObject;
 
 import io.appium.uiautomator2.common.exceptions.InvalidCoordinatesException;
+import io.appium.uiautomator2.core.EventRegister;
+import io.appium.uiautomator2.core.ReturningRunnable;
 import io.appium.uiautomator2.handler.request.SafeRequestHandler;
 import io.appium.uiautomator2.http.AppiumResponse;
 import io.appium.uiautomator2.http.IHttpRequest;
@@ -26,7 +28,7 @@ public class Swipe extends SafeRequestHandler {
 
     @Override
     public AppiumResponse safeHandle(IHttpRequest request) {
-        Point absStartPos, absEndPos;
+        final Point absStartPos, absEndPos;
         final boolean isSwipePerformed;
         try {
             final SwipeArguments swipeArgs;
@@ -47,9 +49,15 @@ public class Swipe extends SafeRequestHandler {
                         + absEndPos.toString() + " with steps: " + swipeArgs.steps.toString());
             }
 
-            isSwipePerformed = getUiDevice().swipe(absStartPos.x.intValue(),
-                    absStartPos.y.intValue(), absEndPos.x.intValue(),
-                    absEndPos.y.intValue(), swipeArgs.steps);
+            isSwipePerformed = EventRegister.runAndRegisterScrollEvents(new ReturningRunnable<Boolean>() {
+                @Override
+                public void run() {
+                    setResult(getUiDevice().swipe(absStartPos.x.intValue(),
+                            absStartPos.y.intValue(), absEndPos.x.intValue(),
+                            absEndPos.y.intValue(), swipeArgs.steps));
+
+                }
+            });
             if (!isSwipePerformed) {
                 return new AppiumResponse(getSessionId(request), WDStatus.UNKNOWN_ERROR, "Swipe did not complete successfully");
             } else {

--- a/app/src/main/java/io/appium/uiautomator2/model/AccessibilityScrollData.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/AccessibilityScrollData.java
@@ -1,0 +1,53 @@
+package io.appium.uiautomator2.model;
+
+import java.util.HashMap;
+
+public class AccessibilityScrollData {
+
+    private boolean hasData;
+    private int scrollX;
+    private int maxScrollX;
+    private int scrollY;
+    private int maxScrollY;
+    private int fromIndex;
+    private int toIndex;
+    private int itemCount;
+
+    public AccessibilityScrollData(int scrollX, int maxScrollX, int scrollY, int maxScrollY,
+                                   int fromIndex, int toIndex, int itemCount) {
+        this.scrollX = scrollX;
+        this.scrollY = scrollY;
+        this.maxScrollX = maxScrollX;
+        this.maxScrollY = maxScrollY;
+        this.fromIndex = fromIndex;
+        this.toIndex = toIndex;
+        this.itemCount = itemCount;
+        this.hasData = true;
+    }
+
+    public AccessibilityScrollData() {
+        clearScrollData();
+    }
+
+    public void clearScrollData() {
+        this.hasData = false;
+    }
+
+    public HashMap<String, Integer> getAsMap () {
+        HashMap<String, Integer> map = new HashMap<>();
+
+        if (!hasData) {
+            return map;
+        }
+
+        map.put("scrollX", scrollX);
+        map.put("maxScrollX", maxScrollX);
+        map.put("scrollY", scrollY);
+        map.put("maxScrollY", maxScrollY);
+        map.put("fromIndex", fromIndex);
+        map.put("toIndex", toIndex);
+        map.put("itemCount", itemCount);
+
+        return map;
+    }
+}

--- a/app/src/main/java/io/appium/uiautomator2/model/AccessibilityScrollData.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/AccessibilityScrollData.java
@@ -1,10 +1,11 @@
 package io.appium.uiautomator2.model;
 
+import android.view.accessibility.AccessibilityEvent;
+
 import java.util.HashMap;
 
 public class AccessibilityScrollData {
 
-    private boolean hasData;
     private int scrollX;
     private int maxScrollX;
     private int scrollY;
@@ -13,32 +14,19 @@ public class AccessibilityScrollData {
     private int toIndex;
     private int itemCount;
 
-    public AccessibilityScrollData(int scrollX, int maxScrollX, int scrollY, int maxScrollY,
-                                   int fromIndex, int toIndex, int itemCount) {
-        this.scrollX = scrollX;
-        this.scrollY = scrollY;
-        this.maxScrollX = maxScrollX;
-        this.maxScrollY = maxScrollY;
-        this.fromIndex = fromIndex;
-        this.toIndex = toIndex;
-        this.itemCount = itemCount;
-        this.hasData = true;
+    public AccessibilityScrollData(AccessibilityEvent event) {
+        this.scrollX = event.getScrollX();
+        this.scrollY = event.getScrollY();
+        this.maxScrollX = event.getMaxScrollX();
+        this.maxScrollY = event.getMaxScrollY();
+        this.fromIndex = event.getFromIndex();
+        this.toIndex = event.getToIndex();
+        this.itemCount = event.getItemCount();
     }
 
-    public AccessibilityScrollData() {
-        clearScrollData();
-    }
-
-    public void clearScrollData() {
-        this.hasData = false;
-    }
 
     public HashMap<String, Integer> getAsMap () {
         HashMap<String, Integer> map = new HashMap<>();
-
-        if (!hasData) {
-            return map;
-        }
 
         map.put("scrollX", scrollX);
         map.put("maxScrollX", maxScrollX);

--- a/app/src/main/java/io/appium/uiautomator2/model/AppiumUiAutomatorDriver.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/AppiumUiAutomatorDriver.java
@@ -9,6 +9,9 @@ import java.util.UUID;
 public class AppiumUiAutomatorDriver {
 
     private Session session;
+    private static AppiumUiAutomatorDriver instance;
+
+    private AppiumUiAutomatorDriver() {}
 
     public String initializeSession() throws JSONException {
 
@@ -18,6 +21,17 @@ public class AppiumUiAutomatorDriver {
         }
         this.session = new Session(UUID.randomUUID().toString());
         return session.getSessionId();
+    }
+
+    public Session getSession () {
+        return session;
+    }
+
+    public static AppiumUiAutomatorDriver getInstance() {
+        if (instance == null) {
+            instance = new AppiumUiAutomatorDriver();
+        }
+        return instance;
     }
 }
 

--- a/app/src/main/java/io/appium/uiautomator2/model/AppiumUiAutomatorDriver.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/AppiumUiAutomatorDriver.java
@@ -27,7 +27,7 @@ public class AppiumUiAutomatorDriver {
         return session;
     }
 
-    public static AppiumUiAutomatorDriver getInstance() {
+    public static synchronized AppiumUiAutomatorDriver getInstance() {
         if (instance == null) {
             instance = new AppiumUiAutomatorDriver();
         }

--- a/app/src/main/java/io/appium/uiautomator2/model/Session.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/Session.java
@@ -12,7 +12,7 @@ public class Session {
     private String sessionId;
     private ConcurrentMap<String, JSONObject> commandConfiguration;
     private KnownElements knownElements;
-    private Map<String, Integer> lastScrollData = new HashMap<>();
+    private AccessibilityScrollData lastScrollData = new AccessibilityScrollData();
     public static Map<String, Object> capabilities = new HashMap<>();
 
     public Session(String sessionId) {
@@ -44,16 +44,15 @@ public class Session {
 
     public void setLastScrollData(int scrollX, int maxScrollX, int scrollY, int maxScrollY,
                                   int fromIndex, int toIndex, int itemCount) {
-        lastScrollData.put("scrollX", scrollX);
-        lastScrollData.put("maxScrollX", maxScrollX);
-        lastScrollData.put("scrollY", scrollY);
-        lastScrollData.put("maxScrollY", maxScrollY);
-        lastScrollData.put("fromIndex", fromIndex);
-        lastScrollData.put("toIndex", toIndex);
-        lastScrollData.put("itemCount", itemCount);
+        lastScrollData = new AccessibilityScrollData(scrollX, maxScrollX, scrollY, maxScrollY,
+                fromIndex, toIndex, itemCount);
+    }
+
+    public void clearLastScrollData() {
+        lastScrollData.clearScrollData();
     }
 
     public Map<String, Integer> getLastScrollData() {
-        return lastScrollData;
+        return lastScrollData.getAsMap();
     }
 }

--- a/app/src/main/java/io/appium/uiautomator2/model/Session.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/Session.java
@@ -12,7 +12,8 @@ public class Session {
     private String sessionId;
     private ConcurrentMap<String, JSONObject> commandConfiguration;
     private KnownElements knownElements;
-    public static Map<String, Object> capabilities = new HashMap<String, Object>();
+    private Map<String, Integer> lastScrollData = new HashMap<>();
+    public static Map<String, Object> capabilities = new HashMap<>();
 
     public Session(String sessionId) {
         this.sessionId = sessionId;
@@ -41,5 +42,18 @@ public class Session {
         return commandConfiguration.get(command);
     }
 
+    public void setLastScrollData(int scrollX, int maxScrollX, int scrollY, int maxScrollY,
+                                  int fromIndex, int toIndex, int itemCount) {
+        lastScrollData.put("scrollX", scrollX);
+        lastScrollData.put("maxScrollX", maxScrollX);
+        lastScrollData.put("scrollY", scrollY);
+        lastScrollData.put("maxScrollY", maxScrollY);
+        lastScrollData.put("fromIndex", fromIndex);
+        lastScrollData.put("toIndex", toIndex);
+        lastScrollData.put("itemCount", itemCount);
+    }
 
+    public Map<String, Integer> getLastScrollData() {
+        return lastScrollData;
+    }
 }

--- a/app/src/main/java/io/appium/uiautomator2/model/Session.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/Session.java
@@ -12,7 +12,7 @@ public class Session {
     private String sessionId;
     private ConcurrentMap<String, JSONObject> commandConfiguration;
     private KnownElements knownElements;
-    private AccessibilityScrollData lastScrollData = new AccessibilityScrollData();
+    private AccessibilityScrollData lastScrollData;
     public static Map<String, Object> capabilities = new HashMap<>();
 
     public Session(String sessionId) {
@@ -42,17 +42,11 @@ public class Session {
         return commandConfiguration.get(command);
     }
 
-    public void setLastScrollData(int scrollX, int maxScrollX, int scrollY, int maxScrollY,
-                                  int fromIndex, int toIndex, int itemCount) {
-        lastScrollData = new AccessibilityScrollData(scrollX, maxScrollX, scrollY, maxScrollY,
-                fromIndex, toIndex, itemCount);
+    public void setLastScrollData(AccessibilityScrollData scrollData) {
+        lastScrollData = scrollData;
     }
 
-    public void clearLastScrollData() {
-        lastScrollData.clearScrollData();
-    }
-
-    public Map<String, Integer> getLastScrollData() {
-        return lastScrollData.getAsMap();
+    public AccessibilityScrollData getLastScrollData() {
+        return lastScrollData;
     }
 }

--- a/app/src/main/java/io/appium/uiautomator2/server/AppiumServlet.java
+++ b/app/src/main/java/io/appium/uiautomator2/server/AppiumServlet.java
@@ -28,6 +28,7 @@ import io.appium.uiautomator2.handler.GetName;
 import io.appium.uiautomator2.handler.GetRect;
 import io.appium.uiautomator2.handler.GetRotation;
 import io.appium.uiautomator2.handler.GetScreenOrientation;
+import io.appium.uiautomator2.handler.GetSessionDetails;
 import io.appium.uiautomator2.handler.GetSize;
 import io.appium.uiautomator2.handler.GetSystemBars;
 import io.appium.uiautomator2.handler.GetText;
@@ -119,6 +120,7 @@ public class AppiumServlet implements IHttpServlet {
 
     private void registerGetHandler() {
         register(getHandler, new Status("/wd/hub/status"));
+        register(getHandler, new GetSessionDetails("/wd/hub/session/:sessionId"));
         register(getHandler, new CaptureScreenshot("/wd/hub/session/:sessionId/screenshot"));
         register(getHandler, new GetScreenOrientation("/wd/hub/session/:sessionId/orientation"));
         register(getHandler, new GetRotation("/wd/hub/session/:sessionId/rotation"));


### PR DESCRIPTION
It is desirable to know certain things about scroll views / list views, for example how much content is in them in terms of pixels or child elements. Because elements don't exist until scrolled into view, this is not possible.

However, the scroll accessibility event does contain this info, so we can examine it retroactively after a scroll action.

This PR traps that data and puts it on the session object, so it can be retrieved by a call to get the session details.