### PR TITLE
Update appium-gulp-plugins

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,7 @@ env:
 before_script:
   # node stuff
   - curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.1/install.sh | bash
-  - nvm install 6
+  - nvm install 8
   - node --version
   - npm --version
   - npm install appium-test-support # get the travis emu scripts

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   },
   "devDependencies": {
     "android-apidemos": "^3.0.0",
-    "appium-gulp-plugins": "^2.4.0"
+    "appium-gulp-plugins": "^3.1.0",
+    "gulp": "^4.0.0"
   }
 }


### PR DESCRIPTION
This PR does two main things:
1. Updates `eslint-config-appium` and fixes any linting errors.
1. Updated `appium-gulp-plugins` and moves to Babel 7 and Gulp 4.

See https://github.com/appium/appium-gulp-plugins/pull/35 for more details.