### PR TITLE
Return empty string if null

### DIFF
--- a/app/src/androidTestE2eTest/java/io/appium/uiautomator2/unittest/test/DeviceCommandsTest.java
+++ b/app/src/androidTestE2eTest/java/io/appium/uiautomator2/unittest/test/DeviceCommandsTest.java
@@ -352,7 +352,6 @@ public class DeviceCommandsTest extends BaseTest {
         assertEquals("Access'ibility", response.getValue());
     }
 
-
     @Test
     public void findElementWithAttributes() throws JSONException {
         scrollTo("Views");

--- a/app/src/main/java/io/appium/uiautomator2/handler/GetText.java
+++ b/app/src/main/java/io/appium/uiautomator2/handler/GetText.java
@@ -26,6 +26,9 @@ public class GetText extends SafeRequestHandler {
             return new AppiumResponse(getSessionId(request), WDStatus.NO_SUCH_ELEMENT);
         }
         text = element.getText();
+        if (text == null) {
+          text = "";
+        }
         Logger.info("Get Text :" + text);
         return new AppiumResponse(getSessionId(request), WDStatus.SUCCESS, text);
     }

--- a/app/src/main/java/io/appium/uiautomator2/handler/GetText.java
+++ b/app/src/main/java/io/appium/uiautomator2/handler/GetText.java
@@ -26,10 +26,7 @@ public class GetText extends SafeRequestHandler {
             return new AppiumResponse(getSessionId(request), WDStatus.NO_SUCH_ELEMENT);
         }
         text = element.getText();
-        if (text == null) {
-          text = "";
-        }
-        Logger.info("Get Text :" + text);
+        Logger.info("Get Text: " + text);
         return new AppiumResponse(getSessionId(request), WDStatus.SUCCESS, text);
     }
 

--- a/app/src/main/java/io/appium/uiautomator2/handler/SendKeysToElement.java
+++ b/app/src/main/java/io/appium/uiautomator2/handler/SendKeysToElement.java
@@ -45,7 +45,8 @@ public class SendKeysToElement extends SafeRequestHandler {
     }
 
     private static boolean isTextFieldClear(AndroidElement element) throws UiObjectNotFoundException {
-        return element.getText() == null || element.getText().isEmpty();
+        String text = element.getText();
+        return text == null || text.isEmpty();
     }
 
     @Override
@@ -105,5 +106,3 @@ public class SendKeysToElement extends SafeRequestHandler {
         return new AppiumResponse(getSessionId(request), WDStatus.SUCCESS, actionMsg);
     }
 }
-
-

--- a/app/src/main/java/io/appium/uiautomator2/model/CustomUiSelector.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/CustomUiSelector.java
@@ -44,7 +44,9 @@ public class CustomUiSelector {
         }
         put(Attribute.PACKAGE, charSequenceToString(uiAutomationElement.getPackageName()));
         put(Attribute.CLASS, charSequenceToString(uiAutomationElement.getClassName()));
-        put(Attribute.TEXT, charSequenceToString(uiAutomationElement.getText()));
+        // the element will give empty strings as "" but for searching we need null
+        String text = charSequenceToString(uiAutomationElement.getText());
+        put(Attribute.TEXT, (text != null && text.isEmpty()) ? null : text);
         put(Attribute.CONTENT_DESC, charSequenceToString(uiAutomationElement.getContentDescription()));
         put(Attribute.RESOURCE_ID, charSequenceToString(uiAutomationElement.getResourceId()));
         put(Attribute.CHECKABLE, uiAutomationElement.isCheckable());

--- a/app/src/main/java/io/appium/uiautomator2/model/CustomUiSelector.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/CustomUiSelector.java
@@ -44,9 +44,7 @@ public class CustomUiSelector {
         }
         put(Attribute.PACKAGE, charSequenceToString(uiAutomationElement.getPackageName()));
         put(Attribute.CLASS, charSequenceToString(uiAutomationElement.getClassName()));
-        // the element will give empty strings as "" but for searching we need null
-        String text = charSequenceToString(uiAutomationElement.getText());
-        put(Attribute.TEXT, (text != null && text.isEmpty()) ? null : text);
+        put(Attribute.TEXT, charSequenceToString(uiAutomationElement.getNullableText()));
         put(Attribute.CONTENT_DESC, charSequenceToString(uiAutomationElement.getContentDescription()));
         put(Attribute.RESOURCE_ID, charSequenceToString(uiAutomationElement.getResourceId()));
         put(Attribute.CHECKABLE, uiAutomationElement.isCheckable());

--- a/app/src/main/java/io/appium/uiautomator2/model/UiAutomationElement.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/UiAutomationElement.java
@@ -182,4 +182,10 @@ public class UiAutomationElement extends UiElement<AccessibilityNodeInfo, UiAuto
     protected Map<Attribute, Object> getAttributes() {
         return attributes;
     }
+
+    @Nullable
+    public String getNullableText() {
+        String text = getText();
+        return (text != null && text.isEmpty()) ? null : text;
+    }
 }

--- a/app/src/main/java/io/appium/uiautomator2/utils/ElementHelpers.java
+++ b/app/src/main/java/io/appium/uiautomator2/utils/ElementHelpers.java
@@ -221,10 +221,9 @@ public abstract class ElementHelpers {
                 Arrays.toString(Attribute.exposableAliases())), attributeName);
     }
 
-    @Nullable
     public static String getText(@Nullable AccessibilityNodeInfo nodeInfo) {
         if (nodeInfo == null) {
-            return null;
+            return "";
         }
 
         if (nodeInfo.getRangeInfo() != null) {
@@ -234,7 +233,6 @@ public abstract class ElementHelpers {
         return text == null ? "" : text.toString();
     }
 
-    @Nullable
     public static String getText(Object element) throws UiObjectNotFoundException {
         if (element instanceof UiObject2) {
             /*

--- a/app/src/main/java/io/appium/uiautomator2/utils/ElementHelpers.java
+++ b/app/src/main/java/io/appium/uiautomator2/utils/ElementHelpers.java
@@ -231,7 +231,7 @@ public abstract class ElementHelpers {
             return Float.toString(nodeInfo.getRangeInfo().getCurrent());
         }
         CharSequence text = nodeInfo.getText();
-        return text == null ? null : text.toString();
+        return text == null ? "" : text.toString();
     }
 
     @Nullable
@@ -246,7 +246,7 @@ public abstract class ElementHelpers {
                     "mCachedNode", element);
             if (nodeInfo != null && Objects.equals(nodeInfo.getClassName(), Toast.class.getName())) {
                 CharSequence text = nodeInfo.getText();
-                return text == null ? null : text.toString();
+                return text == null ? "" : text.toString();
             }
 
             return getText(AccessibilityNodeInfoGetter.fromUiObject(element));


### PR DESCRIPTION
In certain circumstances (such as Java 1.7, Android-21 in our `appium-uiautomator2-driver` Travis build (see https://travis-ci.org/appium/appium-uiautomator2-driver/jobs/447774226#L3630-L3637)) the framework returns `null`, and we pass that back, leading to failures where `""` is expected.
```
info HTTP --> GET /wd/hub/session/a31a2b91-2d5b-45e5-8b82-fbe8a5e13061/element/e0205769-e494-4f91-bcc8-76c1b2cdbb8b/text
info HTTP {}
info MJSONWP (a31a2b91) Driver proxy active, passing request on via HTTP proxy
dbug JSONWP Proxy Matched '/wd/hub/session/a31a2b91-2d5b-45e5-8b82-fbe8a5e13061/element/e0205769-e494-4f91-bcc8-76c1b2cdbb8b/text' to command name 'getText'
dbug JSONWP Proxy Proxying [GET /wd/hub/session/a31a2b91-2d5b-45e5-8b82-fbe8a5e13061/element/e0205769-e494-4f91-bcc8-76c1b2cdbb8b/text] to [GET http://localhost:8200/wd/hub/session/a6cdb841-e905-49ad-ae43-51a9ac773de4/element/e0205769-e494-4f91-bcc8-76c1b2cdbb8b/text] with body: {}
dbug JSONWP Proxy Got response with status 200: "{\"sessionId\":\"a6cdb841-e905-49ad-ae43-51a9ac773de4\",\"status\":0,\"value\":null}"
info JSONWP Proxy Replacing sessionId a6cdb841-e905-49ad-ae43-51a9ac773de4 with a31a2b91-2d5b-45e5-8b82-fbe8a5e13061
info HTTP <-- GET /wd/hub/session/a31a2b91-2d5b-45e5-8b82-fbe8a5e13061/element/e0205769-e494-4f91-bcc8-76c1b2cdbb8b/text 200 39
```