### PR TITLE
Do not include gradle files in npm package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,6 +1,0 @@
-app
-build
-doc
-gradle
-.gradle/
-local.properties

--- a/.npmignore
+++ b/.npmignore
@@ -2,4 +2,5 @@ app
 build
 doc
 gradle
+.gradle/
 local.properties

--- a/package.json
+++ b/package.json
@@ -18,6 +18,10 @@
   "bugs": {
     "url": "https://github.com/appium/appium-uiautomator2-server/issues"
   },
+  "files": [
+    "/lib",
+    "/apks"
+  ],
   "homepage": "https://github.com/appium/appium-uiautomator2-server",
   "scripts": {
     "clean": "rm -rf node_modules && rm -f package-lock.json && npm install",


### PR DESCRIPTION
Small win in tarball size, but on-disk size is pretty significant:
```
npm notice === Tarball Details ===
npm notice name:          appium-uiautomator2-server
npm notice version:       1.16.0
npm notice filename:      appium-uiautomator2-server-1.16.0.tgz
npm notice package size:  4.9 MB
npm notice unpacked size: 10.5 MB
npm notice shasum:        734ed66b9220ebac87ccbf522730f3b323c0485a
npm notice integrity:     sha512-sIkcuB0VV98NG[...]++cqSjvtDoR+g==
npm notice total files:   29
npm notice
appium-uiautomator2-server-1.16.0.tgz
```
```
npm notice === Tarball Details ===
npm notice name:          appium-uiautomator2-server
npm notice version:       1.16.0
npm notice filename:      appium-uiautomator2-server-1.16.0.tgz
npm notice package size:  3.5 MB
npm notice unpacked size: 3.5 MB
npm notice shasum:        f954ad08b07c94a0ad7491a7b3482e67c3c6b8ed
npm notice integrity:     sha512-Dy4kMF5iqgSQT[...]1IWoLlRSbhPZg==
npm notice total files:   13
npm notice
appium-uiautomator2-server-1.16.0.tgz
```