### PR TITLE
Sign apk with default appium certificate

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
   "scripts": {
     "clean": "rm -rf node_modules && rm -f package-lock.json && npm install",
     "bump-gradle-version": "gulp gradle-version-update --package-version=${npm_package_version} && git add app/build.gradle",
-    "build": "./gradlew clean assembleServerDebug assembleServerDebugAndroidTest && npm run move-apks",
+    "build": "./gradlew clean assembleServerDebug assembleServerDebugAndroidTest && npm run move-apks && npm run sign-apk",
+    "sign-apk": "babel-node ./scripts/sign-apk.js",
     "move-server": "cp app/build/outputs/apk/server/debug/appium-uiautomator2-server-v${npm_package_version}.apk ./apks",
     "move-test": "cp app/build/outputs/apk/androidTest/server/debug/appium-uiautomator2-server-debug-androidTest.apk ./apks",
     "move-apks": "rm -rf apks && mkdir -p apks && npm run move-server && npm run move-test",
@@ -35,7 +36,10 @@
   },
   "devDependencies": {
     "android-apidemos": "^3.0.0",
+    "appium-adb": "^6.21.1",
+    "appium-android-driver": "^4.3.1",
     "appium-gulp-plugins": "^3.1.0",
+    "asyncbox": "^2.5.0",
     "gulp": "^4.0.0"
   }
 }

--- a/scripts/sign-apk.js
+++ b/scripts/sign-apk.js
@@ -1,0 +1,15 @@
+
+import { androidHelpers } from 'appium-android-driver';
+import { asyncify } from 'asyncbox';
+import path from 'path';
+import packageJson from '../package.json';
+
+async function main () {
+  // Signs the APK with the default Appium Certificate
+  const adb = await androidHelpers.createADB({});
+  const pathToApk = path.resolve('apks', `appium-uiautomator2-server-v${packageJson.version}.apk`);
+  await adb.sign(pathToApk);
+  await adb.executeApksigner(['verify', '--print-certs', pathToApk]);
+}
+
+asyncify(main);

--- a/scripts/sign-apk.js
+++ b/scripts/sign-apk.js
@@ -9,7 +9,6 @@ async function main () {
   const adb = await androidHelpers.createADB({});
   const pathToApk = path.resolve('apks', `appium-uiautomator2-server-v${packageJson.version}.apk`);
   await adb.sign(pathToApk);
-  await adb.executeApksigner(['verify', '--print-certs', pathToApk]);
 }
 
 asyncify(main);


### PR DESCRIPTION
* Does this on 'build' so that we publish an APK that contains the Appium certificate
* This is so that the server doesn't have to run 'apksigner' during a session