### PR TITLE
Speed up xpath and source commands

### DIFF
--- a/app/src/main/java/io/appium/uiautomator2/model/UiAutomationElement.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/UiAutomationElement.java
@@ -100,18 +100,16 @@ public class UiAutomationElement extends UiElement<AccessibilityNodeInfo, UiAuto
         this.children = mutableChildren;
     }
 
-    public static UiAutomationElement rebuildForNewRoot(AccessibilityNodeInfo rawElement,
-                                                        @Nullable List<CharSequence> toastMSGs) {
+    public static UiAutomationElement rebuildForNewRoot(AccessibilityNodeInfo rawElement, @Nullable List<CharSequence> toastMSGs) {
         cache.clear();
-
-        UiAutomationElement rootElement = new UiAutomationElement(ROOT_NODE_NAME, rawElement, 0);
+        UiAutomationElement root = new UiAutomationElement(ROOT_NODE_NAME, rawElement, 0);
         if (toastMSGs != null && !toastMSGs.isEmpty()) {
             for (CharSequence toastMSG : toastMSGs) {
                 Logger.debug("Adding toastMSG to root:" + toastMSG);
-                rootElement.addToastMsgToRoot(toastMSG);
+                root.addToastMsgToRoot(toastMSG);
             }
         }
-        return rootElement;
+        return root;
     }
 
     @Nullable
@@ -145,7 +143,7 @@ public class UiAutomationElement extends UiElement<AccessibilityNodeInfo, UiAuto
         node.setPackageName("com.android.settings");
         setField("mSealed", true, node);
 
-        this.children.add(new UiAutomationElement(node, 0));
+        this.children.add(new UiAutomationElement(node, this.children.size()));
     }
 
     private List<UiAutomationElement> buildChildren(AccessibilityNodeInfo node) {

--- a/app/src/main/java/io/appium/uiautomator2/utils/AXWindowHelpers.java
+++ b/app/src/main/java/io/appium/uiautomator2/utils/AXWindowHelpers.java
@@ -24,10 +24,9 @@ import android.view.accessibility.AccessibilityWindowInfo;
 import java.util.ArrayList;
 import java.util.List;
 
+import androidx.annotation.NonNull;
 import io.appium.uiautomator2.common.exceptions.UiAutomator2Exception;
 import io.appium.uiautomator2.core.UiAutomatorBridge;
-import io.appium.uiautomator2.model.NotificationListener;
-import io.appium.uiautomator2.model.UiAutomationElement;
 import io.appium.uiautomator2.model.internal.CustomUiDevice;
 
 public class AXWindowHelpers {
@@ -72,8 +71,6 @@ public class AXWindowHelpers {
                         "getRootAccessibilityNodeInActiveWindow() - ignoring it", e.getMessage()));
             }
             if (root != null) {
-                UiAutomationElement.rebuildForNewRoot(root,
-                        NotificationListener.getInstance().getToastMessage());
                 currentActiveWindowRoot = root;
                 return;
             }
@@ -108,16 +105,12 @@ public class AXWindowHelpers {
             }
             // Prior to API level 21 we can only access the active window
         } else {
-            AccessibilityNodeInfo node = currentActiveWindowRoot();
-            if (node == null) {
-                throw new UiAutomator2Exception("Unable to get Root in Active window," +
-                        " ERROR: null root node returned by UiTestAutomationBridge.");
-            }
-            ret.add(node);
+            ret.add(currentActiveWindowRoot());
         }
         return ret.toArray(new AccessibilityNodeInfo[0]);
     }
 
+    @NonNull
     public static synchronized AccessibilityNodeInfo currentActiveWindowRoot() {
         if (currentActiveWindowRoot == null) {
             refreshRootAXNode();


### PR DESCRIPTION
There is no need to rebuild the UI hierarchy for XML creation, since it is always gets rebuilt before on findElement(s)/source call (inside `refreshRootAXNode`)