### PR TITLE
Add system clipboard handlers

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -85,6 +85,7 @@ dependencies {
     testCompile 'org.powermock:powermock-module-junit4-rule:1.6.4'
     testCompile 'org.powermock:powermock-api-mockito:1.6.4'
     testCompile 'org.powermock:powermock-classloading-xstream:1.6.4'
+    testCompile "org.robolectric:robolectric:3.3.2"
     androidTestCompile 'junit:junit:4.12'
     androidTestCompile 'com.android.support:support-annotations:23.1.1'
     androidTestCompile 'com.android.support.test.uiautomator:uiautomator-v18:2.1.2'

--- a/app/src/main/java/io/appium/uiautomator2/handler/GetClipboard.java
+++ b/app/src/main/java/io/appium/uiautomator2/handler/GetClipboard.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.appium.uiautomator2.handler;
+
+import android.app.Instrumentation;
+import android.support.test.InstrumentationRegistry;
+import android.util.Base64;
+
+import org.json.JSONObject;
+
+import java.nio.charset.StandardCharsets;
+
+import io.appium.uiautomator2.handler.request.SafeRequestHandler;
+import io.appium.uiautomator2.http.AppiumResponse;
+import io.appium.uiautomator2.http.IHttpRequest;
+import io.appium.uiautomator2.server.WDStatus;
+import io.appium.uiautomator2.utils.ClipboardHelper;
+import io.appium.uiautomator2.utils.ClipboardHelper.ClipDataType;
+import io.appium.uiautomator2.utils.Logger;
+
+public class GetClipboard extends SafeRequestHandler {
+    private final Instrumentation mInstrumentation = InstrumentationRegistry.getInstrumentation();
+
+    private static String toBase64String(String s) {
+        return Base64.encodeToString(s.getBytes(StandardCharsets.UTF_8), Base64.DEFAULT);
+    }
+
+    public GetClipboard(String mappedUri) {
+        super(mappedUri);
+    }
+
+    @Override
+    public AppiumResponse safeHandle(IHttpRequest request) {
+        Logger.info("Get Clipboard command");
+        ClipDataType contentType = ClipDataType.PLAINTEXT;
+        try {
+            JSONObject payload = getPayload(request);
+            if (payload.has("contentType")) {
+                contentType = ClipDataType.valueOf(payload
+                        .getString("contentType")
+                        .toUpperCase());
+            }
+            switch (contentType) {
+                case PLAINTEXT:
+                    return new AppiumResponse(getSessionId(request), WDStatus.SUCCESS,
+                            toBase64String(new ClipboardHelper(mInstrumentation.getTargetContext())
+                                    .getTextData()));
+                default:
+                    throw new IllegalArgumentException();
+            }
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException(
+                    String.format("Only '%s' content types are supported. '%s' is given instead",
+                            ClipDataType.supportedDataTypes(),
+                            contentType));
+        } catch (Exception e) {
+            return new AppiumResponse(getSessionId(request), WDStatus.UNKNOWN_ERROR, e);
+        }
+    }
+}

--- a/app/src/main/java/io/appium/uiautomator2/handler/GetClipboard.java
+++ b/app/src/main/java/io/appium/uiautomator2/handler/GetClipboard.java
@@ -63,7 +63,7 @@ public class GetClipboard extends SafeRequestHandler {
                     throw new IllegalArgumentException();
             }
         } catch (IllegalArgumentException e) {
-            throw new IllegalArgumentException(
+            return new AppiumResponse(getSessionId(request), WDStatus.UNKNOWN_ERROR,
                     String.format("Only '%s' content types are supported. '%s' is given instead",
                             ClipDataType.supportedDataTypes(),
                             contentType));

--- a/app/src/main/java/io/appium/uiautomator2/handler/SetClipboard.java
+++ b/app/src/main/java/io/appium/uiautomator2/handler/SetClipboard.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.appium.uiautomator2.handler;
+
+import android.app.Instrumentation;
+import android.support.test.InstrumentationRegistry;
+import android.util.Base64;
+
+import org.json.JSONObject;
+
+import java.nio.charset.StandardCharsets;
+
+import io.appium.uiautomator2.handler.request.SafeRequestHandler;
+import io.appium.uiautomator2.http.AppiumResponse;
+import io.appium.uiautomator2.http.IHttpRequest;
+import io.appium.uiautomator2.server.WDStatus;
+import io.appium.uiautomator2.utils.ClipboardHelper;
+import io.appium.uiautomator2.utils.ClipboardHelper.ClipDataType;
+import io.appium.uiautomator2.utils.Logger;
+
+public class SetClipboard extends SafeRequestHandler {
+    private final Instrumentation mInstrumentation = InstrumentationRegistry.getInstrumentation();
+
+    private static String fromBase64String(String s) {
+        return new String(Base64.decode(s, Base64.DEFAULT), StandardCharsets.UTF_8);
+    }
+
+    public SetClipboard(String mappedUri) {
+        super(mappedUri);
+    }
+
+    @Override
+    public AppiumResponse safeHandle(IHttpRequest request) {
+        Logger.info("Set Clipboard command");
+        final String content;
+        ClipDataType contentType = ClipDataType.PLAINTEXT;
+        String label = null;
+        try {
+            JSONObject payload = getPayload(request);
+            content = fromBase64String(payload.getString("content"));
+            if (payload.has("contentType")) {
+                contentType = ClipDataType.valueOf(payload
+                        .getString("contentType")
+                        .toUpperCase());
+            }
+            if (payload.has("label")) {
+                label = payload.getString("label");
+            }
+            switch (contentType) {
+                case PLAINTEXT:
+                    new ClipboardHelper(mInstrumentation.getTargetContext())
+                            .setTextData(label, content);
+                    break;
+                default:
+                    throw new IllegalArgumentException();
+            }
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException(
+                    String.format("Only '%s' content types are supported. '%s' is given instead",
+                            ClipDataType.supportedDataTypes(),
+                            contentType));
+        } catch (Exception e) {
+            return new AppiumResponse(getSessionId(request), WDStatus.UNKNOWN_ERROR, e);
+        }
+        return new AppiumResponse(getSessionId(request), WDStatus.SUCCESS);
+    }
+
+}

--- a/app/src/main/java/io/appium/uiautomator2/handler/SetClipboard.java
+++ b/app/src/main/java/io/appium/uiautomator2/handler/SetClipboard.java
@@ -69,7 +69,7 @@ public class SetClipboard extends SafeRequestHandler {
                     throw new IllegalArgumentException();
             }
         } catch (IllegalArgumentException e) {
-            throw new IllegalArgumentException(
+            return new AppiumResponse(getSessionId(request), WDStatus.UNKNOWN_ERROR,
                     String.format("Only '%s' content types are supported. '%s' is given instead",
                             ClipDataType.supportedDataTypes(),
                             contentType));

--- a/app/src/main/java/io/appium/uiautomator2/server/AppiumServlet.java
+++ b/app/src/main/java/io/appium/uiautomator2/server/AppiumServlet.java
@@ -1,5 +1,20 @@
-package io.appium.uiautomator2.server;
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
+package io.appium.uiautomator2.server;
 
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -20,6 +35,7 @@ import io.appium.uiautomator2.handler.FindElement;
 import io.appium.uiautomator2.handler.FindElements;
 import io.appium.uiautomator2.handler.FirstVisibleView;
 import io.appium.uiautomator2.handler.Flick;
+import io.appium.uiautomator2.handler.GetClipboard;
 import io.appium.uiautomator2.handler.GetDevicePixelRatio;
 import io.appium.uiautomator2.handler.GetDeviceSize;
 import io.appium.uiautomator2.handler.GetElementAttribute;
@@ -44,6 +60,7 @@ import io.appium.uiautomator2.handler.RotateScreen;
 import io.appium.uiautomator2.handler.ScrollTo;
 import io.appium.uiautomator2.handler.ScrollToElement;
 import io.appium.uiautomator2.handler.SendKeysToElement;
+import io.appium.uiautomator2.handler.SetClipboard;
 import io.appium.uiautomator2.handler.Source;
 import io.appium.uiautomator2.handler.Status;
 import io.appium.uiautomator2.handler.Swipe;
@@ -116,6 +133,8 @@ public class AppiumServlet implements IHttpServlet {
         register(postHandler, new UpdateSettings("/wd/hub/session/:sessionId/appium/settings"));
         register(postHandler, new NetworkConnection("/wd/hub/session/:sessionId/network_connection"));
         register(postHandler, new ScrollToElement("/wd/hub/session/:sessionId/appium/element/:id/scroll_to/:elementId"));
+        register(postHandler, new GetClipboard("/wd/hub/session/:sessionId/appium/clipboard/get"));
+        register(postHandler, new SetClipboard("/wd/hub/session/:sessionId/appium/clipboard/set"));
     }
 
     private void registerGetHandler() {
@@ -136,6 +155,7 @@ public class AppiumServlet implements IHttpServlet {
         register(getHandler, new GetSystemBars("/wd/hub/session/:sessionId/appium/device/system_bars"));
         register(getHandler, new GetDevicePixelRatio("/wd/hub/session/:sessionId/appium/device/pixel_ratio"));
         register(getHandler, new FirstVisibleView("/wd/hub/session/:sessionId/appium/element/:id/first_visible"));
+
     }
 
     protected void register(Map<String, BaseRequestHandler> registerOn, BaseRequestHandler handler) {

--- a/app/src/main/java/io/appium/uiautomator2/utils/ClipboardHelper.java
+++ b/app/src/main/java/io/appium/uiautomator2/utils/ClipboardHelper.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.appium.uiautomator2.utils;
+
+import android.content.ClipData;
+import android.content.ClipboardManager;
+import android.content.Context;
+import android.support.annotation.Nullable;
+
+import java.util.Arrays;
+
+public class ClipboardHelper {
+    private static final int DEFAULT_LABEL_LEN = 10;
+
+    private final Context context;
+
+    public ClipboardHelper(Context context) {
+        this.context = context;
+    }
+
+    private ClipboardManager getManager() {
+        final ClipboardManager cm = (ClipboardManager) context
+                .getSystemService(Context.CLIPBOARD_SERVICE);
+        if (cm == null) {
+            throw new ClipboardError("Cannot receive ClipboardManager instance from the system");
+        }
+        return cm;
+    }
+
+    public String getTextData() {
+        final ClipboardManager cm = getManager();
+        if (!cm.hasPrimaryClip()) {
+            return "";
+        }
+        final ClipData cd = cm.getPrimaryClip();
+        if (cd == null || cd.getItemCount() == 0) {
+            return "";
+        }
+        final CharSequence text = cd.getItemAt(0).coerceToText(context);
+        return text == null ? "" : text.toString();
+    }
+
+    public void setTextData(@Nullable String label, String data) {
+        final ClipboardManager cm = getManager();
+        if (label == null) {
+            label = data.length() >= DEFAULT_LABEL_LEN
+                    ? data.substring(0, DEFAULT_LABEL_LEN)
+                    : data;
+        }
+        cm.setPrimaryClip(ClipData.newPlainText(label, data));
+    }
+
+    public static class ClipboardError extends RuntimeException {
+        ClipboardError(String message) {
+            super(message);
+        }
+    }
+
+    public enum ClipDataType {
+        PLAINTEXT;
+
+        public static String supportedDataTypes() {
+            return Arrays.toString(values());
+        }
+    }
+}

--- a/app/src/test/java/io/appium/uiautomator2/utils/ClipboardHelperTests.java
+++ b/app/src/test/java/io/appium/uiautomator2/utils/ClipboardHelperTests.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.appium.uiautomator2.utils;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+import org.robolectric.shadows.ShadowApplication;
+
+import io.appium.uiautomator2.test.BuildConfig;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(RobolectricTestRunner.class)
+@Config(constants = BuildConfig.class)
+public class ClipboardHelperTests {
+
+    @Test
+    public void verifySettingAndGettingClipboardContent() {
+        final String text = "Appium is the best of the best";
+        final ClipboardHelper clipboardHelper = new ClipboardHelper(ShadowApplication
+                .getInstance()
+                .getApplicationContext());
+        clipboardHelper.setTextData(null, text);
+        assertEquals(clipboardHelper.getTextData(), text);
+    }
+
+}


### PR DESCRIPTION
this add clipboard handling primitives, so one can automate copypaste operations better. Only plain text clipboard format is supported, but the implementation allows to extend this.

@vmaxim Please take a look at this when you have time.