### PR TITLE
Avoid refreshing accessibility twice while executing xpath queries

### DIFF
--- a/app/src/main/java/io/appium/uiautomator2/handler/FindElement.java
+++ b/app/src/main/java/io/appium/uiautomator2/handler/FindElement.java
@@ -93,7 +93,10 @@ public class FindElement extends SafeRequestHandler {
     @Nullable
     private Object findElement(By by) throws ClassNotFoundException, UiAutomator2Exception,
             UiObjectNotFoundException {
-        refreshRootAXNode();
+        if (!(by instanceof By.ByXPath)) {
+            // The accessibility is refreshed when xml page source is built
+            refreshRootAXNode();
+        }
 
         if (by instanceof ById) {
             String locator = rewriteIdLocator((ById) by);

--- a/app/src/main/java/io/appium/uiautomator2/model/KnownElements.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/KnownElements.java
@@ -83,7 +83,7 @@ public class KnownElements {
                 }
                 if (ui2Object == null) {
                     throw new StaleElementReferenceException(String.format(
-                            "The element '%s' does not exist in DOM anymore", id));
+                            "The element '%s' does not exist in DOM anymore", by));
                 }
                 AndroidElement androidElement = getAndroidElement(id, ui2Object, result.getBy());
                 cache.put(androidElement.getId(), androidElement);

--- a/app/src/main/java/io/appium/uiautomator2/utils/ElementLocationHelpers.java
+++ b/app/src/main/java/io/appium/uiautomator2/utils/ElementLocationHelpers.java
@@ -84,7 +84,6 @@ public class ElementLocationHelpers {
 
     public static List<UiSelector> toSelectors(String uiaExpression) throws UiSelectorSyntaxException,
             UiObjectNotFoundException {
-        UiAutomatorParser uiAutomatorParser = new UiAutomatorParser();
-        return uiAutomatorParser.parse(uiaExpression);
+        return new UiAutomatorParser().parse(uiaExpression);
     }
 }


### PR DESCRIPTION
The accessibility is refreshed anyway when xml page source is built