### PR TITLE
UiAutomator2: return element attributes during findElement(s)

### DIFF
--- a/app/src/main/java/io/appium/uiautomator2/handler/FindElement.java
+++ b/app/src/main/java/io/appium/uiautomator2/handler/FindElement.java
@@ -33,6 +33,7 @@ import io.appium.uiautomator2.model.XPathFinder;
 import io.appium.uiautomator2.model.internal.NativeAndroidBySelector;
 import io.appium.uiautomator2.server.WDStatus;
 import io.appium.uiautomator2.utils.Device;
+import io.appium.uiautomator2.utils.ElementHelpers;
 import io.appium.uiautomator2.utils.Logger;
 import io.appium.uiautomator2.utils.NodeInfoList;
 import io.appium.uiautomator2.utils.UiAutomatorParser;
@@ -106,8 +107,7 @@ public class FindElement extends SafeRequestHandler {
                 String id = UUID.randomUUID().toString();
                 AndroidElement androidElement = getAndroidElement(id, element, by);
                 ke.add(androidElement);
-                JSONObject result = new JSONObject();
-                result.put("ELEMENT", id);
+                JSONObject result = ElementHelpers.toJSON(androidElement);
                 return new AppiumResponse(getSessionId(request), WDStatus.SUCCESS, result);
             }
         } catch (UnsupportedOperationException e) {

--- a/app/src/main/java/io/appium/uiautomator2/handler/FindElements.java
+++ b/app/src/main/java/io/appium/uiautomator2/handler/FindElements.java
@@ -89,8 +89,7 @@ public class FindElements extends SafeRequestHandler {
                 String id = UUID.randomUUID().toString();
                 AndroidElement androidElement = getAndroidElement(id, element, by);
                 ke.add(androidElement);
-                JSONObject jsonElement = new JSONObject();
-                jsonElement.put("ELEMENT", id);
+                JSONObject jsonElement = ElementHelpers.toJSON(androidElement);
                 result.put(jsonElement);
             }
             return new AppiumResponse(getSessionId(request), result);

--- a/app/src/main/java/io/appium/uiautomator2/handler/GetElementAttribute.java
+++ b/app/src/main/java/io/appium/uiautomator2/handler/GetElementAttribute.java
@@ -63,26 +63,8 @@ public class GetElementAttribute extends SafeRequestHandler {
             return new AppiumResponse(getSessionId(request), WDStatus.NO_SUCH_ELEMENT);
         }
         try {
-            if ("name".equals(attributeName) || "contentDescription".equals(attributeName)
-                    || "text".equals(attributeName) || "className".equals(attributeName)
-                    || "resourceId".equals(attributeName)) {
-                String attribute = element.getStringAttribute(attributeName);
-                return new AppiumResponse(getSessionId(request), WDStatus.SUCCESS, attribute);
-            } else if ("contentSize".equals(attributeName)) {
-                Rect boundsRect = element.getBounds();
-                ContentSize contentSize = new ContentSize(boundsRect);
-                contentSize.touchPadding = getTouchPadding(element);
-                contentSize.scrollableOffset = getScrollableOffset(element);
-
-                return new AppiumResponse(getSessionId(request), WDStatus.SUCCESS, contentSize.toString());
-            } else {
-                Boolean boolAttribute = element.getBoolAttribute(attributeName);
-                // The result should be of type string according to
-                // https://w3c.github.io/webdriver/webdriver-spec.html#get-element-attribute
-                return new AppiumResponse(getSessionId(request), WDStatus.SUCCESS,
-                        boolAttribute.toString());
-            }
-
+            String attribute = getElementAttributeValue(element, attributeName);
+            return new AppiumResponse(getSessionId(request), WDStatus.SUCCESS, attribute);
         } catch (UiObjectNotFoundException e) {
             Logger.error(MessageFormat.format("Element not found while trying to get attribute '{0}'", attributeName), e);
             return new AppiumResponse(getSessionId(request), WDStatus.UNKNOWN_ERROR);
@@ -100,6 +82,25 @@ public class GetElementAttribute extends SafeRequestHandler {
             return new AppiumResponse(getSessionId(request), WDStatus.UNKNOWN_ERROR, e);
         }
 
+    }
+
+    public static String getElementAttributeValue(AndroidElement element, String attributeName) throws NoAttributeFoundException, UiObjectNotFoundException, ReflectiveOperationException {
+        if ("name".equals(attributeName) || "contentDescription".equals(attributeName)
+                || "text".equals(attributeName) || "className".equals(attributeName)
+                || "resourceId".equals(attributeName)) {
+            return element.getStringAttribute(attributeName);
+        } else if ("contentSize".equals(attributeName)) {
+            Rect boundsRect = element.getBounds();
+            ContentSize contentSize = new ContentSize(boundsRect);
+            contentSize.touchPadding = getTouchPadding(element);
+            contentSize.scrollableOffset = getScrollableOffset(element);
+            return contentSize.toString();
+        } else {
+            Boolean boolAttribute = element.getBoolAttribute(attributeName);
+            // The result should be of type string according to
+            // https://w3c.github.io/webdriver/webdriver-spec.html#get-element-attribute
+            return boolAttribute.toString();
+        }
     }
 
     private static int getScrollableOffset(AndroidElement uiScrollable) {

--- a/app/src/main/java/io/appium/uiautomator2/handler/GetRect.java
+++ b/app/src/main/java/io/appium/uiautomator2/handler/GetRect.java
@@ -43,17 +43,13 @@ public class GetRect extends SafeRequestHandler {
     public AppiumResponse safeHandle(IHttpRequest request) {
         Logger.info("Get Rect of element command");
         String id = getElementId(request);
-        final JSONObject result = new JSONObject();
+        final JSONObject result;
         AndroidElement element = KnownElements.getElementFromCache(id);
         if (element == null) {
             return new AppiumResponse(getSessionId(request), WDStatus.NO_SUCH_ELEMENT);
         }
         try {
-            final Rect rect = element.getBounds();
-            result.put("x", rect.left);
-            result.put("y", rect.top);
-            result.put("width", rect.width());
-            result.put("height", rect.height());
+            result = getElementRectJSON(element);
         } catch (UiObjectNotFoundException e) {
             Logger.error("Element not found: ", e);
             return new AppiumResponse(getSessionId(request), WDStatus.NO_SUCH_ELEMENT);
@@ -65,4 +61,13 @@ public class GetRect extends SafeRequestHandler {
         return new AppiumResponse(getSessionId(request), WDStatus.SUCCESS, result);
     }
 
+    public static JSONObject getElementRectJSON(AndroidElement element) throws UiObjectNotFoundException, JSONException {
+        final JSONObject result = new JSONObject();
+        final Rect rect = element.getBounds();
+        result.put("x", rect.left);
+        result.put("y", rect.top);
+        result.put("width", rect.width());
+        result.put("height", rect.height());
+        return result;
+    }
 }

--- a/app/src/main/java/io/appium/uiautomator2/handler/UpdateSettings.java
+++ b/app/src/main/java/io/appium/uiautomator2/handler/UpdateSettings.java
@@ -13,9 +13,11 @@ import io.appium.uiautomator2.http.AppiumResponse;
 import io.appium.uiautomator2.http.IHttpRequest;
 import io.appium.uiautomator2.model.Session;
 import io.appium.uiautomator2.model.settings.AllowInvisibleElements;
+import io.appium.uiautomator2.model.settings.ElementResponseFields;
 import io.appium.uiautomator2.model.settings.EnableNotificationListener;
 import io.appium.uiautomator2.model.settings.CompressedLayoutHierarchy;
 import io.appium.uiautomator2.model.settings.ISetting;
+import io.appium.uiautomator2.model.settings.ShouldUseCompactResponses;
 import io.appium.uiautomator2.model.settings.WaitForIdleTimeout;
 import io.appium.uiautomator2.server.WDStatus;
 import io.appium.uiautomator2.utils.Logger;
@@ -28,6 +30,8 @@ public class UpdateSettings extends SafeRequestHandler {
             put(CompressedLayoutHierarchy.SETTING_NAME, CompressedLayoutHierarchy.class);
             put(WaitForIdleTimeout.SETTING_NAME, WaitForIdleTimeout.class);
             put(EnableNotificationListener.SETTING_NAME, EnableNotificationListener.class);
+            put(ElementResponseFields.SETTING_NAME, ElementResponseFields.class);
+            put(ShouldUseCompactResponses.SETTING_NAME, ShouldUseCompactResponses.class);
         }
     };
 

--- a/app/src/main/java/io/appium/uiautomator2/model/Session.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/Session.java
@@ -1,5 +1,6 @@
 package io.appium.uiautomator2.model;
 
+import org.apache.commons.lang.BooleanUtils;
 import org.json.JSONObject;
 
 import java.util.HashMap;
@@ -9,6 +10,8 @@ import java.util.concurrent.ConcurrentMap;
 
 public class Session {
     public static final String SEND_KEYS_TO_ELEMENT = "sendKeysToElement";
+    public static final String CAP_SHOULD_USE_COMPACT_RESPONSES = "shouldUseCompactResponses";
+    public static final String CAP_ELEMENT_RESPONSE_FIELDS = "elementResponseFields";
     private String sessionId;
     private ConcurrentMap<String, JSONObject> commandConfiguration;
     private KnownElements knownElements;
@@ -26,6 +29,21 @@ public class Session {
 
     public String getSessionId() {
         return sessionId;
+    }
+
+    public static boolean shouldUseCompactResponses() {
+        boolean shouldUseCompactResponses = true;
+        if (Session.capabilities.containsKey(CAP_SHOULD_USE_COMPACT_RESPONSES)) {
+            shouldUseCompactResponses = BooleanUtils.toBoolean(Session.capabilities.get(CAP_SHOULD_USE_COMPACT_RESPONSES).toString());
+        }
+        return shouldUseCompactResponses;
+    }
+
+    public static String[] getElementResponseFields() {
+        if (Session.capabilities.containsKey(CAP_ELEMENT_RESPONSE_FIELDS)) {
+            return Session.capabilities.get(CAP_ELEMENT_RESPONSE_FIELDS).toString().split(",");
+        }
+        return new String[] { "name", "text" };
     }
 
     public void setCommandConfiguration(String command, JSONObject config) {

--- a/app/src/main/java/io/appium/uiautomator2/model/settings/ElementResponseFields.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/settings/ElementResponseFields.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.appium.uiautomator2.model.settings;
+
+import io.appium.uiautomator2.utils.Logger;
+
+public class ElementResponseFields extends AbstractSetting<String> {
+
+    public static final String SETTING_NAME = "elementResponseFields";
+
+    public ElementResponseFields() {
+        super(String.class);
+    }
+
+    @Override
+    public String getSettingName() {
+        return SETTING_NAME;
+    }
+
+    @Override
+    protected void apply(String elementResponseFields) {
+        Logger.debug("Dummy setting. Maintained in Session.capabilities.");
+    }
+
+}

--- a/app/src/main/java/io/appium/uiautomator2/model/settings/ShouldUseCompactResponses.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/settings/ShouldUseCompactResponses.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.appium.uiautomator2.model.settings;
+
+import io.appium.uiautomator2.utils.Logger;
+
+public class ShouldUseCompactResponses extends AbstractSetting<Boolean> {
+
+    public static final String SETTING_NAME = "shouldUseCompactResponses";
+
+    public ShouldUseCompactResponses() {
+        super(Boolean.class);
+    }
+
+    @Override
+    public String getSettingName() {
+        return SETTING_NAME;
+    }
+
+    @Override
+    protected void apply(Boolean shouldUseCompactResponses) {
+        Logger.debug("Dummy setting. Maintained in Session.capabilities.");
+    }
+
+}

--- a/app/src/main/java/io/appium/uiautomator2/utils/ElementHelpers.java
+++ b/app/src/main/java/io/appium/uiautomator2/utils/ElementHelpers.java
@@ -29,11 +29,14 @@ import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.List;
 
+import io.appium.uiautomator2.common.exceptions.NoAttributeFoundException;
 import io.appium.uiautomator2.core.AccessibilityNodeInfoHelper;
 import io.appium.uiautomator2.core.AccessibilityNodeInfoGetter;
 import io.appium.uiautomator2.common.exceptions.UiAutomator2Exception;
+import io.appium.uiautomator2.handler.GetElementAttribute;
+import io.appium.uiautomator2.handler.GetRect;
 import io.appium.uiautomator2.model.AndroidElement;
-import io.appium.uiautomator2.utils.UnicodeEncoder;
+import io.appium.uiautomator2.model.Session;
 
 import static io.appium.uiautomator2.utils.ReflectionUtils.method;
 
@@ -84,8 +87,41 @@ public abstract class ElementHelpers {
      *
      * For example, appium returns elements like [{"ELEMENT":1}, {"ELEMENT":2}]
      */
-    public static JSONObject toJSON(AndroidElement el) throws JSONException {
-        return new JSONObject().put("ELEMENT", el.getId());
+    public static JSONObject toJSON(AndroidElement el) throws JSONException, UiObjectNotFoundException {
+        JSONObject jsonObject = new JSONObject();
+        jsonObject.put("ELEMENT", el.getId());
+        if (!Session.shouldUseCompactResponses()) {
+            for (String field : Session.getElementResponseFields()) {
+                try {
+                    if (field.equals("name")) {
+                        putNullable(jsonObject, field, el.getContentDesc());
+                    } else if (field.equals("text")) {
+                        putNullable(jsonObject, field, el.getText());
+                    } else if (field.equals("rect")) {
+                        putNullable(jsonObject, field, GetRect.getElementRectJSON(el));
+                    } else if (field.equals("enabled")) {
+                        putNullable(jsonObject, field, GetElementAttribute.getElementAttributeValue(el, field));
+                    } else if (field.equals("displayed")) {
+                        putNullable(jsonObject, field, GetElementAttribute.getElementAttributeValue(el, field));
+                    } else if (field.equals("selected")) {
+                        putNullable(jsonObject, field, GetElementAttribute.getElementAttributeValue(el, field));
+                    } else if (field.startsWith("attribute/")) {
+                        String attributeName = field.substring(10);
+                        putNullable(jsonObject, field, GetElementAttribute.getElementAttributeValue(el, attributeName));
+                    }
+                } catch (ReflectiveOperationException | NoAttributeFoundException e) {
+                    // ignore field
+                }
+            }
+        }
+        return jsonObject;
+    }
+
+    private static void putNullable(JSONObject jsonObject, String fieldName, Object value) throws JSONException {
+        if (value == null) {
+            value = JSONObject.NULL;
+        }
+        jsonObject.put(fieldName, value);
     }
 
     /**

--- a/app/src/test/java/io/appium/uiautomator2/handler/UpdateSettingsTests.java
+++ b/app/src/test/java/io/appium/uiautomator2/handler/UpdateSettingsTests.java
@@ -37,7 +37,9 @@ import io.appium.uiautomator2.model.Session;
 import io.appium.uiautomator2.model.settings.AbstractSetting;
 import io.appium.uiautomator2.model.settings.AllowInvisibleElements;
 import io.appium.uiautomator2.model.settings.CompressedLayoutHierarchy;
+import io.appium.uiautomator2.model.settings.ElementResponseFields;
 import io.appium.uiautomator2.model.settings.EnableNotificationListener;
+import io.appium.uiautomator2.model.settings.ShouldUseCompactResponses;
 import io.appium.uiautomator2.model.settings.WaitForIdleTimeout;
 import io.appium.uiautomator2.server.WDStatus;
 
@@ -98,6 +100,16 @@ public class UpdateSettingsTests {
     @Test
     public void shouldBeAbleToReturnWaitForIdleTimeoutSetting() throws InstantiationException, IllegalAccessException {
         verifySettingIsAvailable(WaitForIdleTimeout.SETTING_NAME, WaitForIdleTimeout.class);
+    }
+
+    @Test
+    public void shouldBeAbleToReturnElementResponseFieldsSetting() throws InstantiationException, IllegalAccessException {
+        verifySettingIsAvailable(ElementResponseFields.SETTING_NAME, ElementResponseFields.class);
+    }
+
+    @Test
+    public void shouldBeAbleToReturShouldUseCompactResponsesSetting() throws InstantiationException, IllegalAccessException {
+        verifySettingIsAvailable(ShouldUseCompactResponses.SETTING_NAME, ShouldUseCompactResponses.class);
     }
 
     @Test(expected=UnsupportedSettingException.class)

--- a/app/src/test/java/io/appium/uiautomator2/model/settings/ElementResponseFieldsTest.java
+++ b/app/src/test/java/io/appium/uiautomator2/model/settings/ElementResponseFieldsTest.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.appium.uiautomator2.model.settings;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class ElementResponseFieldsTest {
+
+    private ElementResponseFields elementResponseFields;
+
+    @Before
+    public void setup() {
+        elementResponseFields = new ElementResponseFields();
+    }
+
+    @Test
+    public void shouldBeString() {
+        Assert.assertEquals(String.class, elementResponseFields.getValueType());
+    }
+
+    @Test
+    public void shouldReturnValidSettingName() {
+        Assert.assertEquals("elementResponseFields", elementResponseFields.getSettingName());
+    }
+}

--- a/app/src/test/java/io/appium/uiautomator2/model/settings/ShouldUseCompactResponsesTest.java
+++ b/app/src/test/java/io/appium/uiautomator2/model/settings/ShouldUseCompactResponsesTest.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.appium.uiautomator2.model.settings;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class ShouldUseCompactResponsesTest {
+
+    private ShouldUseCompactResponses shouldUseCompactResponses;
+
+    @Before
+    public void setup() {
+        shouldUseCompactResponses = new ShouldUseCompactResponses();
+    }
+
+    @Test
+    public void shouldBeBoolean() {
+        Assert.assertEquals(Boolean.class, shouldUseCompactResponses.getValueType());
+    }
+
+    @Test
+    public void shouldReturnValidSettingName() {
+        Assert.assertEquals("shouldUseCompactResponses", shouldUseCompactResponses.getSettingName());
+    }
+}


### PR DESCRIPTION
Support returning element attributes when making a find element or find elements request. Configured by shouldUseCompactResponses and elementResponseFields settings/capabilities.
See also appium/WebDriverAgent#69