### PR TITLE
Set zero to `moveTo` then the position should be zero

### DIFF
--- a/app/src/main/java/io/appium/uiautomator2/utils/PositionHelper.java
+++ b/app/src/main/java/io/appium/uiautomator2/utils/PositionHelper.java
@@ -36,9 +36,7 @@ public abstract class PositionHelper {
     private static double translateCoordinate(double pointCoord, double length, double offset) {
         double translatedCoord;
 
-        if (pointCoord == 0) {
-            translatedCoord = length * 0.5;
-        } else if (Math.abs(pointCoord) > 0 && Math.abs(pointCoord) < 1) {
+        if (Math.abs(pointCoord) > 0 && Math.abs(pointCoord) < 1) {
             translatedCoord = length * pointCoord;
         } else {
             translatedCoord = pointCoord;


### PR DESCRIPTION
## Summary

1. The absolute position of `moveTo` is not zero if we set zero like `moveTo({x:200, y:0})`.
2. The absolute position of `moveTo` is 1 if we set 1 like `moveTo({x:200, y:1})`.

In 1 case, the position should be zero.

## Current problem

If we set `moveTo` as `{x:200, y:0}`, the absolute position becomes a half of display [width or height](https://github.com/appium/appium-uiautomator2-server/compare/master...KazuCocoa:fix-position-y-0?expand=1#diff-9272eed4d1e0f705f90e64bab57915d3R66). (The position should be zero.)

### `moveTo({x:200, y:0})`
- client script
    ```js
    action.press({x: 200, y:500}).wait({ms: 500}).moveTo({x:200, y:0}).release();
    ```
- server adb
    ```
    04-02 16:50:09.542 21665-21685/? D/appium: Display bounds: [0,0][1080,1794]
        Swiping On Device from [x=200.0, y=500.0] to [x=200.0, y=897.0] with steps: 14
    ```
    - The ` to [x=200.0, y=897.0]` should be  `to [x=200.0, y=0.0]`

### `moveTo({x:200, y:1})`

If we set `moveTo` as `{x:200, y:1}`, the absolute positon becomes 1.0

- client script
    ```js
    action.press({x: 200, y:500}).wait({ms: 500}).moveTo({x:200, y:1}).release();
    ```
- server adb
    ```
    04-02 16:36:53.620 20513-20534/? D/appium: Display bounds: [0,0][1080,1794]
        Swiping On Device from [x=200.0, y=500.0] to [x=200.0, y=1.0] with steps: 14
    ```

# Fixed

If the position is zero, then set the absolute position is `pointCoord`. As the result, if the offset also zero, the return becomes zero.

- client script
    ```js
    action.press({x: 200, y:500}).wait({ms: 500}).moveTo({x:200, y:0}).release();
    ```
- server adb
    ```
    04-02 16:36:53.620 20513-20534/? D/appium: Display bounds: [0,0][1080,1794]
        Swiping On Device from [x=200.0, y=500.0] to [x=200.0, y=0.0] with steps: 14
    ```