### PR TITLE
Add a possibility to emulate IME actions with press_keycode endpoint

### DIFF
--- a/app/src/androidTestE2eTest/java/io/appium/uiautomator2/unittest/test/ActionsCommandsTest.java
+++ b/app/src/androidTestE2eTest/java/io/appium/uiautomator2/unittest/test/ActionsCommandsTest.java
@@ -26,10 +26,10 @@ import io.appium.uiautomator2.unittest.test.internal.BaseTest;
 import io.appium.uiautomator2.unittest.test.internal.Response;
 
 import static io.appium.uiautomator2.unittest.test.internal.commands.DeviceCommands.findElement;
-import static io.appium.uiautomator2.unittest.test.internal.commands.DeviceCommands.getElementAttribute;
 import static io.appium.uiautomator2.unittest.test.internal.commands.DeviceCommands.performActions;
 import static io.appium.uiautomator2.unittest.test.internal.commands.DeviceCommands.scrollTo;
 import static io.appium.uiautomator2.unittest.test.internal.commands.ElementCommands.click;
+import static io.appium.uiautomator2.unittest.test.internal.commands.ElementCommands.getText;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -43,7 +43,7 @@ public class ActionsCommandsTest extends BaseTest {
 
     private void verifyDragResult(String expectedText) {
         Response response = findElement(DRAG_TEXT);
-        response = getElementAttribute(response.getElementId(), "text");
+        response = getText(response.getElementId());
         assertThat((String) response.getValue(), containsString(expectedText));
     }
 
@@ -105,7 +105,7 @@ public class ActionsCommandsTest extends BaseTest {
                 "} ]");
         Response actionsResponse = performActions(actionsJson);
         assertThat(actionsResponse.getStatus(), equalTo(WDStatus.SUCCESS.code()));
-        Response response = getElementAttribute(edit.getElementId(), "text");
+        Response response = getText(edit.getElementId());
         assertThat((String) response.getValue(), equalTo("Hi"));
     }
 }

--- a/app/src/androidTestE2eTest/java/io/appium/uiautomator2/unittest/test/internal/commands/DeviceCommands.java
+++ b/app/src/androidTestE2eTest/java/io/appium/uiautomator2/unittest/test/internal/commands/DeviceCommands.java
@@ -267,15 +267,4 @@ public class DeviceCommands {
         payload.put("actions", actions);
         return Client.post("/actions", payload);
     }
-
-    /**
-     * Retrieves element attribute value
-     *
-     * @param elementId element identifier
-     * @param attrName valid attribute name
-     * @return Response from UiAutomator2 server
-     */
-    public static Response getElementAttribute(String elementId, String attrName){
-        return Client.get(String.format("/element/%s/attribute/%s", elementId, attrName));
-    }
 }

--- a/app/src/androidTestE2eTest/java/io/appium/uiautomator2/unittest/test/internal/commands/ElementCommands.java
+++ b/app/src/androidTestE2eTest/java/io/appium/uiautomator2/unittest/test/internal/commands/ElementCommands.java
@@ -56,6 +56,23 @@ public class ElementCommands {
     }
 
     /**
+     * Send a keycode with particular parameters
+     *
+     * @param keyCode Android key code
+     * @param metaState the state of meta keys
+     * @param flags KeyEvent flags
+     * @return Response from UiAutomator2 server
+     * @throws JSONException
+     */
+    public static Response pressKeyCode(int keyCode, int metaState, int flags) throws JSONException {
+        JSONObject payload = new JSONObject();
+        payload.put("keycode", keyCode);
+        payload.put("metastate", metaState);
+        payload.put("flags", flags);
+        return Client.post("/appium/device/press_keycode", payload);
+    }
+
+    /**
      * get the text from the element
      * GET /element/:elementId/text
      *

--- a/app/src/main/java/io/appium/uiautomator2/handler/LongPressKeyCode.java
+++ b/app/src/main/java/io/appium/uiautomator2/handler/LongPressKeyCode.java
@@ -1,19 +1,35 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.appium.uiautomator2.handler;
 
 import android.os.SystemClock;
-import android.view.InputDevice;
 import android.view.KeyCharacterMap;
 import android.view.KeyEvent;
 
 import org.json.JSONException;
 import org.json.JSONObject;
 
-import io.appium.uiautomator2.core.InteractionController;
-import io.appium.uiautomator2.core.UiAutomatorBridge;
 import io.appium.uiautomator2.handler.request.SafeRequestHandler;
 import io.appium.uiautomator2.http.AppiumResponse;
 import io.appium.uiautomator2.http.IHttpRequest;
 import io.appium.uiautomator2.server.WDStatus;
+
+import static io.appium.uiautomator2.utils.InteractionUtils.injectEventSync;
+import static io.appium.uiautomator2.utils.JSONUtils.readInteger;
 
 public class LongPressKeyCode extends SafeRequestHandler {
 
@@ -23,51 +39,25 @@ public class LongPressKeyCode extends SafeRequestHandler {
 
     @Override
     protected AppiumResponse safeHandle(IHttpRequest request) throws JSONException {
-        InteractionController interactionController = UiAutomatorBridge.getInstance()
-                .getInteractionController();
-
         final JSONObject payload = getPayload(request);
-        final Object kc = payload.get("keycode");
-        final Object ms = payload.has("metastate") ? payload.get("metastate") : null;
+        final int keyCode = readInteger(payload, "keycode");
+        Integer metaState = readInteger(payload, "metastate", false);
+        metaState = metaState == null ? 0 : metaState;
+        Integer flags = readInteger(payload, "flags", false);
+        flags = flags == null ? 0 : flags;
 
-        final Integer keyCode;
-        if (kc instanceof Integer) {
-            keyCode = (Integer) kc;
-        } else if (kc instanceof String) {
-            keyCode = Integer.parseInt((String) kc);
-        } else {
-            return new AppiumResponse(getSessionId(request), WDStatus.UNKNOWN_ERROR,
-                    "Keycode of type " + kc.getClass() + "not supported.");
-        }
-
-        final Integer metaState;
-        if (ms instanceof Integer) {
-            metaState = (Integer) ms;
-        } else if (ms instanceof String) {
-            metaState = Integer.parseInt((String) ms);
-        } else {
-            metaState = 0;
-        }
-
-        final long eventTime = SystemClock.uptimeMillis();
-        // Send an initial down event
-        final KeyEvent downEvent = new KeyEvent(eventTime, eventTime, KeyEvent.ACTION_DOWN,
-                keyCode, 0, metaState, KeyCharacterMap.VIRTUAL_KEYBOARD,
-                0, 0, InputDevice.SOURCE_KEYBOARD);
-        boolean isInjectionSuccessful = interactionController.injectEventSync(downEvent);
+        final long downTime = SystemClock.uptimeMillis();
+        boolean isSuccessful = injectEventSync(new KeyEvent(downTime, downTime,
+                KeyEvent.ACTION_DOWN, keyCode, 0, metaState, KeyCharacterMap.VIRTUAL_KEYBOARD,
+                0, flags));
         // https://android.googlesource.com/platform/frameworks/base.git/+/9d83b4783c33f1fafc43f367503e129e5a5047fa%5E%21/#F0
-        final KeyEvent repeatEvent = new KeyEvent(eventTime, eventTime, KeyEvent.ACTION_DOWN,
-                keyCode, 1, metaState, KeyCharacterMap.VIRTUAL_KEYBOARD,
-                0, KeyEvent.FLAG_LONG_PRESS, InputDevice.SOURCE_KEYBOARD);
-        isInjectionSuccessful = interactionController.injectEventSync(repeatEvent)
-                && isInjectionSuccessful;
-        // Finally, send the up event
-        final KeyEvent upEvent = new KeyEvent(eventTime, eventTime, KeyEvent.ACTION_UP,
-                keyCode, 0, metaState, KeyCharacterMap.VIRTUAL_KEYBOARD,
-                0, 0, InputDevice.SOURCE_KEYBOARD);
-        isInjectionSuccessful = interactionController.injectEventSync(upEvent)
-                && isInjectionSuccessful;
-        if (!isInjectionSuccessful) {
+        isSuccessful &= injectEventSync(new KeyEvent(downTime, SystemClock.uptimeMillis(),
+                KeyEvent.ACTION_DOWN, keyCode, 1, metaState, KeyCharacterMap.VIRTUAL_KEYBOARD,
+                0, flags | KeyEvent.FLAG_LONG_PRESS));
+        isSuccessful &= injectEventSync(new KeyEvent(downTime, SystemClock.uptimeMillis(),
+                KeyEvent.ACTION_UP, keyCode, 0, metaState, KeyCharacterMap.VIRTUAL_KEYBOARD,
+                0, flags));
+        if (!isSuccessful) {
             return new AppiumResponse(getSessionId(request), WDStatus.UNKNOWN_ERROR,
                     "Cannot inject long press event for key code " + keyCode);
         }

--- a/app/src/main/java/io/appium/uiautomator2/handler/W3CActions.java
+++ b/app/src/main/java/io/appium/uiautomator2/handler/W3CActions.java
@@ -19,8 +19,6 @@ package io.appium.uiautomator2.handler;
 import android.os.SystemClock;
 import android.util.Log;
 import android.util.LongSparseArray;
-import android.view.InputDevice;
-import android.view.InputEvent;
 import android.view.KeyCharacterMap;
 import android.view.KeyEvent;
 import android.view.MotionEvent;
@@ -38,7 +36,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import io.appium.uiautomator2.core.UiAutomatorBridge;
 import io.appium.uiautomator2.handler.request.SafeRequestHandler;
 import io.appium.uiautomator2.http.AppiumResponse;
 import io.appium.uiautomator2.http.IHttpRequest;
@@ -50,6 +47,7 @@ import io.appium.uiautomator2.utils.w3c.ActionsHelpers.KeyInputEventParams;
 import io.appium.uiautomator2.utils.w3c.ActionsHelpers.MotionInputEventParams;
 import io.appium.uiautomator2.utils.w3c.ActionsParseException;
 
+import static io.appium.uiautomator2.utils.InteractionUtils.injectEventSync;
 import static io.appium.uiautomator2.utils.w3c.ActionsHelpers.actionsToInputEventsMapping;
 import static io.appium.uiautomator2.utils.w3c.ActionsHelpers.getPointerAction;
 import static io.appium.uiautomator2.utils.w3c.ActionsHelpers.metaKeysToState;
@@ -142,10 +140,6 @@ public class W3CActions extends SafeRequestHandler {
         }
     }
 
-    private boolean injectEventSync(InputEvent event) {
-        return UiAutomatorBridge.getInstance().injectInputEvent(event, true);
-    }
-
     private static Set<Integer> getMetaKeyCodes() {
         final Field[] fields = KeyEvent.class.getFields();
         final Set<Integer> result = new HashSet<>();
@@ -193,9 +187,7 @@ public class W3CActions extends SafeRequestHandler {
                         final int metaState = metaKeysToState(depressedMetaKeys);
                         result &= injectEventSync(new KeyEvent(startTimestamp + eventParam.startDelta,
                                 SystemClock.uptimeMillis(), keyAction, keyCode, 0,
-                                metaState, KeyCharacterMap.VIRTUAL_KEYBOARD,
-                                0, KeyEvent.FLAG_FROM_SYSTEM | KeyEvent.FLAG_VIRTUAL_HARD_KEY,
-                                InputDevice.SOURCE_KEYBOARD));
+                                metaState, KeyCharacterMap.VIRTUAL_KEYBOARD, 0, 0));
                         Log.d(TAG, String.format("Generated KeyEvent for keyAction '%s', keyCode: '%s', metaState: '%s'",
                                 keyAction, keyCode, metaState));
                     }

--- a/app/src/main/java/io/appium/uiautomator2/utils/InteractionUtils.java
+++ b/app/src/main/java/io/appium/uiautomator2/utils/InteractionUtils.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.appium.uiautomator2.utils;
+
+import android.view.InputEvent;
+
+import io.appium.uiautomator2.core.UiAutomatorBridge;
+
+public class InteractionUtils {
+    public static boolean injectEventSync(InputEvent event) {
+        return UiAutomatorBridge.getInstance().injectInputEvent(event, true);
+    }
+}

--- a/app/src/main/java/io/appium/uiautomator2/utils/JSONUtils.java
+++ b/app/src/main/java/io/appium/uiautomator2/utils/JSONUtils.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.appium.uiautomator2.utils;
+
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+
+public class JSONUtils {
+    @NonNull
+    public static Integer readInteger(JSONObject payload, String name) throws JSONException {
+        //noinspection ConstantConditions
+        return readInteger(payload, name, true);
+    }
+
+    @Nullable
+    public static Integer readInteger(JSONObject payload, String name, boolean isRequired)
+            throws JSONException {
+        if (!payload.has(name)) {
+            if (isRequired) {
+                throw new IllegalArgumentException(String.format("'%s' parameter is mandatory", name));
+            }
+            return null;
+        }
+
+        final Object objValue = payload.get(name);
+        if (objValue instanceof Integer) {
+            return  (Integer) objValue;
+        } else if (objValue instanceof Long) {
+            return ((Long) objValue).intValue();
+        } else if (objValue instanceof String) {
+            return Integer.parseInt((String) objValue);
+        }
+        if (isRequired) {
+            throw new IllegalArgumentException(String.format(
+                    "'%s' parameter should be a valid integer number. '%s' is given instead",
+                    name, objValue));
+        }
+        return null;
+    }
+}


### PR DESCRIPTION
The actual idea has been borrowed from the Espresso's implementation of `performEditorAction` method. 