### PR TITLE
Avoid NPE on getting session details

### DIFF
--- a/app/src/main/java/io/appium/uiautomator2/handler/GetSessionDetails.java
+++ b/app/src/main/java/io/appium/uiautomator2/handler/GetSessionDetails.java
@@ -1,3 +1,19 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.appium.uiautomator2.handler;
 
 import org.json.JSONException;
@@ -20,12 +36,14 @@ public class GetSessionDetails extends SafeRequestHandler {
     protected AppiumResponse safeHandle(IHttpRequest request) throws JSONException {
         Session session = AppiumUiAutomatorDriver.getInstance().getSession();
         JSONObject result = new JSONObject();
-        AccessibilityScrollData scrollData = session.getLastScrollData();
-        JSONObject lastScrollData = null;
-        if (scrollData != null) {
-            lastScrollData = new JSONObject(scrollData.getAsMap());
+        if (session != null) {
+            AccessibilityScrollData scrollData = session.getLastScrollData();
+            JSONObject lastScrollData = null;
+            if (scrollData != null) {
+                lastScrollData = new JSONObject(scrollData.getAsMap());
+            }
+            result.put("lastScrollData", lastScrollData);
         }
-        result.put("lastScrollData", lastScrollData);
         return new AppiumResponse(getSessionId(request), WDStatus.SUCCESS, result);
     }
 }

--- a/app/src/main/java/io/appium/uiautomator2/handler/GetSessionDetails.java
+++ b/app/src/main/java/io/appium/uiautomator2/handler/GetSessionDetails.java
@@ -38,11 +38,9 @@ public class GetSessionDetails extends SafeRequestHandler {
         JSONObject result = new JSONObject();
         if (session != null) {
             AccessibilityScrollData scrollData = session.getLastScrollData();
-            JSONObject lastScrollData = null;
             if (scrollData != null) {
-                lastScrollData = new JSONObject(scrollData.getAsMap());
+                result.put("lastScrollData", new JSONObject(scrollData.getAsMap()));
             }
-            result.put("lastScrollData", lastScrollData);
         }
         return new AppiumResponse(getSessionId(request), WDStatus.SUCCESS, result);
     }

--- a/app/src/main/java/io/appium/uiautomator2/handler/NewSession.java
+++ b/app/src/main/java/io/appium/uiautomator2/handler/NewSession.java
@@ -1,5 +1,20 @@
-package io.appium.uiautomator2.handler;
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
+package io.appium.uiautomator2.handler;
 
 import org.json.JSONException;
 

--- a/app/src/main/java/io/appium/uiautomator2/model/AppiumUiAutomatorDriver.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/AppiumUiAutomatorDriver.java
@@ -1,8 +1,24 @@
-package io.appium.uiautomator2.model;
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
+package io.appium.uiautomator2.model;
 
 import java.util.UUID;
 
+import androidx.annotation.Nullable;
 
 public class AppiumUiAutomatorDriver {
 
@@ -20,7 +36,6 @@ public class AppiumUiAutomatorDriver {
     }
 
     public String initializeSession() {
-
         if (this.session != null) {
             session.getKnownElements().clear();
             return session.getSessionId();
@@ -29,6 +44,7 @@ public class AppiumUiAutomatorDriver {
         return session.getSessionId();
     }
 
+    @Nullable
     public Session getSession() {
         return session;
     }

--- a/app/src/main/java/io/appium/uiautomator2/model/Session.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/Session.java
@@ -8,6 +8,8 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
+import androidx.annotation.Nullable;
+
 import static io.appium.uiautomator2.model.settings.Settings.ELEMENT_RESPONSE_ATTRIBUTES;
 import static io.appium.uiautomator2.model.settings.Settings.SHOULD_USE_COMPACT_RESPONSES;
 
@@ -63,6 +65,7 @@ public class Session {
         return commandConfiguration.get(command);
     }
 
+    @Nullable
     public AccessibilityScrollData getLastScrollData() {
         return lastScrollData;
     }


### PR DESCRIPTION
Addresses https://github.com/appium/appium/issues/12162

@jlipps There are several other places where getSession is called like this without checking for nullability. I'd better leave it to you to perform the necessary fixes, since the code has to do with AccessibilityScrollData stuff. 