### PR TITLE
Shutdown server on ACTION_POWER_DISCONNECT

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,12 +52,21 @@ before_script:
 
   - |
     if [ ${START_EMU} = "1" ]; then
+      echo y | android update sdk --no-ui -t platform-tools
+      echo y | android update sdk --no-ui -t tools
+      echo y | android update sdk --no-ui -t android-22
+      echo y | android update sdk --no-ui -t android-24
+      adb version
       echo no | android create avd --force -n ${ANDROID_EMU_NAME} -t ${ANDROID_EMU_TARGET} --abi ${ANDROID_EMU_ABI} --sdcard 200M
-      emulator -avd ${ANDROID_EMU_NAME} -no-audio -no-window &
-    fi
+      emulator -avd ${ANDROID_EMU_NAME} -no-window &
 
-  # make sure emulator started
-  - $(npm bin)/android-emu-travis-post
+      # make sure emulator started
+      $(npm bin)/android-emu-travis-post
+
+      # get root
+      adb root
+      adb devices
+    fi
 script:
   - |
     if [ "$TEST" == "unit" ]; then

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -95,14 +95,17 @@ dependencies {
 task installAUT(type: Exec) {
     group = 'test'
     description = 'Install app under test'
-    def adb = android.getAdbExe().toString()
-    def apk = file('../node_modules/android-apidemos/bin/ApiDemos-debug.apk')
-    commandLine "$adb install -rg $apk".split(' ')
-    standardOutput = new ByteArrayOutputStream()
-    ext.output = {
-        return standardOutput.toString()
+    doFirst {
+        println("Install AUT")
+        def adb = android.getAdbExecutable().toString()
+        def apk = file('../node_modules/android-apidemos/bin/ApiDemos-debug.apk')
+        def sdkVersion = "$adb shell getprop ro.build.version.sdk".execute().text.trim()
+        println "Device SDK version:" + sdkVersion
+        /* This seems weird but it is what it is: https://github.com/wix/detox/issues/274 */
+        def command = sdkVersion.toInteger() < 24 ? "$adb install -rg $apk" : "$adb install -r -g $apk"
+        println "Execute command:" + command
+        commandLine command.split(" ")
     }
-    println ext.output.toString()
 }
 
 afterEvaluate {

--- a/app/src/androidTestE2eTest/java/io/appium/uiautomator2/unittest/test/Config.java
+++ b/app/src/androidTestE2eTest/java/io/appium/uiautomator2/unittest/test/Config.java
@@ -18,6 +18,7 @@ package io.appium.uiautomator2.unittest.test;
 import io.appium.uiautomator2.server.ServerConfig;
 
 public class Config {
+    public static final Long NETTY_STATUS_TIMEOUT = 32_000L;
     public static final Long EXPLICIT_TIMEOUT = 16_000L;
     public static final Long IMPLICIT_TIMEOUT = 8_000L;
     public static final Long APP_LAUNCH_TIMEOUT = 32_000L;

--- a/app/src/androidTestE2eTest/java/io/appium/uiautomator2/unittest/test/DeviceCommandsTest.java
+++ b/app/src/androidTestE2eTest/java/io/appium/uiautomator2/unittest/test/DeviceCommandsTest.java
@@ -17,6 +17,7 @@ package io.appium.uiautomator2.unittest.test;
 
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
+import android.support.test.uiautomator.UiDevice;
 import android.util.Base64;
 
 import org.json.JSONArray;
@@ -24,18 +25,25 @@ import org.json.JSONException;
 import org.json.JSONObject;
 import org.junit.Test;
 
+import java.io.IOException;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import io.appium.uiautomator2.model.By;
 import io.appium.uiautomator2.model.internal.CustomUiDevice;
 import io.appium.uiautomator2.server.WDStatus;
 import io.appium.uiautomator2.unittest.test.internal.BaseTest;
+import io.appium.uiautomator2.unittest.test.internal.NettyStatus;
 import io.appium.uiautomator2.unittest.test.internal.Response;
+import io.appium.uiautomator2.unittest.test.internal.RootRequired;
 import io.appium.uiautomator2.unittest.test.internal.SkipHeadlessDevices;
 import io.appium.uiautomator2.utils.Device;
 
+import static android.support.test.InstrumentationRegistry.getInstrumentation;
 import static io.appium.uiautomator2.model.settings.Settings.ENABLE_NOTIFICATION_LISTENER;
+import static io.appium.uiautomator2.unittest.test.internal.Client.waitForNettyStatus;
 import static io.appium.uiautomator2.unittest.test.internal.TestUtils.getJsonObjectCountInJsonArray;
 import static io.appium.uiautomator2.unittest.test.internal.TestUtils.waitForElement;
 import static io.appium.uiautomator2.unittest.test.internal.TestUtils.waitForElementInvisibility;
@@ -43,8 +51,7 @@ import static io.appium.uiautomator2.unittest.test.internal.commands.DeviceComma
 import static io.appium.uiautomator2.unittest.test.internal.commands.DeviceCommands.findElements;
 import static io.appium.uiautomator2.unittest.test.internal.commands.DeviceCommands.getDeviceSize;
 import static io.appium.uiautomator2.unittest.test.internal.commands.DeviceCommands.getRotation;
-import static io.appium.uiautomator2.unittest.test.internal.commands.DeviceCommands
-        .getScreenOrientation;
+import static io.appium.uiautomator2.unittest.test.internal.commands.DeviceCommands.getScreenOrientation;
 import static io.appium.uiautomator2.unittest.test.internal.commands.DeviceCommands.getSettings;
 import static io.appium.uiautomator2.unittest.test.internal.commands.DeviceCommands.rotateScreen;
 import static io.appium.uiautomator2.unittest.test.internal.commands.DeviceCommands.screenshot;
@@ -446,29 +453,27 @@ public class DeviceCommandsTest extends BaseTest {
     public void shouldBeAbleToUpdateSettings() throws JSONException {
         Response response = getSettings();
         JSONObject defaultSettings = response.getValue();
+        Map<String, Object> settings = new HashMap<>();
+        settings.put("actionAcknowledgmentTimeout", 123);
+        settings.put("allowInvisibleElements", true);
+        settings.put("ignoreUnimportantViews", true);
+        settings.put("elementResponseAttributes", "text");
+        settings.put("enableNotificationListener", true);
+        settings.put("keyInjectionDelay", 10);
+        settings.put("scrollAcknowledgmentTimeout", 300);
+        settings.put("shouldUseCompactResponses", false);
+        settings.put("waitForIdleTimeout", 50001);
+        settings.put("waitForSelectorTimeout", 10);
+        settings.put("shutdownOnPowerDisconnect", false);
         try {
-            updateSetting("actionAcknowledgmentTimeout", 123);
-            updateSetting("allowInvisibleElements", true);
-            updateSetting("ignoreUnimportantViews", true);
-            updateSetting("elementResponseAttributes", "text");
-            updateSetting("enableNotificationListener", true);
-            updateSetting("keyInjectionDelay", 10);
-            updateSetting("scrollAcknowledgmentTimeout", 300);
-            updateSetting("shouldUseCompactResponses", false);
-            updateSetting("waitForIdleTimeout", 50001);
-            updateSetting("waitForSelectorTimeout", 10);
+            for (Map.Entry<String, Object> entry : settings.entrySet()) {
+                updateSetting(entry.getKey(), entry.getValue());
+            }
             response = getSettings();
             JSONObject jsonObject = response.getValue();
-            assertEquals(123, jsonObject.get("actionAcknowledgmentTimeout"));
-            assertEquals(true, jsonObject.get("allowInvisibleElements"));
-            assertEquals(true, jsonObject.get("ignoreUnimportantViews"));
-            assertEquals("text", jsonObject.get("elementResponseAttributes"));
-            assertEquals(true, jsonObject.get("enableNotificationListener"));
-            assertEquals(10, jsonObject.get("keyInjectionDelay"));
-            assertEquals(300, jsonObject.get("scrollAcknowledgmentTimeout"));
-            assertEquals(false, jsonObject.get("shouldUseCompactResponses"));
-            assertEquals(50001, jsonObject.get("waitForIdleTimeout"));
-            assertEquals(10, jsonObject.get("waitForSelectorTimeout"));
+            for (Map.Entry<String, Object> entry : settings.entrySet()) {
+                assertEquals(entry.getValue(), jsonObject.get(entry.getKey()));
+            }
         } finally {
             updateSettings(defaultSettings);
         }
@@ -552,5 +557,21 @@ public class DeviceCommandsTest extends BaseTest {
                         ".scrollIntoView(new UiSelector().text(\"Lorem ipsum dolor sit amet.\"))");
         Response response = findElement(androidUiAutomator);
         assertTrue(androidUiAutomator + " should be found", response.isSuccessful());
+    }
+
+    @Test
+    @RootRequired
+    public void shouldShutdownServerOnPowerDisconnect() throws IOException, JSONException,
+            InterruptedException {
+        try {
+            UiDevice.getInstance(getInstrumentation()).executeShellCommand(
+                    "su 0 am broadcast -a android.intent.action.ACTION_POWER_DISCONNECTED " +
+                            "io.appium.uiautomator2.e2etest &");
+            waitForNettyStatus(NettyStatus.OFFLINE);
+            assertTrue(serverInstrumentation.isStopServer());
+        } finally {
+            serverInstrumentation = null;
+            startServer();
+        }
     }
 }

--- a/app/src/androidTestE2eTest/java/io/appium/uiautomator2/unittest/test/DeviceCommandsTest.java
+++ b/app/src/androidTestE2eTest/java/io/appium/uiautomator2/unittest/test/DeviceCommandsTest.java
@@ -568,7 +568,7 @@ public class DeviceCommandsTest extends BaseTest {
                     "su 0 am broadcast -a android.intent.action.ACTION_POWER_DISCONNECTED " +
                             "io.appium.uiautomator2.e2etest &");
             waitForNettyStatus(NettyStatus.OFFLINE);
-            assertTrue(serverInstrumentation.isStopServer());
+            assertTrue(serverInstrumentation.isServerStopped());
         } finally {
             serverInstrumentation = null;
             startServer();

--- a/app/src/androidTestE2eTest/java/io/appium/uiautomator2/unittest/test/internal/BaseTest.java
+++ b/app/src/androidTestE2eTest/java/io/appium/uiautomator2/unittest/test/internal/BaseTest.java
@@ -33,7 +33,6 @@ import java.io.IOException;
 
 import io.appium.uiautomator2.model.By;
 import io.appium.uiautomator2.model.settings.Settings;
-import io.appium.uiautomator2.server.ServerConfig;
 import io.appium.uiautomator2.server.ServerInstrumentation;
 import io.appium.uiautomator2.unittest.test.Config;
 import io.netty.channel.ConnectTimeoutException;
@@ -53,9 +52,9 @@ import static org.junit.Assert.assertNotNull;
 @FixMethodOrder(MethodSorters.NAME_ASCENDING)
 @RunWith(AndroidJUnit4.class)
 public abstract class BaseTest {
-
-    private static ServerInstrumentation serverInstrumentation;
+    protected static ServerInstrumentation serverInstrumentation;
     private static Context ctx;
+
     @Rule
     public TestWatcher watcher = new TestWatcher();
 
@@ -63,15 +62,14 @@ public abstract class BaseTest {
      * start io.appium.uiautomator2.server and launch the application main activity
      */
     @BeforeClass
-    public static void beforeStartServer() throws InterruptedException,
+    public static void startServer() throws InterruptedException,
             JSONException, IOException {
         if (serverInstrumentation != null) {
             return;
         }
         assertNotNull(getUiDevice());
         ctx = InstrumentationRegistry.getInstrumentation().getContext();
-        serverInstrumentation = ServerInstrumentation.getInstance(ctx, ServerConfig
-                .getServerPort());
+        serverInstrumentation = ServerInstrumentation.getInstance();
         Logger.info("Starting Server");
         serverInstrumentation.startServer();
         Client.waitForNettyStatus(NettyStatus.ONLINE);

--- a/app/src/androidTestE2eTest/java/io/appium/uiautomator2/unittest/test/internal/Client.java
+++ b/app/src/androidTestE2eTest/java/io/appium/uiautomator2/unittest/test/internal/Client.java
@@ -15,6 +15,8 @@
  */
 package io.appium.uiautomator2.unittest.test.internal;
 
+import android.os.SystemClock;
+
 import com.squareup.okhttp.MediaType;
 import com.squareup.okhttp.OkHttpClient;
 import com.squareup.okhttp.Request;
@@ -82,7 +84,8 @@ public abstract class Client {
             if (actualStatus.equals(status)) {
                 return;
             }
-        } while (elapsedRealtime() - start < Config.EXPLICIT_TIMEOUT);
+            SystemClock.sleep(500);
+        } while (elapsedRealtime() - start < Config.NETTY_STATUS_TIMEOUT);
         throw new TimeoutException(String.format("netty status. Expected:%s; Actual:%s;",
                 status, actualStatus));
     }

--- a/app/src/androidTestE2eTest/java/io/appium/uiautomator2/unittest/test/internal/RootRequired.java
+++ b/app/src/androidTestE2eTest/java/io/appium/uiautomator2/unittest/test/internal/RootRequired.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package io.appium.uiautomator2.unittest.test.internal;
 
 import java.lang.annotation.ElementType;
@@ -22,5 +23,5 @@ import java.lang.annotation.Target;
 
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)
-public @interface SkipHeadlessDevices {
+public @interface RootRequired {
 }

--- a/app/src/androidTestServer/java/io/appium/uiautomator2/server/test/AppiumUiAutomator2Server.java
+++ b/app/src/androidTestServer/java/io/appium/uiautomator2/server/test/AppiumUiAutomator2Server.java
@@ -1,23 +1,18 @@
 package io.appium.uiautomator2.server.test;
 
-import android.content.Context;
 import android.os.SystemClock;
-import android.support.test.InstrumentationRegistry;
 import android.support.test.runner.AndroidJUnit4;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import io.appium.uiautomator2.common.exceptions.SessionRemovedException;
-import io.appium.uiautomator2.server.ServerConfig;
 import io.appium.uiautomator2.server.ServerInstrumentation;
 import io.appium.uiautomator2.utils.Logger;
 
 @RunWith(AndroidJUnit4.class)
 public class AppiumUiAutomator2Server {
     private static ServerInstrumentation serverInstrumentation;
-    private Context ctx;
-
 
     /**
      * Starts the server on the device
@@ -25,15 +20,14 @@ public class AppiumUiAutomator2Server {
     @Test
     public void startServer() throws InterruptedException {
         if (serverInstrumentation == null) {
-            ctx = InstrumentationRegistry.getInstrumentation().getContext();
-            serverInstrumentation = ServerInstrumentation.getInstance(ctx, ServerConfig.getServerPort());
+            serverInstrumentation = ServerInstrumentation.getInstance();
             Logger.info("[AppiumUiAutomator2Server]", " Starting Server");
             try {
                 while (!serverInstrumentation.isStopServer()) {
                     SystemClock.sleep(1000);
                     serverInstrumentation.startServer();
                 }
-            }catch (SessionRemovedException e){
+            } catch (SessionRemovedException e) {
                 //Ignoring SessionRemovedException
             }
         }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,14 +1,18 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
           package="io.appium.uiautomator2.test">
 
-    <application android:allowBackup="true">
-
-    </application>
-
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.WAKE_LOCK" />
     <uses-permission android:name="android.permission.CHANGE_WIFI_STATE" />
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
+
+    <application android:allowBackup="true">
+        <receiver android:name="io.appium.uiautomator2.server.ServerInstrumentation$PowerConnectionReceiver">
+            <intent-filter>
+                <action android:name="android.intent.action.ACTION_POWER_DISCONNECTED" />
+            </intent-filter>
+        </receiver>
+    </application>
 
 </manifest>

--- a/app/src/main/java/io/appium/uiautomator2/handler/DeleteSession.java
+++ b/app/src/main/java/io/appium/uiautomator2/handler/DeleteSession.java
@@ -1,12 +1,9 @@
 package io.appium.uiautomator2.handler;
 
-import android.support.test.InstrumentationRegistry;
-
 import io.appium.uiautomator2.handler.request.SafeRequestHandler;
 import io.appium.uiautomator2.http.AppiumResponse;
 import io.appium.uiautomator2.http.IHttpRequest;
 import io.appium.uiautomator2.model.NotificationListener;
-import io.appium.uiautomator2.server.ServerConfig;
 import io.appium.uiautomator2.server.ServerInstrumentation;
 import io.appium.uiautomator2.server.WDStatus;
 import io.appium.uiautomator2.utils.Logger;
@@ -22,8 +19,7 @@ public class DeleteSession extends SafeRequestHandler {
         Logger.info("Delete session command");
         String sessionId = getSessionId(request);
         NotificationListener.getInstance().stop();
-        ServerInstrumentation.getInstance(InstrumentationRegistry.getInstrumentation().getContext(),
-                ServerConfig.getServerPort()).stopServer();
+        ServerInstrumentation.getInstance().stopServer();
         return new AppiumResponse(sessionId, WDStatus.SUCCESS, "Session deleted");
     }
 }

--- a/app/src/main/java/io/appium/uiautomator2/handler/UpdateSettings.java
+++ b/app/src/main/java/io/appium/uiautomator2/handler/UpdateSettings.java
@@ -28,6 +28,7 @@ public class UpdateSettings extends SafeRequestHandler {
                 String settingName = entry.getKey();
                 Object settingValue = entry.getValue();
                 ISetting setting = getSetting(settingName);
+                //noinspection unchecked
                 setting.update(settingValue);
                 Session.capabilities.put(settingName, settingValue);
             }
@@ -39,8 +40,8 @@ public class UpdateSettings extends SafeRequestHandler {
         return new AppiumResponse(getSessionId(request), WDStatus.SUCCESS, true);
     }
 
-    public ISetting getSetting(String settingName) throws UnsupportedSettingException, IllegalAccessException, InstantiationException {
-        for (Settings value : Settings.values()) {
+    public ISetting getSetting(String settingName) throws UnsupportedSettingException {
+        for (final Settings value : Settings.values()) {
             if (value.toString().equals(settingName)) {
                 return value.getSetting();
             }

--- a/app/src/main/java/io/appium/uiautomator2/model/settings/AbstractSetting.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/settings/AbstractSetting.java
@@ -41,7 +41,7 @@ public abstract class AbstractSetting<T> implements ISetting {
 
     public String getName() {
         return settingName;
-    };
+    }
 
     public Class<T> getValueType() {
         return valueType;

--- a/app/src/main/java/io/appium/uiautomator2/model/settings/CompressedLayoutHierarchy.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/settings/CompressedLayoutHierarchy.java
@@ -19,10 +19,9 @@ package io.appium.uiautomator2.model.settings;
 import io.appium.uiautomator2.utils.Device;
 
 public class CompressedLayoutHierarchy extends AbstractSetting<Boolean> {
-
     private static final String SETTING_NAME = "ignoreUnimportantViews";
 
-    public static boolean compressedLayoutHierarchy = false;
+    private boolean compressedLayoutHierarchy = false;
 
     public CompressedLayoutHierarchy() {
         super(Boolean.class, SETTING_NAME);

--- a/app/src/main/java/io/appium/uiautomator2/model/settings/Settings.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/settings/Settings.java
@@ -1,3 +1,19 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.appium.uiautomator2.model.settings;
 
 public enum Settings {
@@ -10,9 +26,10 @@ public enum Settings {
     SCROLL_ACKNOWLEDGMENT_TIMEOUT(new ScrollAcknowledgmentTimeout()),
     SHOULD_USE_COMPACT_RESPONSES(new ShouldUseCompactResponses()),
     WAIT_FOR_IDLE_TIMEOUT(new WaitForIdleTimeout()),
-    WAIT_FOR_SELECTOR_TIMEOUT(new WaitForSelectorTimeout());
+    WAIT_FOR_SELECTOR_TIMEOUT(new WaitForSelectorTimeout()),
+    SHUTDOWN_ON_POWER_DISCONNECT(new ShutdownOnPowerDisconnect());
 
-    private ISetting setting;
+    private final ISetting setting;
 
     Settings(ISetting setting) {
         this.setting = setting;

--- a/app/src/main/java/io/appium/uiautomator2/model/settings/ShutdownOnPowerDisconnect.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/settings/ShutdownOnPowerDisconnect.java
@@ -13,14 +13,25 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.appium.uiautomator2.unittest.test.internal;
 
-import java.lang.annotation.ElementType;
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
-import java.lang.annotation.Target;
+package io.appium.uiautomator2.model.settings;
 
-@Target(ElementType.METHOD)
-@Retention(RetentionPolicy.RUNTIME)
-public @interface SkipHeadlessDevices {
+public class ShutdownOnPowerDisconnect extends AbstractSetting<Boolean> {
+    private static final String SETTING_NAME = "shutdownOnPowerDisconnect";
+
+    private boolean value = true;
+
+    public ShutdownOnPowerDisconnect() {
+        super(Boolean.class, SETTING_NAME);
+    }
+
+    @Override
+    public Boolean getValue() {
+        return value;
+    }
+
+    @Override
+    protected void apply(Boolean value) {
+        this.value = value;
+    }
 }

--- a/app/src/main/java/io/appium/uiautomator2/server/ServerInstrumentation.java
+++ b/app/src/main/java/io/appium/uiautomator2/server/ServerInstrumentation.java
@@ -27,7 +27,7 @@ public class ServerInstrumentation {
     private HttpdThread serverThread;
     private PowerManager.WakeLock wakeLock;
     private final int serverPort;
-    private boolean isStopServer;
+    private boolean isServerStopped;
 
     public static class PowerConnectionReceiver extends BroadcastReceiver {
 
@@ -66,8 +66,8 @@ public class ServerInstrumentation {
         this.context = context;
     }
 
-    public boolean isStopServer(){
-        return isStopServer;
+    public boolean isServerStopped(){
+        return isServerStopped;
     }
 
     private boolean isValidPort(int port) {
@@ -102,7 +102,7 @@ public class ServerInstrumentation {
             return;
         }
 
-        if(serverThread == null && isStopServer){
+        if(serverThread == null && isServerStopped){
             throw new SessionRemovedException("Delete Session has been invoked");
         }
 
@@ -134,7 +134,7 @@ public class ServerInstrumentation {
         } catch (InterruptedException ignored) {
         }
         serverThread = null;
-        isStopServer = true;
+        isServerStopped = true;
     }
 
     private class HttpdThread extends Thread {

--- a/app/src/main/java/io/appium/uiautomator2/server/ServerInstrumentation.java
+++ b/app/src/main/java/io/appium/uiautomator2/server/ServerInstrumentation.java
@@ -39,16 +39,16 @@ public class ServerInstrumentation {
                 return;
             }
 
+            if (instance == null) {
+                Logger.debug("The server is already down - doing nothing.");
+                return;
+            }
+
             final ShutdownOnPowerDisconnect shutdownOnPowerDisconnect =
                     (ShutdownOnPowerDisconnect) Settings.SHUTDOWN_ON_POWER_DISCONNECT.getSetting();
             if (!shutdownOnPowerDisconnect.getValue()) {
                 Logger.debug(String.format("The value of `%s` setting is false - " +
                                 "ignoring broadcasting.", shutdownOnPowerDisconnect.getName()));
-                return;
-            }
-
-            if (getInstance().isStopServer()) {
-                Logger.debug("The server is already down - doing nothing.");
                 return;
             }
 

--- a/app/src/main/java/io/appium/uiautomator2/server/ServerInstrumentation.java
+++ b/app/src/main/java/io/appium/uiautomator2/server/ServerInstrumentation.java
@@ -1,42 +1,82 @@
 package io.appium.uiautomator2.server;
 
+import android.content.BroadcastReceiver;
 import android.content.Context;
+import android.content.Intent;
 import android.os.Looper;
 import android.os.PowerManager;
 import android.os.RemoteException;
-
 import io.appium.uiautomator2.common.exceptions.SessionRemovedException;
+import io.appium.uiautomator2.common.exceptions.UiAutomator2Exception;
+import io.appium.uiautomator2.model.settings.Settings;
+import io.appium.uiautomator2.model.settings.ShutdownOnPowerDisconnect;
 import io.appium.uiautomator2.utils.Logger;
 
+import static android.content.Intent.ACTION_POWER_DISCONNECTED;
+import static android.support.test.InstrumentationRegistry.getContext;
+import static io.appium.uiautomator2.server.ServerConfig.getServerPort;
 import static io.appium.uiautomator2.utils.Device.getUiDevice;
 
 public class ServerInstrumentation {
+    private static final int MIN_PORT = 1024;
+    private static final int MAX_PORT = 65535;
+
     private static ServerInstrumentation instance;
-    private static Context context;
+
+    private final Context context;
     private HttpdThread serverThread;
     private PowerManager.WakeLock wakeLock;
-    private int serverPort;
-    private  boolean isStopServer;
+    private final int serverPort;
+    private boolean isStopServer;
 
-    private ServerInstrumentation(int serverPort) {
-        this.serverPort = serverPort;
+    public static class PowerConnectionReceiver extends BroadcastReceiver {
 
-        if (!isValidPort(serverPort)) {
-            throw new RuntimeException(("Invalid port: " + serverPort));
+        @Override
+        public void onReceive(Context context, Intent intent) {
+            Logger.debug("Received broadcast action: " + intent.getAction());
+
+            if (!ACTION_POWER_DISCONNECTED.equalsIgnoreCase(intent.getAction())) {
+                return;
+            }
+
+            final ShutdownOnPowerDisconnect shutdownOnPowerDisconnect =
+                    (ShutdownOnPowerDisconnect) Settings.SHUTDOWN_ON_POWER_DISCONNECT.getSetting();
+            if (!shutdownOnPowerDisconnect.getValue()) {
+                Logger.debug(String.format("The value of `%s` setting is false - " +
+                                "ignoring broadcasting.", shutdownOnPowerDisconnect.getName()));
+                return;
+            }
+
+            if (getInstance().isStopServer()) {
+                Logger.debug("The server is already down - doing nothing.");
+                return;
+            }
+
+            Logger.info("The device was disconnected from power source. Shutting down the server.");
+            getInstance().stopServer();
         }
+    }
+
+    public ServerInstrumentation(Context context, int serverPort) {
+        if (!isValidPort(serverPort)) {
+            throw new UiAutomator2Exception(String.format(
+                    "The port is out of valid range [%s;%s]: %s", MIN_PORT, MAX_PORT, serverPort));
+        }
+        this.serverPort = serverPort;
+        this.context = context;
     }
 
     public boolean isStopServer(){
         return isStopServer;
     }
-    private static boolean isValidPort(int port) {
-        return port >= 1024 && port <= 65535;
+
+    private boolean isValidPort(int port) {
+        return port >= MIN_PORT && port <= MAX_PORT;
     }
 
-    public static synchronized ServerInstrumentation getInstance(Context activityContext, int serverPort) {
+    public static synchronized ServerInstrumentation getInstance() {
         if (instance == null) {
-            context = activityContext;
-            instance = new ServerInstrumentation(serverPort);
+            instance = new ServerInstrumentation(getContext(), getServerPort());
         }
         return instance;
     }
@@ -57,7 +97,7 @@ public class ServerInstrumentation {
     }
 
 
-    public void startServer() throws InterruptedException, SessionRemovedException {
+    public void startServer() throws SessionRemovedException {
         if (serverThread != null && serverThread.isAlive()) {
             return;
         }
@@ -71,7 +111,7 @@ public class ServerInstrumentation {
             stopServer();
         }
 
-        serverThread = new HttpdThread(this, this.serverPort);
+        serverThread = new HttpdThread(this.serverPort);
         serverThread.start();
         //client to wait for io.appium.uiautomator2.server to up
         Logger.info("io.appium.uiautomator2.server started:");
@@ -100,11 +140,9 @@ public class ServerInstrumentation {
     private class HttpdThread extends Thread {
 
         private final AndroidServer server;
-        private ServerInstrumentation instrumentation;
         private Looper looper;
 
-        public HttpdThread(ServerInstrumentation instrumentation, int serverPort) {
-            this.instrumentation = instrumentation;
+        public HttpdThread(int serverPort) {
             // Create the io.appium.uiautomator2.server but absolutely do not start it here
             server = new AndroidServer(serverPort);
         }

--- a/app/src/test/java/io/appium/uiautomator2/handler/UpdateSettingsTests.java
+++ b/app/src/test/java/io/appium/uiautomator2/handler/UpdateSettingsTests.java
@@ -20,7 +20,6 @@ import org.json.JSONException;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.Matchers;
 import org.mockito.Mock;
 import org.mockito.Spy;
 import org.powermock.modules.junit4.PowerMockRunner;
@@ -42,6 +41,7 @@ import io.appium.uiautomator2.model.settings.KeyInjectionDelay;
 import io.appium.uiautomator2.model.settings.ScrollAcknowledgmentTimeout;
 import io.appium.uiautomator2.model.settings.Settings;
 import io.appium.uiautomator2.model.settings.ShouldUseCompactResponses;
+import io.appium.uiautomator2.model.settings.ShutdownOnPowerDisconnect;
 import io.appium.uiautomator2.model.settings.WaitForIdleTimeout;
 import io.appium.uiautomator2.model.settings.WaitForSelectorTimeout;
 import io.appium.uiautomator2.server.WDStatus;
@@ -54,6 +54,7 @@ import static io.appium.uiautomator2.model.settings.Settings.ENABLE_NOTIFICATION
 import static io.appium.uiautomator2.model.settings.Settings.KEY_INJECTION_DELAY;
 import static io.appium.uiautomator2.model.settings.Settings.SCROLL_ACKNOWLEDGMENT_TIMEOUT;
 import static io.appium.uiautomator2.model.settings.Settings.SHOULD_USE_COMPACT_RESPONSES;
+import static io.appium.uiautomator2.model.settings.Settings.SHUTDOWN_ON_POWER_DISCONNECT;
 import static io.appium.uiautomator2.model.settings.Settings.WAIT_FOR_IDLE_TIMEOUT;
 import static io.appium.uiautomator2.model.settings.Settings.WAIT_FOR_SELECTOR_TIMEOUT;
 import static org.hamcrest.CoreMatchers.containsString;
@@ -68,7 +69,6 @@ import static org.mockito.Mockito.verify;
 
 @RunWith(PowerMockRunner.class)
 public class UpdateSettingsTests {
-
     private static final String SETTING_NAME = "my_setting";
     private static final String SETTING_VALUE = "my_value";
 
@@ -95,57 +95,62 @@ public class UpdateSettingsTests {
     }
 
     @Test
-    public void shouldBeAbleToReturnAllowInvisibleElementsSetting() throws InstantiationException, IllegalAccessException {
+    public void shouldBeAbleToReturnAllowInvisibleElementsSetting() {
         verifySettingIsAvailable(ALLOW_INVISIBLE_ELEMENTS, AllowInvisibleElements.class);
     }
 
     @Test
-    public void shouldBeAbleToReturnCompressedLayoutHierarchySetting() throws InstantiationException, IllegalAccessException {
+    public void shouldBeAbleToReturnCompressedLayoutHierarchySetting() {
         verifySettingIsAvailable(COMPRESSED_LAYOUT_HIERARCHY, CompressedLayoutHierarchy.class);
     }
 
     @Test
-    public void shouldBeAbleToReturnAllowNotificationListenerSetting() throws InstantiationException, IllegalAccessException {
+    public void shouldBeAbleToReturnAllowNotificationListenerSetting() {
         verifySettingIsAvailable(ENABLE_NOTIFICATION_LISTENER, EnableNotificationListener.class);
     }
 
     @Test
-    public void shouldBeAbleToReturnWaitForIdleTimeoutSetting() throws InstantiationException, IllegalAccessException {
+    public void shouldBeAbleToReturnWaitForIdleTimeoutSetting() {
         verifySettingIsAvailable(WAIT_FOR_IDLE_TIMEOUT, WaitForIdleTimeout.class);
     }
 
     @Test
-    public void shouldBeAbleToReturnWaitForSelectorTimeoutSetting() throws InstantiationException, IllegalAccessException {
+    public void shouldBeAbleToReturnWaitForSelectorTimeoutSetting() {
         verifySettingIsAvailable(WAIT_FOR_SELECTOR_TIMEOUT, WaitForSelectorTimeout.class);
     }
 
     @Test
-    public void shouldBeAbleToReturnActionAcknowledgmentTimeout() throws InstantiationException, IllegalAccessException {
+    public void shouldBeAbleToReturnActionAcknowledgmentTimeout() {
         verifySettingIsAvailable(ACTION_ACKNOWLEDGMENT_TIMEOUT, ActionAcknowledgmentTimeout.class);
     }
 
     @Test
-    public void shouldBeAbleToReturnKeyInjectionDelay() throws InstantiationException, IllegalAccessException {
+    public void shouldBeAbleToReturnKeyInjectionDelay() {
         verifySettingIsAvailable(KEY_INJECTION_DELAY, KeyInjectionDelay.class);
     }
 
     @Test
-    public void shouldBeAbleToReturnScrollAcknowledgmentTimeout() throws InstantiationException, IllegalAccessException {
+    public void shouldBeAbleToReturnScrollAcknowledgmentTimeout() {
         verifySettingIsAvailable(SCROLL_ACKNOWLEDGMENT_TIMEOUT, ScrollAcknowledgmentTimeout.class);
     }
 
     @Test
-    public void shouldBeAbleToReturnElementResponseAttributesSetting() throws InstantiationException, IllegalAccessException {
+    public void shouldBeAbleToReturnElementResponseAttributesSetting() {
         verifySettingIsAvailable(ELEMENT_RESPONSE_ATTRIBUTES, ElementResponseAttributes.class);
     }
 
     @Test
-    public void shouldBeAbleToReturnShouldUseCompactResponsesSetting() throws InstantiationException, IllegalAccessException {
+    public void shouldBeAbleToReturnShouldUseCompactResponsesSetting() {
         verifySettingIsAvailable(SHOULD_USE_COMPACT_RESPONSES, ShouldUseCompactResponses.class);
     }
 
+    @Test
+    public void shouldBeAbleToReturnShutdownOnPowerDisconnectSetting() {
+        verifySettingIsAvailable(SHUTDOWN_ON_POWER_DISCONNECT, ShutdownOnPowerDisconnect.class);
+    }
+
     @Test(expected=UnsupportedSettingException.class)
-    public void shouldThrowExceptionIfSettingIsNotSupported() throws InstantiationException, IllegalAccessException {
+    public void shouldThrowExceptionIfSettingIsNotSupported() {
         updateSettings.getSetting("unsupported_setting");
     }
 
@@ -160,13 +165,13 @@ public class UpdateSettingsTests {
 
     @Test
     public void shouldReturnResponseWithUnknownErrorStatusIfFailed() {
-        doThrow(new UiAutomator2Exception("error")).when(mySetting).update(Matchers.anyObject());
+        doThrow(new UiAutomator2Exception("error")).when(mySetting).update(any());
         AppiumResponse resp = updateSettings.safeHandle(req);
         assertEquals(WDStatus.UNKNOWN_ERROR.code(), resp.getStatus());
         assertThat(resp.getValue().toString(), containsString("UiAutomator2Exception: error"));
     }
 
-    private void verifySettingIsAvailable(Settings setting, Class<? extends AbstractSetting> clazz) throws InstantiationException, IllegalAccessException {
+    private void verifySettingIsAvailable(Settings setting, Class<? extends AbstractSetting> clazz) {
         assertThat(updateSettings.getSetting(setting.toString()), instanceOf(clazz));
     }
 }

--- a/app/src/test/java/io/appium/uiautomator2/model/settings/CompressedLayoutHierarchyTests.java
+++ b/app/src/test/java/io/appium/uiautomator2/model/settings/CompressedLayoutHierarchyTests.java
@@ -29,7 +29,6 @@ import org.powermock.modules.junit4.PowerMockRunner;
 
 import io.appium.uiautomator2.utils.Device;
 
-import static io.appium.uiautomator2.model.settings.Settings.COMPRESSED_LAYOUT_HIERARCHY;
 import static org.mockito.Matchers.anyBoolean;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.verify;
@@ -66,13 +65,13 @@ public class CompressedLayoutHierarchyTests {
     public void shouldBeAbleToEnableCompressedLayout() {
         compressedLayoutHierarchy.update(true);
         verify(uiDevice).setCompressedLayoutHeirarchy(true);
-        Assert.assertEquals(true, COMPRESSED_LAYOUT_HIERARCHY.getSetting().getValue());
+        Assert.assertEquals(true, compressedLayoutHierarchy.getValue());
     }
 
     @Test
     public void shouldBeAbleToDisableCompressedLayout() {
         compressedLayoutHierarchy.update(false);
         verify(uiDevice).setCompressedLayoutHeirarchy(false);
-        Assert.assertEquals(false, COMPRESSED_LAYOUT_HIERARCHY.getSetting().getValue());
+        Assert.assertEquals(false, compressedLayoutHierarchy.getValue());
     }
 }

--- a/app/src/test/java/io/appium/uiautomator2/model/settings/ShutdownOnPowerDisconnectTest.java
+++ b/app/src/test/java/io/appium/uiautomator2/model/settings/ShutdownOnPowerDisconnectTest.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.appium.uiautomator2.model.settings;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class ShutdownOnPowerDisconnectTest {
+    private ShutdownOnPowerDisconnect shutdownOnPowerDisconnect;
+
+    @Before
+    public void setUp() {
+        shutdownOnPowerDisconnect = new ShutdownOnPowerDisconnect();
+    }
+
+    @Test
+    public void shouldBeBoolean() {
+        Assert.assertEquals(Boolean.class, shutdownOnPowerDisconnect.getValueType());
+    }
+
+    @Test
+    public void shouldReturnValidSettingName() {
+        Assert.assertEquals("shutdownOnPowerDisconnect", shutdownOnPowerDisconnect.getName());
+    }
+
+    @Test
+    public void shouldBeTrueByDefault() {
+        assertTrue(shutdownOnPowerDisconnect.getValue());
+    }
+
+    @Test
+    public void shouldBeAbleToSetValue() {
+        shutdownOnPowerDisconnect.update(false);
+        assertFalse(shutdownOnPowerDisconnect.getValue());
+    }
+}

--- a/app/src/test/java/io/appium/uiautomator2/server/ServerInstrumentationTests.java
+++ b/app/src/test/java/io/appium/uiautomator2/server/ServerInstrumentationTests.java
@@ -25,6 +25,7 @@ import org.junit.runner.RunWith;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
+import org.powermock.reflect.Whitebox;
 
 import io.appium.uiautomator2.server.ServerInstrumentation.PowerConnectionReceiver;
 
@@ -54,6 +55,8 @@ public class ServerInstrumentationTests {
             serverInstrumentation = spy(new ServerInstrumentation(context, 1025));
 
             when(ServerInstrumentation.getInstance()).thenReturn(serverInstrumentation);
+            Whitebox.setInternalState(ServerInstrumentation.class, "instance",
+                    serverInstrumentation);
             doNothing().when(serverInstrumentation).stopServer();
             powerConnectionReceiver = new PowerConnectionReceiver();
         }
@@ -80,7 +83,8 @@ public class ServerInstrumentationTests {
 
         @Test
         public void shouldNOTShutdownServerIfAlreadyDown() {
-            doReturn(true).when(serverInstrumentation).isStopServer();
+            Whitebox.setInternalState(ServerInstrumentation.class, "instance",
+                    (ServerInstrumentation) null);
             powerConnectionReceiver.onReceive(context, intent);
             verify(serverInstrumentation, never()).stopServer();
         }

--- a/app/src/test/java/io/appium/uiautomator2/server/ServerInstrumentationTests.java
+++ b/app/src/test/java/io/appium/uiautomator2/server/ServerInstrumentationTests.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.appium.uiautomator2.server;
+
+import android.content.Intent;
+import android.test.mock.MockContext;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import io.appium.uiautomator2.server.ServerInstrumentation.PowerConnectionReceiver;
+
+import static io.appium.uiautomator2.model.settings.Settings.SHUTDOWN_ON_POWER_DISCONNECT;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class ServerInstrumentationTests {
+    private static final MockContext context = new MockContext();
+    private static ServerInstrumentation serverInstrumentation;
+
+    @SuppressWarnings("unchecked")
+    @RunWith(PowerMockRunner.class)
+    @PrepareForTest(ServerInstrumentation.class)
+    public static class PowerConnectionReceiverTests {
+        private final TestIntent intent = new TestIntent(Intent.ACTION_POWER_DISCONNECTED);
+        private PowerConnectionReceiver powerConnectionReceiver;
+
+        @Before
+        public void setUp() throws Exception {
+            PowerMockito.mockStatic(ServerInstrumentation.class);
+            SHUTDOWN_ON_POWER_DISCONNECT.getSetting().update(true);
+            serverInstrumentation = spy(new ServerInstrumentation(context, 1025));
+
+            when(ServerInstrumentation.getInstance()).thenReturn(serverInstrumentation);
+            doNothing().when(serverInstrumentation).stopServer();
+            powerConnectionReceiver = new PowerConnectionReceiver();
+        }
+
+        @Test
+        public void shouldShutdownServerOnPowerDisconnected() {
+            powerConnectionReceiver.onReceive(context, intent);
+            verify(serverInstrumentation).stopServer();
+        }
+
+        @Test
+        public void shouldSkipInvalidActions() {
+            powerConnectionReceiver.onReceive(context, new TestIntent(Intent.
+                    ACTION_POWER_CONNECTED));
+            verify(serverInstrumentation, never()).stopServer();
+        }
+
+        @Test
+        public void shouldNOTShutdownServerIfSettingValueIsFalse() {
+            SHUTDOWN_ON_POWER_DISCONNECT.getSetting().update(false);
+            powerConnectionReceiver.onReceive(context, intent);
+            verify(serverInstrumentation, never()).stopServer();
+        }
+
+        @Test
+        public void shouldNOTShutdownServerIfAlreadyDown() {
+            doReturn(true).when(serverInstrumentation).isStopServer();
+            powerConnectionReceiver.onReceive(context, intent);
+            verify(serverInstrumentation, never()).stopServer();
+        }
+    }
+
+    private static class TestIntent extends Intent {
+        private final String action;
+
+        public TestIntent(String action) {
+            this.action = action;
+        }
+
+        @Override
+        public String getAction() {
+            return action;
+        }
+    }
+}


### PR DESCRIPTION
Shutdown the server through the broadcast receiver on [ACTION_POWER_DISCONNECTED](https://developer.android.com/reference/android/content/Intent.html#ACTION_POWER_DISCONNECTED). 
This behaviour can be controlled using `shutdownOnPowerDisconnect` setting whose value is `true` by default.

Addressed to: appium/appium#9412
CI results: https://travis-ci.org/vmaxim/appium-uiautomator2-server/builds/371962846