### PR TITLE
Rename elementResponseFields to elementResponseAttributes

### DIFF
--- a/app/src/main/java/io/appium/uiautomator2/handler/UpdateSettings.java
+++ b/app/src/main/java/io/appium/uiautomator2/handler/UpdateSettings.java
@@ -11,7 +11,7 @@ import io.appium.uiautomator2.http.IHttpRequest;
 import io.appium.uiautomator2.model.Session;
 import io.appium.uiautomator2.model.settings.ActionAcknowledgmentTimeout;
 import io.appium.uiautomator2.model.settings.AllowInvisibleElements;
-import io.appium.uiautomator2.model.settings.ElementResponseFields;
+import io.appium.uiautomator2.model.settings.ElementResponseAttributes;
 import io.appium.uiautomator2.model.settings.EnableNotificationListener;
 import io.appium.uiautomator2.model.settings.CompressedLayoutHierarchy;
 import io.appium.uiautomator2.model.settings.ISetting;
@@ -35,7 +35,7 @@ public class UpdateSettings extends SafeRequestHandler {
             put(KeyInjectionDelay.SETTING_NAME, KeyInjectionDelay.class);
             put(ActionAcknowledgmentTimeout.SETTING_NAME, ActionAcknowledgmentTimeout.class);
             put(ScrollAcknowledgmentTimeout.SETTING_NAME, ScrollAcknowledgmentTimeout.class);
-            put(ElementResponseFields.SETTING_NAME, ElementResponseFields.class);
+            put(ElementResponseAttributes.SETTING_NAME, ElementResponseAttributes.class);
             put(ShouldUseCompactResponses.SETTING_NAME, ShouldUseCompactResponses.class);
         }
     };

--- a/app/src/main/java/io/appium/uiautomator2/model/Session.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/Session.java
@@ -11,7 +11,7 @@ import java.util.concurrent.ConcurrentMap;
 public class Session {
     public static final String SEND_KEYS_TO_ELEMENT = "sendKeysToElement";
     public static final String CAP_SHOULD_USE_COMPACT_RESPONSES = "shouldUseCompactResponses";
-    public static final String CAP_ELEMENT_RESPONSE_FIELDS = "elementResponseFields";
+    public static final String CAP_ELEMENT_RESPONSE_ATTRIBUTES = "elementResponseAttributes";
     private String sessionId;
     private ConcurrentMap<String, JSONObject> commandConfiguration;
     private KnownElements knownElements;
@@ -39,9 +39,9 @@ public class Session {
         return shouldUseCompactResponses;
     }
 
-    public static String[] getElementResponseFields() {
-        if (Session.capabilities.containsKey(CAP_ELEMENT_RESPONSE_FIELDS)) {
-            return Session.capabilities.get(CAP_ELEMENT_RESPONSE_FIELDS).toString().split(",");
+    public static String[] getElementResponseAttributes() {
+        if (Session.capabilities.containsKey(CAP_ELEMENT_RESPONSE_ATTRIBUTES)) {
+            return Session.capabilities.get(CAP_ELEMENT_RESPONSE_ATTRIBUTES).toString().split(",");
         }
         return new String[] { "name", "text" };
     }

--- a/app/src/main/java/io/appium/uiautomator2/model/settings/ElementResponseAttributes.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/settings/ElementResponseAttributes.java
@@ -18,11 +18,11 @@ package io.appium.uiautomator2.model.settings;
 
 import io.appium.uiautomator2.utils.Logger;
 
-public class ElementResponseFields extends AbstractSetting<String> {
+public class ElementResponseAttributes extends AbstractSetting<String> {
 
-    public static final String SETTING_NAME = "elementResponseFields";
+    public static final String SETTING_NAME = "elementResponseAttributes";
 
-    public ElementResponseFields() {
+    public ElementResponseAttributes() {
         super(String.class);
     }
 
@@ -32,7 +32,7 @@ public class ElementResponseFields extends AbstractSetting<String> {
     }
 
     @Override
-    protected void apply(String elementResponseFields) {
+    protected void apply(String elementResponseAttributes) {
         Logger.debug("Dummy setting. Maintained in Session.capabilities.");
     }
 

--- a/app/src/main/java/io/appium/uiautomator2/utils/ElementHelpers.java
+++ b/app/src/main/java/io/appium/uiautomator2/utils/ElementHelpers.java
@@ -95,7 +95,7 @@ public abstract class ElementHelpers {
         if (Session.shouldUseCompactResponses()) {
             return jsonObject;
         }
-        for (String field : Session.getElementResponseFields()) {
+        for (String field : Session.getElementResponseAttributes()) {
             try {
                 if (field.equals("name")) {
                     putNullable(jsonObject, field, el.getContentDesc());

--- a/app/src/test/java/io/appium/uiautomator2/handler/UpdateSettingsTests.java
+++ b/app/src/test/java/io/appium/uiautomator2/handler/UpdateSettingsTests.java
@@ -36,7 +36,7 @@ import io.appium.uiautomator2.model.settings.AbstractSetting;
 import io.appium.uiautomator2.model.settings.ActionAcknowledgmentTimeout;
 import io.appium.uiautomator2.model.settings.AllowInvisibleElements;
 import io.appium.uiautomator2.model.settings.CompressedLayoutHierarchy;
-import io.appium.uiautomator2.model.settings.ElementResponseFields;
+import io.appium.uiautomator2.model.settings.ElementResponseAttributes;
 import io.appium.uiautomator2.model.settings.EnableNotificationListener;
 import io.appium.uiautomator2.model.settings.KeyInjectionDelay;
 import io.appium.uiautomator2.model.settings.ScrollAcknowledgmentTimeout;
@@ -123,8 +123,8 @@ public class UpdateSettingsTests {
     }
 
     @Test
-    public void shouldBeAbleToReturnElementResponseFieldsSetting() throws InstantiationException, IllegalAccessException {
-        verifySettingIsAvailable(ElementResponseFields.SETTING_NAME, ElementResponseFields.class);
+    public void shouldBeAbleToReturnElementResponseAttributesSetting() throws InstantiationException, IllegalAccessException {
+        verifySettingIsAvailable(ElementResponseAttributes.SETTING_NAME, ElementResponseAttributes.class);
     }
 
     @Test

--- a/app/src/test/java/io/appium/uiautomator2/model/settings/ElementResponseAttributesTest.java
+++ b/app/src/test/java/io/appium/uiautomator2/model/settings/ElementResponseAttributesTest.java
@@ -20,22 +20,22 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-public class ElementResponseFieldsTest {
+public class ElementResponseAttributesTest {
 
-    private ElementResponseFields elementResponseFields;
+    private ElementResponseAttributes elementResponseAttributes;
 
     @Before
     public void setup() {
-        elementResponseFields = new ElementResponseFields();
+        elementResponseAttributes = new ElementResponseAttributes();
     }
 
     @Test
     public void shouldBeString() {
-        Assert.assertEquals(String.class, elementResponseFields.getValueType());
+        Assert.assertEquals(String.class, elementResponseAttributes.getValueType());
     }
 
     @Test
     public void shouldReturnValidSettingName() {
-        Assert.assertEquals("elementResponseFields", elementResponseFields.getSettingName());
+        Assert.assertEquals("elementResponseAttributes", elementResponseAttributes.getSettingName());
     }
 }


### PR DESCRIPTION
Fix https://github.com/appium/appium-uiautomator2-server/pull/128 to use same capability name as used in https://github.com/appium/WebDriverAgent/pull/69.