### PR TITLE
Update options for /touch/flick endpoint

### DIFF
--- a/app/src/androidTestE2eTest/java/io/appium/uiautomator2/unittest/test/internal/commands/GestureCommands.java
+++ b/app/src/androidTestE2eTest/java/io/appium/uiautomator2/unittest/test/internal/commands/GestureCommands.java
@@ -32,8 +32,8 @@ public class GestureCommands {
      */
     public static Response flickOnPosition() throws JSONException {
         JSONObject jsonObject = new JSONObject();
-        jsonObject.put("xSpeed", 50);
-        jsonObject.put("ySpeed", -180);
+        jsonObject.put("xspeed", 50);
+        jsonObject.put("yspeed", -180);
 
         Response response = Client.post("/touch/flick", jsonObject);
         Logger.info("Flick response:" + response);

--- a/app/src/main/java/io/appium/uiautomator2/handler/Flick.java
+++ b/app/src/main/java/io/appium/uiautomator2/handler/Flick.java
@@ -47,8 +47,8 @@ public class Flick extends SafeRequestHandler {
             end.y = start.y + yoffset;
 
         } else {
-            final Integer xSpeed = Integer.parseInt(payload.getString("xSpeed"));
-            final Integer ySpeed = Integer.parseInt(payload.getString("ySpeed"));
+            final Integer xSpeed = Integer.parseInt(payload.getString("xspeed"));
+            final Integer ySpeed = Integer.parseInt(payload.getString("yspeed"));
 
             final Double speed = Math.min(1250.0,
                     Math.sqrt(xSpeed * xSpeed + ySpeed * ySpeed));


### PR DESCRIPTION
**Reasons:**
1. JsonWireProtocol supports JSON Parameters `xspeed` & `yspeed` as https://github.com/SeleniumHQ/selenium/wiki/JsonWireProtocol#sessionsessionidtouchflick-1
2. Appium-base-driver uses `xspeed` & `yspeed` too as https://github.com/appium/appium-base-driver/blob/master/lib/protocol/routes.js#L280
3. It can compatible when we use automatioName `Appium` or `UiAutomator2`