### PR TITLE
fix to run clip feature on runOnMainSync

### DIFF
--- a/app/src/main/java/io/appium/uiautomator2/handler/GetClipboard.java
+++ b/app/src/main/java/io/appium/uiautomator2/handler/GetClipboard.java
@@ -55,7 +55,7 @@ public class GetClipboard extends SafeRequestHandler {
                         .toUpperCase());
             }
             return new AppiumResponse(getSessionId(request), WDStatus.SUCCESS,
-                    toBase64String(getClipboardResponse(contentType)));
+                    getClipboardResponse(contentType));
         } catch (IllegalArgumentException e) {
             return new AppiumResponse(getSessionId(request), WDStatus.UNKNOWN_ERROR,
                     String.format("Only '%s' content types are supported. '%s' is given instead",
@@ -85,7 +85,7 @@ public class GetClipboard extends SafeRequestHandler {
         public void run() {
             switch (contentType) {
                 case PLAINTEXT:
-                    content = new ClipboardHelper(mInstrumentation.getTargetContext()).getTextData();
+                    content = toBase64String(new ClipboardHelper(mInstrumentation.getTargetContext()).getTextData());
                     break;
                 default:
                     throw new IllegalArgumentException();

--- a/app/src/main/java/io/appium/uiautomator2/handler/SetClipboard.java
+++ b/app/src/main/java/io/appium/uiautomator2/handler/SetClipboard.java
@@ -62,8 +62,7 @@ public class SetClipboard extends SafeRequestHandler {
             }
             switch (contentType) {
                 case PLAINTEXT:
-                    new ClipboardHelper(mInstrumentation.getTargetContext())
-                            .setTextData(label, content);
+                    mInstrumentation.runOnMainSync(new AppiumSetClipboardTextRunnable(label, content));
                     break;
                 default:
                     throw new IllegalArgumentException();
@@ -79,4 +78,20 @@ public class SetClipboard extends SafeRequestHandler {
         return new AppiumResponse(getSessionId(request), WDStatus.SUCCESS);
     }
 
+    // Clip feature should run with main thread
+    private class AppiumSetClipboardTextRunnable implements Runnable {
+        private String label;
+        private String content;
+
+        AppiumSetClipboardTextRunnable(String label, String content) {
+            this.label = label;
+            this.content = content;
+        }
+
+        @Override
+        public void run() {
+            new ClipboardHelper(mInstrumentation.getTargetContext())
+                    .setTextData(label, content);
+        }
+    }
 }


### PR DESCRIPTION
related: https://github.com/appium/ruby_lib_core/pull/69#issuecomment-377466959

When I ran clip feature against Andorid, I encounterd the below error. To avoid the error, I've implemented `runOnMainSync` to run clip feature on main thread.

After this PR, ruby_lib_core's tests run perfectly for clip features on Android.

```
java.lang.RuntimeException: Can't create handler inside thread that has not called Looper.prepare()
  at android.os.Handler.<init>(Handler.java:209)
  at android.os.Handler.<init>(Handler.java:123)
  at android.content.ClipboardManager$2.<init>(ClipboardManager.java:69)
  at android.content.ClipboardManager.<init>(ClipboardManager.java:69)
  at android.app.SystemServiceRegistry$12.createService(SystemServiceRegistry.java:276)
  at android.app.SystemServiceRegistry$12.createService(SystemServiceRegistry.java:275)
  at android.app.SystemServiceRegistry$CachedServiceFetcher.getService(SystemServiceRegistry.java:884)
  at android.app.SystemServiceRegistry.getSystemService(SystemServiceRegistry.java:837)
  at android.app.ContextImpl.getSystemService(ContextImpl.java:1370)
  at io.appium.uiautomator2.utils.ClipboardHelper.getManager(ClipboardHelper.java:37)
  at io.appium.uiautomator2.utils.ClipboardHelper.getTextData(ClipboardHelper.java:45)
  at io.appium.uiautomator2.handler.GetClipboard.safeHandle(GetClipboard.java:61)
  at io.appium.uiautomator2.handler.request.SafeRequestHandler.handle(SafeRequestHandler.java:56)
  at io.appium.uiautomator2.server.AppiumServlet.handleRequest(AppiumServlet.java:238)
  at io.appium.uiautomator2.server.AppiumServlet.handleHttpRequest(AppiumServlet.java:229)
  at io.appium.uiautomator2.http.ServerHandler.channelRead(ServerHandler.java:44)
  at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:366)
  at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:352)
  at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:345)
  at io.netty.handler.codec.MessageToMessageDecoder.channelRead(MessageToMessageDecoder.java:102)
  at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:366)
  at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:352)
  at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:345)
  at io.netty.channel.CombinedChannelDuplexHandler$DelegatingChannelHandlerContext.fireChannelRead(CombinedChannelDuplexHandler.java:435)
  at io.netty.handler.codec.ByteToMessageDecoder.fireChannelRead(ByteToMessageDecoder.java:293)
  at io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:267)
  at io.netty.channel.CombinedChannelDuplexHandler.channelRead(CombinedChannelDuplexHandler.java:250)
  at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:366)
  at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:352)
  at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:345)
  at io.netty.channel.DefaultChannelPipeline$HeadContext.channelRead(DefaultChannelPipeline.java:1294)
  at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:366)
  at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:352)
  at io.netty.channel.DefaultChannelPipeline.fireChannelRead(DefaultChannelPipeline.java:911)
  at io.netty.channel.nio.AbstractNioByteChannel$NioByteUnsafe.read(AbstractNioByteChannel.java:131)
  at io.netty.channel.nio.NioEventLoop.processSelectedKey(NioEventLoop.java:611)
  at io.netty.channel.nio.NioEventLoop.processSelectedKeysPlain(NioEventLoop.java:514)
  at io.netty.channel.nio.NioEventLoop.processSelectedKeys(NioEventLoop.java:468)
  at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:438)
  at io.netty.util.concurrent.SingleThreadEventExecutor$2.run(SingleThreadEventExecutor.java:140)
  at io.netty.util.concurrent.DefaultThreadFactory$DefaultRunnableDecorator.run(DefaultThreadFactory.jav
```