### PR TITLE
Fix appium/appium#10707

### DIFF
--- a/app/src/main/java/io/appium/uiautomator2/core/UiAutomation.java
+++ b/app/src/main/java/io/appium/uiautomator2/core/UiAutomation.java
@@ -16,6 +16,9 @@
 package io.appium.uiautomator2.core;
 
 import android.app.UiAutomation.OnAccessibilityEventListener;
+import android.support.annotation.Nullable;
+
+import io.appium.uiautomator2.common.exceptions.UiAutomator2Exception;
 
 import static io.appium.uiautomator2.utils.ReflectionUtils.getField;
 
@@ -34,9 +37,15 @@ public class UiAutomation {
         return INSTANCE;
     }
 
+    @Nullable
     public OnAccessibilityEventListener getOnAccessibilityEventListener() {
-        return (OnAccessibilityEventListener) getField(android.app.UiAutomation.class,
-                FIELD_ON_ACCESSIBILITY_EVENT_LISTENER, uiAutomation);
+        try {
+            return (OnAccessibilityEventListener) getField(android.app.UiAutomation.class,
+                    FIELD_ON_ACCESSIBILITY_EVENT_LISTENER, uiAutomation);
+        } catch (UiAutomator2Exception e) {
+            /* mOnAccessibilityEventListener is no longer accessible on Android P */
+            return null;
+        }
     }
 
     public void setOnAccessibilityEventListener(OnAccessibilityEventListener listener) {

--- a/app/src/main/java/io/appium/uiautomator2/core/UiAutomation.java
+++ b/app/src/main/java/io/appium/uiautomator2/core/UiAutomation.java
@@ -18,8 +18,6 @@ package io.appium.uiautomator2.core;
 import android.app.UiAutomation.OnAccessibilityEventListener;
 import android.support.annotation.Nullable;
 
-import io.appium.uiautomator2.common.exceptions.UiAutomator2Exception;
-
 import static io.appium.uiautomator2.utils.ReflectionUtils.getField;
 
 public class UiAutomation {
@@ -42,7 +40,7 @@ public class UiAutomation {
         try {
             return (OnAccessibilityEventListener) getField(android.app.UiAutomation.class,
                     FIELD_ON_ACCESSIBILITY_EVENT_LISTENER, uiAutomation);
-        } catch (UiAutomator2Exception e) {
+        } catch (Exception e) {
             /* mOnAccessibilityEventListener is no longer accessible on Android P */
             return null;
         }

--- a/app/src/main/java/io/appium/uiautomator2/model/NotificationListener.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/NotificationListener.java
@@ -17,10 +17,8 @@
 package io.appium.uiautomator2.model;
 
 import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
 import android.view.accessibility.AccessibilityEvent;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 
@@ -38,7 +36,7 @@ public final class NotificationListener implements OnAccessibilityEventListener 
     private List<CharSequence> toastMessage = new CopyOnWriteArrayList<>();
     private long recentToastTimestamp = currentTimeMillis();
     private OnAccessibilityEventListener originalListener = null;
-    private boolean isListening;
+    private volatile boolean isListening;
 
     protected NotificationListener() {
         uiAutomation = UiAutomation.getInstance();

--- a/app/src/main/java/io/appium/uiautomator2/model/NotificationListener.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/NotificationListener.java
@@ -34,10 +34,11 @@ public final class NotificationListener implements OnAccessibilityEventListener 
     private static final NotificationListener INSTANCE = new NotificationListener();
     private static final int TOAST_CLEAR_TIMEOUT = 3500;
 
+    private final UiAutomation uiAutomation;
     private List<CharSequence> toastMessage = new CopyOnWriteArrayList<>();
     private long recentToastTimestamp = currentTimeMillis();
     private OnAccessibilityEventListener originalListener = null;
-    private final UiAutomation uiAutomation;
+    private boolean isListening;
 
     protected NotificationListener() {
         uiAutomation = UiAutomation.getInstance();
@@ -57,6 +58,7 @@ public final class NotificationListener implements OnAccessibilityEventListener 
         }
         Logger.debug("Starting toast notification listener.");
         originalListener = uiAutomation.getOnAccessibilityEventListener();
+        isListening = true;
         Logger.debug("Original listener: " + originalListener);
         uiAutomation.setOnAccessibilityEventListener(this);
     }
@@ -67,6 +69,7 @@ public final class NotificationListener implements OnAccessibilityEventListener 
             return;
         }
         Logger.debug("Stopping toast notification listener.");
+        isListening = false;
         uiAutomation.setOnAccessibilityEventListener(originalListener);
     }
 
@@ -86,7 +89,7 @@ public final class NotificationListener implements OnAccessibilityEventListener 
     }
 
     public boolean isListening() {
-        return uiAutomation.getOnAccessibilityEventListener() == this;
+        return isListening;
     }
 
     protected long getToastClearTimeout() {

--- a/app/src/test/java/io/appium/uiautomator2/model/NotificationListenerTests.java
+++ b/app/src/test/java/io/appium/uiautomator2/model/NotificationListenerTests.java
@@ -85,16 +85,15 @@ public class NotificationListenerTests {
 
     @Test
     public void shouldBeAbleToStartListener() {
-        doReturn(false).when(notificationListener).isListening();
         notificationListener.start();
-        verify(uiAutomation).setOnAccessibilityEventListener(notificationListener);
+        assertTrue(notificationListener.isListening());
     }
 
     @Test
     public void shouldBeAbleToStopListener() {
-        doReturn(true).when(notificationListener).isListening();
+        notificationListener.start();
         notificationListener.stop();
-        verify(uiAutomation).setOnAccessibilityEventListener(null);
+        assertFalse(notificationListener.isListening());
     }
 
     @Test
@@ -144,16 +143,6 @@ public class NotificationListenerTests {
         when(notificationListener.getToastClearTimeout()).thenReturn(-1L);
 
         assertTrue(notificationListener.getToastMessage().isEmpty());
-    }
-
-    @Test
-    public void shouldProperlyDetectListeningState() {
-        doReturn(originalAccessibilityEventListener).when(uiAutomation)
-                .getOnAccessibilityEventListener();
-        assertFalse(notificationListener.isListening());
-
-        doReturn(notificationListener).when(uiAutomation).getOnAccessibilityEventListener();
-        assertTrue(notificationListener.isListening());
     }
 
     @Test


### PR DESCRIPTION
```UiAutomation.mOnAccessibilityEventListener``` is no longer accessible on Android P

```
W tomator2.serve: Accessing hidden field Landroid/app/UiAutomation;->mOnAccessibilityEventListener:Landroid/app/UiAutomation$OnAccessibilityEventListener; (blacklist, reflection)
```
https://android-developers.googleblog.com/2018/02/improving-stability-by-reducing-usage.html