### PR TITLE
make logging configurable

### DIFF
--- a/app/src/main/java/io/appium/uiautomator2/utils/Logger.java
+++ b/app/src/main/java/io/appium/uiautomator2/utils/Logger.java
@@ -35,27 +35,35 @@ public class Logger {
      * Logger error
      */
     public static void error(Object... messages) {
-        android.util.Log.e(TAG, getString(messages));
+        if (android.util.Log.isLoggable(TAG, android.util.Log.ERROR)) {
+            android.util.Log.e(TAG, getString(messages));
+        }
     }
 
     /**
      * Logger error
      */
     public static void error(String message, Throwable throwable) {
-        android.util.Log.e(TAG, getString(message), throwable);
+        if (android.util.Log.isLoggable(TAG, android.util.Log.ERROR)) {
+            android.util.Log.e(TAG, getString(message), throwable);
+        }
     }
 
     /**
      * Logger info
      */
     public static void info(Object... messages) {
-        android.util.Log.i(TAG, getString(messages));
+        if (android.util.Log.isLoggable(TAG, android.util.Log.INFO)) {
+            android.util.Log.i(TAG, getString(messages));
+        }
     }
 
     /**
      * Logger debug
      */
     public static void debug(Object... messages) {
-        android.util.Log.d(TAG, getString(messages));
+        if (android.util.Log.isLoggable(TAG, android.util.Log.DEBUG)) {
+            android.util.Log.d(TAG, getString(messages));
+        }
     }
 }


### PR DESCRIPTION
the logging level is INFO by default, and can be overridden with setprop or
/data/local.prop file (changing the latter requires rebooting the device)

for details see
https://developer.android.com/reference/android/util/Log#isLoggable(java.lang.String,%20int)

fixes #241 