### PR TITLE
Ignore `IllegalStateException` while getting root node

### DIFF
--- a/app/src/main/java/io/appium/uiautomator2/model/XPathFinder.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/XPathFinder.java
@@ -24,6 +24,7 @@ import org.w3c.dom.Element;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
+import java.lang.IllegalStateException;
 import java.lang.reflect.Field;
 import java.util.HashMap;
 import java.util.Map;
@@ -235,8 +236,17 @@ public class XPathFinder implements Finder {
 
     long end = SystemClock.uptimeMillis() + timeoutMillis;
     while (true) {
-      AccessibilityNodeInfo root = UiAutomatorBridge.getInstance().getQueryController().getAccessibilityRootNode();
-
+      AccessibilityNodeInfo root = null;
+      try {
+          root = UiAutomatorBridge.getInstance().getQueryController().getAccessibilityRootNode();
+      } catch (IllegalStateException ignore) {
+          /**
+           * Sometimes getAccessibilityRootNode() throws
+           * "java.lang.IllegalStateException: Cannot perform this action on a sealed instance."
+           * Ignore it and try to re-get root node.
+           */
+           Logger.debug("IllegalStateException was catched while invoking getAccessibilityRootNode() - ignore it");
+      }
       if (root != null) {
         return root;
       }

--- a/app/src/main/java/io/appium/uiautomator2/model/XPathFinder.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/XPathFinder.java
@@ -235,7 +235,7 @@ public class XPathFinder implements Finder {
     Device.waitForIdle();
 
     long end = SystemClock.uptimeMillis() + timeoutMillis;
-    while (true) {
+    while (end > SystemClock.uptimeMillis()) {
       AccessibilityNodeInfo root = null;
       try {
           root = UiAutomatorBridge.getInstance().getQueryController().getAccessibilityRootNode();
@@ -250,14 +250,10 @@ public class XPathFinder implements Finder {
       if (root != null) {
         return root;
       }
-      long remainingMillis = end - SystemClock.uptimeMillis();
-      if (remainingMillis < 0) {
-        throw new UiAutomator2Exception(
-                String.format("Timed out after %d milliseconds waiting for root AccessibilityNodeInfo",
-                        timeoutMillis));
-      }
-      SystemClock.sleep(Math.min(250, remainingMillis));
+      SystemClock.sleep(250);
     }
+    final String message = "Timed out after %d milliseconds waiting for root AccessibilityNodeInfo";
+    throw new UiAutomator2Exception(String.format(message, timeoutMillis));
   }
 
   /**

--- a/app/src/test/java/io/appium/uiautomator2/model/settings/CompressedLayoutHierarchyTests.java
+++ b/app/src/test/java/io/appium/uiautomator2/model/settings/CompressedLayoutHierarchyTests.java
@@ -28,7 +28,6 @@ import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 import org.powermock.reflect.Whitebox;
 
-import io.appium.uiautomator2.utils.API;
 import io.appium.uiautomator2.utils.Device;
 
 import static org.mockito.Matchers.anyBoolean;
@@ -38,7 +37,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @RunWith(PowerMockRunner.class)
-@PrepareForTest({Device.class, API.class})
+@PrepareForTest({Device.class})
 public class CompressedLayoutHierarchyTests {
 
     private CompressedLayoutHierarchy compressedLayoutHierarchy;
@@ -49,7 +48,6 @@ public class CompressedLayoutHierarchyTests {
     @Before
     public void setup() {
         compressedLayoutHierarchy = new CompressedLayoutHierarchy();
-        Whitebox.setInternalState(API.class, "API_18", true);
         doNothing().when(uiDevice).setCompressedLayoutHeirarchy(anyBoolean());
         PowerMockito.mockStatic(Device.class);
         when(Device.getUiDevice()).thenReturn(uiDevice);
@@ -75,12 +73,5 @@ public class CompressedLayoutHierarchyTests {
     public void shouldBeAbleToDisableCompressedLayout() {
         compressedLayoutHierarchy.updateSetting(false);
         verify(uiDevice).setCompressedLayoutHeirarchy(false);
-    }
-
-    @Test
-    public void shouldDoNothingForAPIBelow18() {
-        Whitebox.setInternalState(API.class, "API_18", false);
-        compressedLayoutHierarchy.updateSetting(true);
-        verify(uiDevice, never()).setCompressedLayoutHeirarchy(anyBoolean());
     }
 }


### PR DESCRIPTION
If your device is super fast and you are lucky enough, you can catch a rare exception:

```java
io.appium.uiautomator2.common.exceptions.UiAutomator2Exception: error while invoking method android.view.accessibility.AccessibilityNodeInfo android.support.test.uiautomator.QueryController.getRootNode() on object android.support.test.uiautomator.QueryController@74ff6f1 with parameters []
	at io.appium.uiautomator2.utils.ReflectionUtils.invoke(ReflectionUtils.java:93)
	at io.appium.uiautomator2.core.QueryController.getAccessibilityRootNode(QueryController.java:37)
	at io.appium.uiautomator2.model.XPathFinder.getRootAccessibilityNode(XPathFinder.java:238)
	at io.appium.uiautomator2.model.XPathFinder.refreshUiElementTree(XPathFinder.java:224)
	at io.appium.uiautomator2.model.XPathFinder.getNodesList(XPathFinder.java:116)
	at io.appium.uiautomator2.handler.FindElement.getXPathUiObject(FindElement.java:78)
	at io.appium.uiautomator2.handler.FindElement.findElement(FindElement.java:153)
```
[Full stacktrace](https://gist.github.com/vmaxim/41dca38ff59bfd24476fe06c5670824e)

I assume we can ignore it and try to retrieve root node again.