### PR TITLE
Remove the redundant uiElementIndex attribute from the source tree

### DIFF
--- a/app/src/main/java/io/appium/uiautomator2/core/AccessibilityNodeInfoDumper.java
+++ b/app/src/main/java/io/appium/uiautomator2/core/AccessibilityNodeInfoDumper.java
@@ -59,15 +59,13 @@ public class AccessibilityNodeInfoDumper {
     }
 
     private static Element toDOMElement(UiElement<?, ?> uiElement, final Document document,
-                                        final SparseArray<UiElement<?, ?>> uiElementsMapping,
+                                        @Nullable final SparseArray<UiElement<?, ?>> uiElementsMapping,
                                         final int depth) {
         String className = uiElement.getClassName();
         if (className == null) {
             className = DEFAULT_VIEW_CLASS_NAME;
         }
         Element element = document.createElement(toNodeName(className));
-        final int uiElementIndex = uiElementsMapping.size();
-        uiElementsMapping.put(uiElementIndex, uiElement);
 
         /*
          * Setting the Element's className field.
@@ -81,7 +79,12 @@ public class AccessibilityNodeInfoDumper {
         for (Attribute attr : Attribute.values()) {
             setAttribute(element, attr, toSafeXmlString(uiElement.get(attr), "?"));
         }
-        element.setAttribute(UI_ELEMENT_INDEX, Integer.toString(uiElementIndex));
+
+        if (uiElementsMapping != null) {
+            final int uiElementIndex = uiElementsMapping.size();
+            uiElementsMapping.put(uiElementIndex, uiElement);
+            element.setAttribute(UI_ELEMENT_INDEX, Integer.toString(uiElementIndex));
+        }
 
         if (depth >= MAX_DEPTH) {
             Logger.error(String.format("The xml tree dump has reached its maximum depth of %s at " +
@@ -114,9 +117,6 @@ public class AccessibilityNodeInfoDumper {
                     .newDocument();
         } catch (ParserConfigurationException e) {
             throw new UiAutomator2Exception(e);
-        }
-        if (uiElementsMapping == null) {
-            uiElementsMapping = new SparseArray<>();
         }
         final UiElement<?, ?> xpathRoot = root == null
                 ? UiAutomationElement.rebuildForNewRoot(currentActiveWindowRoot(), NotificationListener

--- a/app/src/main/java/io/appium/uiautomator2/utils/ReflectionUtils.java
+++ b/app/src/main/java/io/appium/uiautomator2/utils/ReflectionUtils.java
@@ -21,27 +21,8 @@ import java.lang.reflect.Method;
 import java.util.Arrays;
 
 import io.appium.uiautomator2.common.exceptions.UiAutomator2Exception;
-import io.appium.uiautomator2.core.UiAutomatorBridge;
 
 public class ReflectionUtils {
-
-    /**
-     * Clears the in-process Accessibility cache, removing any stale references. Because the
-     * AccessibilityInteractionClient singleton stores copies of AccessibilityNodeInfo instances,
-     * calls to public APIs such as `recycle` do not guarantee cached references get updated. See
-     * the android.view.accessibility AIC and ANI source code for more information.
-     */
-    public static boolean clearAccessibilityCache() throws UiAutomator2Exception {
-        try {
-            // This call invokes `AccessibilityInteractionClient.getInstance().clearCache();` method
-            UiAutomatorBridge.getInstance().getUiAutomation().setServiceInfo(null);
-            return true;
-        } catch (Exception e) {
-            Logger.error("Failed to clear Accessibility Node cache.", e);
-            return false;
-        }
-    }
-
     public static Class getClass(final String name) throws UiAutomator2Exception {
         try {
             return Class.forName(name);


### PR DESCRIPTION
This removes the redundant uiElementIndex attribute from page source output. This attribute is only used to assist xpath search and is not needed to be shown.