### PR TITLE
add get settings

### DIFF
--- a/app/src/main/java/io/appium/uiautomator2/handler/GetSettings.java
+++ b/app/src/main/java/io/appium/uiautomator2/handler/GetSettings.java
@@ -1,0 +1,80 @@
+package io.appium.uiautomator2.handler;
+
+import android.graphics.Rect;
+import android.support.test.uiautomator.Configurator;
+import android.support.test.uiautomator.StaleObjectException;
+import android.support.test.uiautomator.UiObject;
+import android.support.test.uiautomator.UiObject2;
+import android.support.test.uiautomator.UiObjectNotFoundException;
+import android.support.test.uiautomator.UiSelector;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import io.appium.uiautomator2.common.exceptions.UiAutomator2Exception;
+import io.appium.uiautomator2.core.AccessibilityNodeInfoGetter;
+import io.appium.uiautomator2.handler.request.SafeRequestHandler;
+import io.appium.uiautomator2.http.AppiumResponse;
+import io.appium.uiautomator2.http.IHttpRequest;
+import io.appium.uiautomator2.model.AndroidElement;
+import io.appium.uiautomator2.model.KnownElements;
+import io.appium.uiautomator2.model.Session;
+import io.appium.uiautomator2.model.settings.ISetting;
+import io.appium.uiautomator2.model.settings.Settings;
+import io.appium.uiautomator2.server.WDStatus;
+import io.appium.uiautomator2.utils.Logger;
+
+import static io.appium.uiautomator2.utils.Device.getAndroidElement;
+
+/**
+ * This method return settings
+ */
+public class GetSettings extends SafeRequestHandler {
+
+    public GetSettings(String mappedUri) {
+        super(mappedUri);
+    }
+
+    @Override
+    public AppiumResponse safeHandle(IHttpRequest request) {
+        Logger.debug("Get settings:");
+        final JSONObject result = new JSONObject();
+
+        for (Settings value : Settings.values()) {
+            try {
+                settingsJson(result, value);
+            } catch (JSONException e) {
+                e.printStackTrace();
+            }
+        }
+
+        return new AppiumResponse(getSessionId(request), WDStatus.SUCCESS, result);
+    }
+
+    private JSONObject settingsJson(JSONObject result, Settings setting) throws JSONException {
+        result.put(setting.toString(), settingValue(setting));
+        return result;
+    }
+
+    private String settingValue(Settings setting) {
+        switch (setting) {
+            case keyInjectionDelay:
+                return Long.toString(Configurator.getInstance().getKeyInjectionDelay());
+            case waitForIdleTimeout:
+                return Long.toString(Configurator.getInstance().getWaitForIdleTimeout());
+            case waitForSelectorTimeout:
+                return Long.toString(Configurator.getInstance().getWaitForSelectorTimeout());
+            case actionAcknowledgmentTimeout:
+                return Long.toString(Configurator.getInstance().getActionAcknowledgmentTimeout());
+            case scrollAcknowledgmentTimeout:
+                return Long.toString(Configurator.getInstance().getScrollAcknowledgmentTimeout());
+            default:
+                return "no settings";
+        }
+    }
+}

--- a/app/src/main/java/io/appium/uiautomator2/handler/GetSettings.java
+++ b/app/src/main/java/io/appium/uiautomator2/handler/GetSettings.java
@@ -1,5 +1,6 @@
 package io.appium.uiautomator2.handler;
 
+import android.support.annotation.VisibleForTesting;
 import android.support.test.uiautomator.Configurator;
 
 import org.json.JSONException;
@@ -36,20 +37,27 @@ public class GetSettings extends SafeRequestHandler {
     @Override
     public AppiumResponse safeHandle(IHttpRequest request) {
         Logger.debug("Get settings:");
+
+        try {
+            return new AppiumResponse(getSessionId(request), WDStatus.SUCCESS, getPayload());
+        } catch (JSONException e) {
+            Logger.error("Exception while reading JSON: ", e);
+            return new AppiumResponse(getSessionId(request), WDStatus.JSON_DECODER_ERROR, e);
+        }
+    }
+
+    @VisibleForTesting
+    public JSONObject getPayload() throws JSONException {
         final JSONObject result = new JSONObject();
 
         for (Settings value : Settings.values()) {
             try {
                 result.put(value.toString(), settingValue(value));
-            } catch (JSONException e) {
-                Logger.error("Exception while reading JSON: ", e);
-                return new AppiumResponse(getSessionId(request), WDStatus.JSON_DECODER_ERROR, e);
             } catch (IllegalArgumentException e) {
-                Logger.error("Error while getting setting: " + value.toString() + " : " + e);
+                Logger.error("No Setting: " + value.toString() + " : " + e);
             }
         }
-
-        return new AppiumResponse(getSessionId(request), WDStatus.SUCCESS, result);
+        return result;
     }
 
     private Object settingValue(Settings setting) {

--- a/app/src/main/java/io/appium/uiautomator2/handler/GetSettings.java
+++ b/app/src/main/java/io/appium/uiautomator2/handler/GetSettings.java
@@ -1,35 +1,22 @@
 package io.appium.uiautomator2.handler;
 
-import android.graphics.Rect;
 import android.support.test.uiautomator.Configurator;
-import android.support.test.uiautomator.StaleObjectException;
-import android.support.test.uiautomator.UiObject;
-import android.support.test.uiautomator.UiObject2;
-import android.support.test.uiautomator.UiObjectNotFoundException;
-import android.support.test.uiautomator.UiSelector;
 
 import org.json.JSONException;
 import org.json.JSONObject;
 
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.UUID;
-
-import io.appium.uiautomator2.common.exceptions.UiAutomator2Exception;
-import io.appium.uiautomator2.core.AccessibilityNodeInfoGetter;
 import io.appium.uiautomator2.handler.request.SafeRequestHandler;
 import io.appium.uiautomator2.http.AppiumResponse;
 import io.appium.uiautomator2.http.IHttpRequest;
-import io.appium.uiautomator2.model.AndroidElement;
-import io.appium.uiautomator2.model.KnownElements;
+import io.appium.uiautomator2.model.NotificationListener;
 import io.appium.uiautomator2.model.Session;
-import io.appium.uiautomator2.model.settings.ISetting;
+import io.appium.uiautomator2.model.settings.AllowInvisibleElements;
+import io.appium.uiautomator2.model.settings.CompressedLayoutHierarchy;
 import io.appium.uiautomator2.model.settings.Settings;
 import io.appium.uiautomator2.server.WDStatus;
 import io.appium.uiautomator2.utils.Logger;
 
-import static io.appium.uiautomator2.utils.Device.getAndroidElement;
+import static io.appium.uiautomator2.model.Session.CAP_ELEMENT_RESPONSE_FIELDS;
 
 /**
  * This method return settings
@@ -61,18 +48,29 @@ public class GetSettings extends SafeRequestHandler {
         return result;
     }
 
-    private String settingValue(Settings setting) {
+    private Object settingValue(Settings setting) {
         switch (setting) {
             case keyInjectionDelay:
-                return Long.toString(Configurator.getInstance().getKeyInjectionDelay());
+                return Configurator.getInstance().getKeyInjectionDelay();
             case waitForIdleTimeout:
-                return Long.toString(Configurator.getInstance().getWaitForIdleTimeout());
+                return Configurator.getInstance().getWaitForIdleTimeout();
             case waitForSelectorTimeout:
-                return Long.toString(Configurator.getInstance().getWaitForSelectorTimeout());
+                return Configurator.getInstance().getWaitForSelectorTimeout();
             case actionAcknowledgmentTimeout:
-                return Long.toString(Configurator.getInstance().getActionAcknowledgmentTimeout());
+                return Configurator.getInstance().getActionAcknowledgmentTimeout();
             case scrollAcknowledgmentTimeout:
-                return Long.toString(Configurator.getInstance().getScrollAcknowledgmentTimeout());
+                return Configurator.getInstance().getScrollAcknowledgmentTimeout();
+            case enableNotificationListener:
+                return NotificationListener.getInstance().isListening;
+            case shouldUseCompactResponses:
+                return Session.shouldUseCompactResponses();
+            case ignoreUnimportantViews:
+                return CompressedLayoutHierarchy.getCompressedLayoutHierarchySetting();
+            case allowInvisibleElements:
+                Object allowInvisibleElements = Session.capabilities.get(AllowInvisibleElements.SETTING_NAME);
+                return allowInvisibleElements != null && (boolean) allowInvisibleElements;
+            case elementResponseFields:
+                return Session.capabilities.containsKey(CAP_ELEMENT_RESPONSE_FIELDS);
             default:
                 // TODO: raise InvalidArgumentException
                 return "no settings";

--- a/app/src/main/java/io/appium/uiautomator2/handler/GetSettings.java
+++ b/app/src/main/java/io/appium/uiautomator2/handler/GetSettings.java
@@ -74,6 +74,7 @@ public class GetSettings extends SafeRequestHandler {
             case scrollAcknowledgmentTimeout:
                 return Long.toString(Configurator.getInstance().getScrollAcknowledgmentTimeout());
             default:
+                // TODO: raise InvalidArgumentException
                 return "no settings";
         }
     }

--- a/app/src/main/java/io/appium/uiautomator2/handler/GetSettings.java
+++ b/app/src/main/java/io/appium/uiautomator2/handler/GetSettings.java
@@ -9,12 +9,10 @@ import org.json.JSONObject;
 import io.appium.uiautomator2.handler.request.SafeRequestHandler;
 import io.appium.uiautomator2.http.AppiumResponse;
 import io.appium.uiautomator2.http.IHttpRequest;
-import io.appium.uiautomator2.model.NotificationListener;
-import io.appium.uiautomator2.model.Session;
 import io.appium.uiautomator2.model.settings.ActionAcknowledgmentTimeout;
 import io.appium.uiautomator2.model.settings.AllowInvisibleElements;
 import io.appium.uiautomator2.model.settings.CompressedLayoutHierarchy;
-import io.appium.uiautomator2.model.settings.ElementResponseFields;
+import io.appium.uiautomator2.model.settings.ElementResponseAttributes;
 import io.appium.uiautomator2.model.settings.EnableNotificationListener;
 import io.appium.uiautomator2.model.settings.KeyInjectionDelay;
 import io.appium.uiautomator2.model.settings.ScrollAcknowledgmentTimeout;
@@ -80,8 +78,8 @@ public class GetSettings extends SafeRequestHandler {
                 return CompressedLayoutHierarchy.isEnabled();
             case allowInvisibleElements:
                 return AllowInvisibleElements.isEnabled();
-            case elementResponseFields:
-                return ElementResponseFields.isEnabled();
+            case elementResponseAttributes:
+                return ElementResponseAttributes.isEnabled();
             default:
                 throw new IllegalArgumentException();
         }

--- a/app/src/main/java/io/appium/uiautomator2/handler/UpdateSettings.java
+++ b/app/src/main/java/io/appium/uiautomator2/handler/UpdateSettings.java
@@ -25,7 +25,7 @@ import io.appium.uiautomator2.utils.Logger;
 
 public class UpdateSettings extends SafeRequestHandler {
 
-    private static final Map<String, Class<? extends ISetting>> SETTINGS = new HashMap<String, Class<? extends ISetting>>() {
+    public static final Map<String, Class<? extends ISetting>> SETTINGS = new HashMap<String, Class<? extends ISetting>>() {
         {
             put(AllowInvisibleElements.SETTING_NAME, AllowInvisibleElements.class);
             put(CompressedLayoutHierarchy.SETTING_NAME, CompressedLayoutHierarchy.class);

--- a/app/src/main/java/io/appium/uiautomator2/handler/UpdateSettings.java
+++ b/app/src/main/java/io/appium/uiautomator2/handler/UpdateSettings.java
@@ -25,7 +25,7 @@ import io.appium.uiautomator2.utils.Logger;
 
 public class UpdateSettings extends SafeRequestHandler {
 
-    public static final Map<String, Class<? extends ISetting>> SETTINGS = new HashMap<String, Class<? extends ISetting>>() {
+    private static final Map<String, Class<? extends ISetting>> SETTINGS = new HashMap<String, Class<? extends ISetting>>() {
         {
             put(AllowInvisibleElements.SETTING_NAME, AllowInvisibleElements.class);
             put(CompressedLayoutHierarchy.SETTING_NAME, CompressedLayoutHierarchy.class);

--- a/app/src/main/java/io/appium/uiautomator2/model/settings/ActionAcknowledgmentTimeout.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/settings/ActionAcknowledgmentTimeout.java
@@ -20,7 +20,7 @@ import android.support.test.uiautomator.Configurator;
 
 public class ActionAcknowledgmentTimeout extends AbstractSetting<Integer> {
 
-    public static final String SETTING_NAME = "actionAcknowledgmentTimeout";
+    public static final String SETTING_NAME = Settings.actionAcknowledgmentTimeout.toString();
 
     public ActionAcknowledgmentTimeout() {
         super(Integer.class);

--- a/app/src/main/java/io/appium/uiautomator2/model/settings/ActionAcknowledgmentTimeout.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/settings/ActionAcknowledgmentTimeout.java
@@ -16,6 +16,7 @@
 
 package io.appium.uiautomator2.model.settings;
 
+import android.support.annotation.NonNull;
 import android.support.test.uiautomator.Configurator;
 
 public class ActionAcknowledgmentTimeout extends AbstractSetting<Integer> {
@@ -24,6 +25,10 @@ public class ActionAcknowledgmentTimeout extends AbstractSetting<Integer> {
 
     public ActionAcknowledgmentTimeout() {
         super(Integer.class);
+    }
+
+    static public long getTime() {
+        return Configurator.getInstance().getActionAcknowledgmentTimeout();
     }
 
     @Override

--- a/app/src/main/java/io/appium/uiautomator2/model/settings/AllowInvisibleElements.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/settings/AllowInvisibleElements.java
@@ -16,6 +16,7 @@
 
 package io.appium.uiautomator2.model.settings;
 
+import io.appium.uiautomator2.model.Session;
 import io.appium.uiautomator2.utils.Logger;
 
 public class AllowInvisibleElements extends AbstractSetting<Boolean> {
@@ -24,6 +25,11 @@ public class AllowInvisibleElements extends AbstractSetting<Boolean> {
 
     public AllowInvisibleElements() {
         super(Boolean.class);
+    }
+
+    static public boolean isEnabled() {
+        Object allowInvisibleElements = Session.capabilities.get(AllowInvisibleElements.SETTING_NAME);
+        return allowInvisibleElements != null && (boolean) allowInvisibleElements;
     }
 
     @Override

--- a/app/src/main/java/io/appium/uiautomator2/model/settings/AllowInvisibleElements.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/settings/AllowInvisibleElements.java
@@ -20,7 +20,7 @@ import io.appium.uiautomator2.utils.Logger;
 
 public class AllowInvisibleElements extends AbstractSetting<Boolean> {
 
-    public static final String SETTING_NAME = "allowInvisibleElements";
+    public static final String SETTING_NAME = Settings.allowInvisibleElements.toString();
 
     public AllowInvisibleElements() {
         super(Boolean.class);

--- a/app/src/main/java/io/appium/uiautomator2/model/settings/CompressedLayoutHierarchy.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/settings/CompressedLayoutHierarchy.java
@@ -21,7 +21,7 @@ import io.appium.uiautomator2.utils.Logger;
 
 public class CompressedLayoutHierarchy extends AbstractSetting<Boolean> {
 
-    public static final String SETTING_NAME = "ignoreUnimportantViews";
+    public static final String SETTING_NAME = Settings.ignoreUnimportantViews.toString();
 
     public CompressedLayoutHierarchy() {
         super(Boolean.class);

--- a/app/src/main/java/io/appium/uiautomator2/model/settings/CompressedLayoutHierarchy.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/settings/CompressedLayoutHierarchy.java
@@ -29,7 +29,7 @@ public class CompressedLayoutHierarchy extends AbstractSetting<Boolean> {
         super(Boolean.class);
     }
 
-    public static boolean getCompressedLayoutHierarchySetting() {
+    public static boolean isEnabled() {
         return compressedLayoutHierarchy;
     }
 

--- a/app/src/main/java/io/appium/uiautomator2/model/settings/CompressedLayoutHierarchy.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/settings/CompressedLayoutHierarchy.java
@@ -23,12 +23,19 @@ public class CompressedLayoutHierarchy extends AbstractSetting<Boolean> {
 
     public static final String SETTING_NAME = Settings.ignoreUnimportantViews.toString();
 
+    public static boolean compressedLayoutHierarchy = false;
+
     public CompressedLayoutHierarchy() {
         super(Boolean.class);
     }
 
+    public static boolean getCompressedLayoutHierarchySetting() {
+        return compressedLayoutHierarchy;
+    }
+
     @Override
     protected void apply(Boolean compressLayout) {
+        compressedLayoutHierarchy = compressLayout;
         Device.getUiDevice().setCompressedLayoutHeirarchy(compressLayout);
     }
 
@@ -36,5 +43,4 @@ public class CompressedLayoutHierarchy extends AbstractSetting<Boolean> {
     public String getSettingName() {
         return SETTING_NAME;
     }
-
 }

--- a/app/src/main/java/io/appium/uiautomator2/model/settings/ElementResponseFields.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/settings/ElementResponseFields.java
@@ -20,7 +20,7 @@ import io.appium.uiautomator2.utils.Logger;
 
 public class ElementResponseFields extends AbstractSetting<String> {
 
-    public static final String SETTING_NAME = "elementResponseFields";
+    public static final String SETTING_NAME = Settings.elementResponseFields.toString();
 
     public ElementResponseFields() {
         super(String.class);

--- a/app/src/main/java/io/appium/uiautomator2/model/settings/ElementResponseFields.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/settings/ElementResponseFields.java
@@ -16,7 +16,10 @@
 
 package io.appium.uiautomator2.model.settings;
 
+import io.appium.uiautomator2.model.Session;
 import io.appium.uiautomator2.utils.Logger;
+
+import static io.appium.uiautomator2.model.Session.CAP_ELEMENT_RESPONSE_FIELDS;
 
 public class ElementResponseFields extends AbstractSetting<String> {
 
@@ -24,6 +27,10 @@ public class ElementResponseFields extends AbstractSetting<String> {
 
     public ElementResponseFields() {
         super(String.class);
+    }
+
+    static public boolean isEnabled() {
+        return Session.capabilities.containsKey(CAP_ELEMENT_RESPONSE_FIELDS);
     }
 
     @Override

--- a/app/src/main/java/io/appium/uiautomator2/model/settings/EnableNotificationListener.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/settings/EnableNotificationListener.java
@@ -26,6 +26,10 @@ public class EnableNotificationListener extends AbstractSetting<Boolean> {
         super(Boolean.class);
     }
 
+    static public boolean isEnabled () {
+        return NotificationListener.getInstance().isListening;
+    }
+
     @Override
     public String getSettingName() {
         return SETTING_NAME;

--- a/app/src/main/java/io/appium/uiautomator2/model/settings/EnableNotificationListener.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/settings/EnableNotificationListener.java
@@ -20,7 +20,7 @@ import io.appium.uiautomator2.model.NotificationListener;
 
 public class EnableNotificationListener extends AbstractSetting<Boolean> {
 
-    public static final String SETTING_NAME = "enableNotificationListener";
+    public static final String SETTING_NAME = Settings.enableNotificationListener.toString();
 
     public EnableNotificationListener() {
         super(Boolean.class);

--- a/app/src/main/java/io/appium/uiautomator2/model/settings/KeyInjectionDelay.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/settings/KeyInjectionDelay.java
@@ -26,6 +26,10 @@ public class KeyInjectionDelay extends AbstractSetting<Integer> {
         super(Integer.class);
     }
 
+    static public long getTime() {
+        return Configurator.getInstance().getKeyInjectionDelay();
+    }
+
     @Override
     public String getSettingName() {
         return SETTING_NAME;

--- a/app/src/main/java/io/appium/uiautomator2/model/settings/KeyInjectionDelay.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/settings/KeyInjectionDelay.java
@@ -20,7 +20,7 @@ import android.support.test.uiautomator.Configurator;
 
 public class KeyInjectionDelay extends AbstractSetting<Integer> {
 
-    public static final String SETTING_NAME = "keyInjectionDelay";
+    public static final String SETTING_NAME = Settings.keyInjectionDelay.toString();
 
     public KeyInjectionDelay() {
         super(Integer.class);

--- a/app/src/main/java/io/appium/uiautomator2/model/settings/ScrollAcknowledgmentTimeout.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/settings/ScrollAcknowledgmentTimeout.java
@@ -26,6 +26,10 @@ public class ScrollAcknowledgmentTimeout extends AbstractSetting<Integer> {
         super(Integer.class);
     }
 
+    static public long getTime() {
+        return Configurator.getInstance().getScrollAcknowledgmentTimeout();
+    }
+
     @Override
     public String getSettingName() {
         return SETTING_NAME;

--- a/app/src/main/java/io/appium/uiautomator2/model/settings/ScrollAcknowledgmentTimeout.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/settings/ScrollAcknowledgmentTimeout.java
@@ -20,7 +20,7 @@ import android.support.test.uiautomator.Configurator;
 
 public class ScrollAcknowledgmentTimeout extends AbstractSetting<Integer> {
 
-    public static final String SETTING_NAME = "scrollAcknowledgmentTimeout";
+    public static final String SETTING_NAME = Settings.scrollAcknowledgmentTimeout.toString();
 
     public ScrollAcknowledgmentTimeout() {
         super(Integer.class);

--- a/app/src/main/java/io/appium/uiautomator2/model/settings/Settings.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/settings/Settings.java
@@ -4,7 +4,7 @@ public enum Settings {
     actionAcknowledgmentTimeout,
     allowInvisibleElements,
     ignoreUnimportantViews,
-    elementResponseFields,
+    elementResponseAttributes,
     enableNotificationListener,
     keyInjectionDelay,
     scrollAcknowledgmentTimeout,

--- a/app/src/main/java/io/appium/uiautomator2/model/settings/Settings.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/settings/Settings.java
@@ -1,0 +1,14 @@
+package io.appium.uiautomator2.model.settings;
+
+public enum Settings {
+    actionAcknowledgmentTimeout,
+    allowInvisibleElements,
+    ignoreUnimportantViews,
+    elementResponseFields,
+    enableNotificationListener,
+    keyInjectionDelay,
+    scrollAcknowledgmentTimeout,
+    shouldUseCompactResponses,
+    waitForIdleTimeout,
+    waitForSelectorTimeout
+}

--- a/app/src/main/java/io/appium/uiautomator2/model/settings/ShouldUseCompactResponses.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/settings/ShouldUseCompactResponses.java
@@ -16,6 +16,7 @@
 
 package io.appium.uiautomator2.model.settings;
 
+import io.appium.uiautomator2.model.Session;
 import io.appium.uiautomator2.utils.Logger;
 
 public class ShouldUseCompactResponses extends AbstractSetting<Boolean> {
@@ -24,6 +25,11 @@ public class ShouldUseCompactResponses extends AbstractSetting<Boolean> {
 
     public ShouldUseCompactResponses() {
         super(Boolean.class);
+    }
+
+
+    static public boolean isEnabled() {
+        return  Session.shouldUseCompactResponses();
     }
 
     @Override

--- a/app/src/main/java/io/appium/uiautomator2/model/settings/ShouldUseCompactResponses.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/settings/ShouldUseCompactResponses.java
@@ -20,7 +20,7 @@ import io.appium.uiautomator2.utils.Logger;
 
 public class ShouldUseCompactResponses extends AbstractSetting<Boolean> {
 
-    public static final String SETTING_NAME = "shouldUseCompactResponses";
+    public static final String SETTING_NAME = Settings.shouldUseCompactResponses.toString();
 
     public ShouldUseCompactResponses() {
         super(Boolean.class);

--- a/app/src/main/java/io/appium/uiautomator2/model/settings/WaitForIdleTimeout.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/settings/WaitForIdleTimeout.java
@@ -20,7 +20,7 @@ import android.support.test.uiautomator.Configurator;
 
 public class WaitForIdleTimeout extends AbstractSetting<Integer> {
 
-    public static final String SETTING_NAME = "waitForIdleTimeout";
+    public static final String SETTING_NAME = Settings.waitForIdleTimeout.toString();
 
     public WaitForIdleTimeout() {
         super(Integer.class);

--- a/app/src/main/java/io/appium/uiautomator2/model/settings/WaitForIdleTimeout.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/settings/WaitForIdleTimeout.java
@@ -26,6 +26,10 @@ public class WaitForIdleTimeout extends AbstractSetting<Integer> {
         super(Integer.class);
     }
 
+    static public long getTime() {
+        return Configurator.getInstance().getWaitForIdleTimeout();
+    }
+
     @Override
     public String getSettingName() {
         return SETTING_NAME;

--- a/app/src/main/java/io/appium/uiautomator2/model/settings/WaitForSelectorTimeout.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/settings/WaitForSelectorTimeout.java
@@ -26,6 +26,10 @@ public class WaitForSelectorTimeout extends AbstractSetting<Integer> {
         super(Integer.class);
     }
 
+    static public long getTime() {
+        return Configurator.getInstance().getWaitForSelectorTimeout();
+    }
+
     @Override
     public String getSettingName() {
         return SETTING_NAME;

--- a/app/src/main/java/io/appium/uiautomator2/model/settings/WaitForSelectorTimeout.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/settings/WaitForSelectorTimeout.java
@@ -20,7 +20,7 @@ import android.support.test.uiautomator.Configurator;
 
 public class WaitForSelectorTimeout extends AbstractSetting<Integer> {
 
-    public static final String SETTING_NAME = "waitForSelectorTimeout";
+    public static final String SETTING_NAME = Settings.waitForSelectorTimeout.toString();
 
     public WaitForSelectorTimeout() {
         super(Integer.class);

--- a/app/src/main/java/io/appium/uiautomator2/server/AppiumServlet.java
+++ b/app/src/main/java/io/appium/uiautomator2/server/AppiumServlet.java
@@ -140,8 +140,6 @@ public class AppiumServlet implements IHttpServlet {
     }
 
     private void registerGetHandler() {
-        Logger.debug("-----handler in registerGetHandler------ ");
-
         register(getHandler, new Status("/wd/hub/status"));
         register(getHandler, new GetSessionDetails("/wd/hub/session/:sessionId"));
         register(getHandler, new CaptureScreenshot("/wd/hub/session/:sessionId/screenshot"));

--- a/app/src/main/java/io/appium/uiautomator2/server/AppiumServlet.java
+++ b/app/src/main/java/io/appium/uiautomator2/server/AppiumServlet.java
@@ -76,7 +76,6 @@ import io.appium.uiautomator2.http.AppiumResponse;
 import io.appium.uiautomator2.http.IHttpRequest;
 import io.appium.uiautomator2.http.IHttpResponse;
 import io.appium.uiautomator2.http.IHttpServlet;
-import io.appium.uiautomator2.utils.Logger;
 
 public class AppiumServlet implements IHttpServlet {
 
@@ -228,11 +227,6 @@ public class AppiumServlet implements IHttpServlet {
         } else if ("DELETE".equals(request.method())) {
             handler = findMatcher(request, deleteHandler);
         }
-
-        if (handler != null) {
-            Logger.debug("-----handler ------ " + handler.getMappedUri());
-        }
-
         handleRequest(request, response, handler);
     }
 

--- a/app/src/main/java/io/appium/uiautomator2/server/AppiumServlet.java
+++ b/app/src/main/java/io/appium/uiautomator2/server/AppiumServlet.java
@@ -45,6 +45,7 @@ import io.appium.uiautomator2.handler.GetRect;
 import io.appium.uiautomator2.handler.GetRotation;
 import io.appium.uiautomator2.handler.GetScreenOrientation;
 import io.appium.uiautomator2.handler.GetSessionDetails;
+import io.appium.uiautomator2.handler.GetSettings;
 import io.appium.uiautomator2.handler.GetSize;
 import io.appium.uiautomator2.handler.GetSystemBars;
 import io.appium.uiautomator2.handler.GetText;
@@ -75,6 +76,7 @@ import io.appium.uiautomator2.http.AppiumResponse;
 import io.appium.uiautomator2.http.IHttpRequest;
 import io.appium.uiautomator2.http.IHttpResponse;
 import io.appium.uiautomator2.http.IHttpServlet;
+import io.appium.uiautomator2.utils.Logger;
 
 public class AppiumServlet implements IHttpServlet {
 
@@ -138,6 +140,8 @@ public class AppiumServlet implements IHttpServlet {
     }
 
     private void registerGetHandler() {
+        Logger.debug("-----handler in registerGetHandler------ ");
+
         register(getHandler, new Status("/wd/hub/status"));
         register(getHandler, new GetSessionDetails("/wd/hub/session/:sessionId"));
         register(getHandler, new CaptureScreenshot("/wd/hub/session/:sessionId/screenshot"));
@@ -153,6 +157,7 @@ public class AppiumServlet implements IHttpServlet {
         register(getHandler, new GetDeviceSize("/wd/hub/session/:sessionId/window/:windowHandle/size"));
         register(getHandler, new Source("/wd/hub/session/:sessionId/source"));
         register(getHandler, new GetSystemBars("/wd/hub/session/:sessionId/appium/device/system_bars"));
+        register(getHandler, new GetSettings("/wd/hub/session/:sessionId/appium/settings"));
         register(getHandler, new GetDevicePixelRatio("/wd/hub/session/:sessionId/appium/device/pixel_ratio"));
         register(getHandler, new FirstVisibleView("/wd/hub/session/:sessionId/appium/element/:id/first_visible"));
     }
@@ -224,6 +229,10 @@ public class AppiumServlet implements IHttpServlet {
             handler = findMatcher(request, postHandler);
         } else if ("DELETE".equals(request.method())) {
             handler = findMatcher(request, deleteHandler);
+        }
+
+        if (handler != null) {
+            Logger.debug("-----handler ------ " + handler.getMappedUri());
         }
 
         handleRequest(request, response, handler);

--- a/app/src/test/java/io/appium/uiautomator2/handler/GetSettingsTests.java
+++ b/app/src/test/java/io/appium/uiautomator2/handler/GetSettingsTests.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.appium.uiautomator2.handler;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import io.appium.uiautomator2.http.IHttpRequest;
+import static org.junit.Assert.assertEquals;
+
+@RunWith(PowerMockRunner.class)
+public class GetSettingsTests {
+
+    @Spy
+    private GetSettings getSettings = new GetSettings("my_uri");
+
+    @Mock
+    private IHttpRequest req;
+
+    @Test
+    public void shouldBeAbleToUpdateSetting() throws JSONException {
+        JSONObject getSessionPayload = getSettings.getPayload(req);
+
+        assertEquals(JSONObject.class, getSessionPayload.getClass());
+    }
+}

--- a/app/src/test/java/io/appium/uiautomator2/model/settings/ActionAcknowledgmentTimeoutTests.java
+++ b/app/src/test/java/io/appium/uiautomator2/model/settings/ActionAcknowledgmentTimeoutTests.java
@@ -62,5 +62,6 @@ public class ActionAcknowledgmentTimeoutTests {
     public void shouldBeAbleToSetIdleTimeout() {
         actionAcknowledgmentTimeout.updateSetting(123);
         verify(configurator).setActionAcknowledgmentTimeout(123);
+        Assert.assertEquals(0, ActionAcknowledgmentTimeout.getTime());
     }
 }

--- a/app/src/test/java/io/appium/uiautomator2/model/settings/AllowInvisibleElementsTest.java
+++ b/app/src/test/java/io/appium/uiautomator2/model/settings/AllowInvisibleElementsTest.java
@@ -20,6 +20,8 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
+import io.appium.uiautomator2.model.Session;
+
 public class AllowInvisibleElementsTest {
 
     private AllowInvisibleElements allowInvisibleElements;
@@ -37,5 +39,19 @@ public class AllowInvisibleElementsTest {
     @Test
     public void shouldReturnValidSettingName() {
         Assert.assertEquals("allowInvisibleElements", allowInvisibleElements.getSettingName());
+    }
+
+    @Test
+    public void shouldBeAbleToDisableAllowInvisibleElements() {
+        Session.capabilities.put(AllowInvisibleElements.SETTING_NAME, false);
+
+        Assert.assertEquals(false, AllowInvisibleElements.isEnabled());
+    }
+
+    @Test
+    public void shouldBeAbleToEnableAllowInvisibleElements() {
+        Session.capabilities.put(AllowInvisibleElements.SETTING_NAME, true);
+
+        Assert.assertEquals(true, AllowInvisibleElements.isEnabled());
     }
 }

--- a/app/src/test/java/io/appium/uiautomator2/model/settings/CompressedLayoutHierarchyTests.java
+++ b/app/src/test/java/io/appium/uiautomator2/model/settings/CompressedLayoutHierarchyTests.java
@@ -26,13 +26,11 @@ import org.mockito.Mock;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
-import org.powermock.reflect.Whitebox;
 
 import io.appium.uiautomator2.utils.Device;
 
 import static org.mockito.Matchers.anyBoolean;
 import static org.mockito.Mockito.doNothing;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -67,11 +65,13 @@ public class CompressedLayoutHierarchyTests {
     public void shouldBeAbleToEnableCompressedLayout() {
         compressedLayoutHierarchy.updateSetting(true);
         verify(uiDevice).setCompressedLayoutHeirarchy(true);
+        Assert.assertEquals(true, CompressedLayoutHierarchy.isEnabled());
     }
 
     @Test
     public void shouldBeAbleToDisableCompressedLayout() {
         compressedLayoutHierarchy.updateSetting(false);
         verify(uiDevice).setCompressedLayoutHeirarchy(false);
+        Assert.assertEquals(false, CompressedLayoutHierarchy.isEnabled());
     }
 }

--- a/app/src/test/java/io/appium/uiautomator2/model/settings/ElementResponseFieldsTest.java
+++ b/app/src/test/java/io/appium/uiautomator2/model/settings/ElementResponseFieldsTest.java
@@ -20,6 +20,10 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
+import io.appium.uiautomator2.model.Session;
+
+import static io.appium.uiautomator2.model.Session.CAP_ELEMENT_RESPONSE_FIELDS;
+
 public class ElementResponseFieldsTest {
 
     private ElementResponseFields elementResponseFields;
@@ -37,5 +41,19 @@ public class ElementResponseFieldsTest {
     @Test
     public void shouldReturnValidSettingName() {
         Assert.assertEquals("elementResponseFields", elementResponseFields.getSettingName());
+    }
+
+    @Test
+    public void shouldBeAbleToDisableElementResponseFields() {
+        Session.capabilities.remove(CAP_ELEMENT_RESPONSE_FIELDS);
+
+        Assert.assertEquals(false, ElementResponseFields.isEnabled());
+    }
+
+    @Test
+    public void shouldBeAbleToEnableElementResponseFields() {
+        Session.capabilities.put(CAP_ELEMENT_RESPONSE_FIELDS, "a,b");
+
+        Assert.assertEquals(true, ElementResponseFields.isEnabled());
     }
 }

--- a/app/src/test/java/io/appium/uiautomator2/model/settings/KeyInjectionDelayTests.java
+++ b/app/src/test/java/io/appium/uiautomator2/model/settings/KeyInjectionDelayTests.java
@@ -46,6 +46,7 @@ public class KeyInjectionDelayTests {
         PowerMockito.mockStatic(Configurator.class);
         when(Configurator.getInstance()).thenReturn(configurator);
         when(configurator.setKeyInjectionDelay(anyLong())).thenReturn(configurator);
+        when(configurator.getKeyInjectionDelay()).thenReturn((long) 123);
     }
 
     @Test
@@ -62,5 +63,6 @@ public class KeyInjectionDelayTests {
     public void shouldBeAbleToSetIdleTimeout() {
         keyInjectionDelay.updateSetting(123);
         verify(configurator).setKeyInjectionDelay(123);
+        Assert.assertEquals(123, KeyInjectionDelay.getTime());
     }
 }

--- a/app/src/test/java/io/appium/uiautomator2/model/settings/ScrollAcknowledgmentTimeoutTests.java
+++ b/app/src/test/java/io/appium/uiautomator2/model/settings/ScrollAcknowledgmentTimeoutTests.java
@@ -46,6 +46,7 @@ public class ScrollAcknowledgmentTimeoutTests {
         PowerMockito.mockStatic(Configurator.class);
         when(Configurator.getInstance()).thenReturn(configurator);
         when(configurator.setScrollAcknowledgmentTimeout(anyLong())).thenReturn(configurator);
+        when(configurator.getScrollAcknowledgmentTimeout()).thenReturn((long) 123);
     }
 
     @Test
@@ -62,5 +63,6 @@ public class ScrollAcknowledgmentTimeoutTests {
     public void shouldBeAbleToSetIdleTimeout() {
         scrollAcknowledgmentTimeout.updateSetting(123);
         verify(configurator).setScrollAcknowledgmentTimeout(123);
+        Assert.assertEquals(123, ScrollAcknowledgmentTimeout.getTime());
     }
 }

--- a/app/src/test/java/io/appium/uiautomator2/model/settings/ShouldUseCompactResponsesTest.java
+++ b/app/src/test/java/io/appium/uiautomator2/model/settings/ShouldUseCompactResponsesTest.java
@@ -20,6 +20,10 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
+import io.appium.uiautomator2.model.Session;
+
+import static io.appium.uiautomator2.model.Session.CAP_SHOULD_USE_COMPACT_RESPONSES;
+
 public class ShouldUseCompactResponsesTest {
 
     private ShouldUseCompactResponses shouldUseCompactResponses;
@@ -37,5 +41,19 @@ public class ShouldUseCompactResponsesTest {
     @Test
     public void shouldReturnValidSettingName() {
         Assert.assertEquals("shouldUseCompactResponses", shouldUseCompactResponses.getSettingName());
+    }
+
+    @Test
+    public void shouldBeAbleToEnableShouldUseCompactResponses() {
+        Session.capabilities.put(CAP_SHOULD_USE_COMPACT_RESPONSES, "true");
+
+        Assert.assertEquals(true, ShouldUseCompactResponses.isEnabled());
+    }
+
+    @Test
+    public void shouldBeAbleToDisableShouldUseCompactResponses() {
+        Session.capabilities.put(CAP_SHOULD_USE_COMPACT_RESPONSES, "false");
+
+        Assert.assertEquals(false, ShouldUseCompactResponses.isEnabled());
     }
 }

--- a/app/src/test/java/io/appium/uiautomator2/model/settings/WaitForIdleTimeoutTests.java
+++ b/app/src/test/java/io/appium/uiautomator2/model/settings/WaitForIdleTimeoutTests.java
@@ -28,7 +28,6 @@ import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
 import static org.mockito.Matchers.anyLong;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -47,6 +46,7 @@ public class WaitForIdleTimeoutTests {
         PowerMockito.mockStatic(Configurator.class);
         when(Configurator.getInstance()).thenReturn(configurator);
         when(configurator.setWaitForIdleTimeout(anyLong())).thenReturn(configurator);
+        when(configurator.getWaitForIdleTimeout()).thenReturn((long) 123);
     }
 
     @Test
@@ -63,5 +63,6 @@ public class WaitForIdleTimeoutTests {
     public void shouldBeAbleToSetIdleTimeout() {
         waitForIdeTimeout.updateSetting(123);
         verify(configurator).setWaitForIdleTimeout(123);
+        Assert.assertEquals(123, WaitForIdleTimeout.getTime());
     }
 }

--- a/app/src/test/java/io/appium/uiautomator2/model/settings/WaitForSelectorTimeoutTests.java
+++ b/app/src/test/java/io/appium/uiautomator2/model/settings/WaitForSelectorTimeoutTests.java
@@ -46,6 +46,8 @@ public class WaitForSelectorTimeoutTests {
         PowerMockito.mockStatic(Configurator.class);
         when(Configurator.getInstance()).thenReturn(configurator);
         when(configurator.setWaitForSelectorTimeout(anyLong())).thenReturn(configurator);
+        when(configurator.getWaitForSelectorTimeout()).thenReturn((long) 123);
+
     }
 
     @Test
@@ -62,5 +64,6 @@ public class WaitForSelectorTimeoutTests {
     public void shouldBeAbleToSetIdleTimeout() {
         waitForSelectorTimeout.updateSetting(123);
         verify(configurator).setWaitForSelectorTimeout(123);
+        Assert.assertEquals(123, WaitForSelectorTimeout.getTime());
     }
 }


### PR DESCRIPTION
After finishing this PR, we can get settings reverting https://github.com/appium/appium-uiautomator2-driver/pull/158 


```ruby
[3] pry(#<AppiumLibCoreTest::Android::DeviceTest>)> @@driver.get_settings
=> {"actionAcknowledgmentTimeout"=>3000,
 "allowInvisibleElements"=>false,
 "ignoreUnimportantViews"=>false,
 "elementResponseAttributes"=>false,
 "enableNotificationListener"=>true,
 "keyInjectionDelay"=>0,
 "scrollAcknowledgmentTimeout"=>200,
 "shouldUseCompactResponses"=>true,
 "waitForIdleTimeout"=>10000,
 "waitForSelectorTimeout"=>10000}
[4] pry(#<AppiumLibCoreTest::Android::DeviceTest>)> @@driver.update_settings('ignoreUnimportantViews' => true)
=> true
[5] pry(#<AppiumLibCoreTest::Android::DeviceTest>)> @@driver.get_settings
=> {"actionAcknowledgmentTimeout"=>3000,
 "allowInvisibleElements"=>false,
 "ignoreUnimportantViews"=>true,
 "elementResponseAttributes"=>false,
 "enableNotificationListener"=>true,
 "keyInjectionDelay"=>0,
 "scrollAcknowledgmentTimeout"=>200,
 "shouldUseCompactResponses"=>true,
 "waitForIdleTimeout"=>10000,
 "waitForSelectorTimeout"=>10000}
```

## TODO
- [x] implement other `no settings` settings and make numbers to integer
- [x] implement test cases
- [x] clean up