### PR TITLE
Avoid skipping a character if it has the same code as a meta key

### DIFF
--- a/app/src/main/java/io/appium/uiautomator2/handler/W3CActions.java
+++ b/app/src/main/java/io/appium/uiautomator2/handler/W3CActions.java
@@ -44,6 +44,7 @@ import io.appium.uiautomator2.http.AppiumResponse;
 import io.appium.uiautomator2.http.IHttpRequest;
 import io.appium.uiautomator2.server.WDStatus;
 import io.appium.uiautomator2.utils.Logger;
+import io.appium.uiautomator2.utils.w3c.ASCIICodeToKeyEventConstantTranslator;
 import io.appium.uiautomator2.utils.w3c.ActionsHelpers;
 import io.appium.uiautomator2.utils.w3c.ActionsHelpers.InputEventParams;
 import io.appium.uiautomator2.utils.w3c.ActionsHelpers.KeyInputEventParams;
@@ -151,10 +152,14 @@ public class W3CActions extends SafeRequestHandler {
         final Set<Integer> result = new HashSet<>();
         for (Field field : fields) {
             if (field.getName().startsWith("META_") && field.getType() == int.class) {
+                final int metaCode;
                 try {
-                    result.add(field.getInt(null));
+                    metaCode = field.getInt(null);
                 } catch (IllegalAccessException e) {
-                    e.printStackTrace();
+                    continue;
+                }
+                if (ASCIICodeToKeyEventConstantTranslator.translate(metaCode) == null) {
+                    result.add(metaCode);
                 }
             }
         }


### PR DESCRIPTION
Some meta key codes, for example `META_ALT_RIGHT_ON` or `META_SHIFT_LEFT_ON` have the same value as some ASCII characters. It is more practical to just ignore these rather than ignoring the corresponding ASCII characters for typing.