### PR TITLE
fix parsing \xCB\x8B

### DIFF
--- a/app/src/main/java/io/appium/uiautomator2/utils/XMLHierarchy.java
+++ b/app/src/main/java/io/appium/uiautomator2/utils/XMLHierarchy.java
@@ -132,7 +132,7 @@ public abstract class XMLHierarchy {
         String fixedName = name
                 .replaceAll("[$@#&]", ".")
                 // https://github.com/appium/appium/issues/9934
-                .replaceAll("[ˊ\\s]", "");
+                .replaceAll("[ˋˊ\\s]", ""); // "ˋ" is \xCB\x8B in UTF-8
         fixedName = safeCharSeqToString(fixedName)
                 // https://github.com/appium/appium/issues/9934
                 .replace("?", "")


### PR DESCRIPTION
I investigated https://github.com/appium/appium/issues/9934 further and finally, I found the cause.

The error was:

```
Original error: org.w3c.dom.DOMException: android.support.v7.app.ActionBar.ˋ
        at org.apache.harmony.xml.dom.NodeImpl.setNameNS(NodeImpl.java:241)
        at org.apache.harmony.xml.dom.DocumentImpl.renameNode(DocumentImpl.java:318)
        at io.appium.uiautomator2.utils.XMLHierarchy.visitNode(XMLHierarchy.java:122)
        at io.appium.uiautomator2.utils.XMLHierarchy.annotateNodes(XMLHierarchy.java:88)
        at io.appium.uiautomator2.utils.XMLHierarchy.annotateNodes(XMLHierarchy.java:89)
...
```

The `ˋ` was the cause and it was `\xCB\x8B`. `\u0060`(\x60) is <code>`</code> from keyboard.

After the change, parsing `class="android.support.v7.app.ActionBar$ˋ"`worked.