### PR TITLE
Add AX tree refresh before getting the page source

### DIFF
--- a/app/src/main/java/io/appium/uiautomator2/handler/FindElement.java
+++ b/app/src/main/java/io/appium/uiautomator2/handler/FindElement.java
@@ -57,8 +57,7 @@ public class FindElement extends SafeRequestHandler {
     }
 
     @Override
-    protected AppiumResponse safeHandle(IHttpRequest request) throws JSONException,
-            UiObjectNotFoundException {
+    protected AppiumResponse safeHandle(IHttpRequest request) throws JSONException, UiObjectNotFoundException {
         Logger.info("Find element command");
         KnownElements ke = new KnownElements();
         final JSONObject payload = getPayload(request);
@@ -91,12 +90,8 @@ public class FindElement extends SafeRequestHandler {
     }
 
     @Nullable
-    private Object findElement(By by) throws ClassNotFoundException, UiAutomator2Exception,
-            UiObjectNotFoundException {
-        if (!(by instanceof By.ByXPath)) {
-            // The accessibility is refreshed when xml page source is built
-            refreshRootAXNode();
-        }
+    private Object findElement(By by) throws ClassNotFoundException, UiAutomator2Exception, UiObjectNotFoundException {
+        refreshRootAXNode();
 
         if (by instanceof ById) {
             String locator = rewriteIdLocator((ById) by);

--- a/app/src/main/java/io/appium/uiautomator2/handler/Source.java
+++ b/app/src/main/java/io/appium/uiautomator2/handler/Source.java
@@ -36,6 +36,8 @@ import io.appium.uiautomator2.http.IHttpRequest;
 import io.appium.uiautomator2.server.WDStatus;
 import io.appium.uiautomator2.utils.Logger;
 
+import static io.appium.uiautomator2.utils.AXWindowHelpers.refreshRootAXNode;
+
 /**
  * Get page source. Return as string of XML doc
  */
@@ -47,6 +49,7 @@ public class Source extends SafeRequestHandler {
 
     @Override
     protected AppiumResponse safeHandle(IHttpRequest request) {
+        refreshRootAXNode();
         try {
             final Document doc = AccessibilityNodeInfoDumper.asXmlDocument();
             final TransformerFactory tf = TransformerFactory.newInstance();

--- a/app/src/main/java/io/appium/uiautomator2/model/KnownElements.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/KnownElements.java
@@ -57,6 +57,7 @@ public class KnownElements {
                 result.getName();
             } catch (Exception e) {
                 final By by = result.getBy();
+                Logger.debug(String.format("Trying to restore the cached element '%s'", by));
                 Object ui2Object = null;
                 try {
                     if (by instanceof By.ById) {


### PR DESCRIPTION
after more extensive testing it looks like getting the page source itself does not refresh the tree, so it is necessary to call the corresponding method on our own.