### PR TITLE
Only wait for idle once on find

### DIFF
--- a/app/src/main/java/io/appium/uiautomator2/handler/FindElement.java
+++ b/app/src/main/java/io/appium/uiautomator2/handler/FindElement.java
@@ -58,15 +58,15 @@ public class FindElement extends SafeRequestHandler {
 
     @Override
     protected AppiumResponse safeHandle(IHttpRequest request) throws JSONException, UiObjectNotFoundException {
-        Logger.info("Find element command");
         final JSONObject payload = getPayload(request);
         final String method = payload.getString("strategy");
         final String selector = payload.getString("selector");
         final String contextId = payload.getString("context");
-        Logger.info(String.format("find element command using '%s' with selector '%s'.", method, selector));
+
+        Logger.info(String.format("Find element command using '%s' with selector '%s'.", method, selector));
+
         final By by = new NativeAndroidBySelector().pickFrom(method, selector);
 
-        Device.waitForIdle();
         Object element;
         try {
             if (contextId.length() > 0) {
@@ -92,7 +92,6 @@ public class FindElement extends SafeRequestHandler {
     @Nullable
     private Object findElement(By by) throws UiAutomator2Exception, UiObjectNotFoundException {
         refreshRootAXNode();
-
         if (by instanceof ById) {
             String locator = rewriteIdLocator((ById) by);
             return CustomUiDevice.getInstance().findObject(androidx.test.uiautomator.By.res(locator));

--- a/app/src/main/java/io/appium/uiautomator2/handler/FindElements.java
+++ b/app/src/main/java/io/appium/uiautomator2/handler/FindElements.java
@@ -65,14 +65,15 @@ public class FindElements extends SafeRequestHandler {
     @Override
     protected AppiumResponse safeHandle(IHttpRequest request) throws JSONException, UiObjectNotFoundException {
         JSONArray result = new JSONArray();
-        Logger.info("Find elements command");
         JSONObject payload = getPayload(request);
         String method = payload.getString("strategy");
         String selector = payload.getString("selector");
         final String contextId = payload.getString("context");
-        Logger.info(String.format("find element command using '%s' with selector '%s'.", method, selector));
+
+        Logger.info(String.format("Find elements command using '%s' with selector '%s'.", method, selector));
+
         By by = new NativeAndroidBySelector().pickFrom(method, selector);
-        Device.waitForIdle();
+
         List<Object> elements;
         try {
             if (contextId.length() > 0) {

--- a/app/src/main/java/io/appium/uiautomator2/model/internal/CustomUiDevice.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/internal/CustomUiDevice.java
@@ -125,7 +125,6 @@ public class CustomUiDevice {
     @Nullable
     public Object findObject(Object selector) throws UiAutomator2Exception {
         final AccessibilityNodeInfo node;
-        Device.waitForIdle();
         if (selector instanceof BySelector) {
             node = (AccessibilityNodeInfo) invoke(METHOD_FIND_MATCH, ByMatcherClass,
                     Device.getUiDevice(), selector, getWindowRoots());

--- a/app/src/main/java/io/appium/uiautomator2/utils/Device.java
+++ b/app/src/main/java/io/appium/uiautomator2/utils/Device.java
@@ -12,6 +12,8 @@ import androidx.test.uiautomator.UiSelector;
 import io.appium.uiautomator2.common.exceptions.UiAutomator2Exception;
 import io.appium.uiautomator2.model.AndroidElement;
 import io.appium.uiautomator2.model.By;
+import io.appium.uiautomator2.model.settings.Settings;
+import io.appium.uiautomator2.model.settings.WaitForIdleTimeout;
 import io.appium.uiautomator2.model.UiObject2Element;
 import io.appium.uiautomator2.model.UiObjectElement;
 
@@ -76,12 +78,9 @@ public abstract class Device {
      * https://code.google.com/p/android/issues/detail?id=73297
      */
     public static void waitForIdle() {
-        Logger.info("Waiting for device to be idle");
-        try {
-            getUiDevice().waitForIdle();
-        } catch (Exception e) {
-            Logger.error("Unable wait for AUT to idle");
-        }
+        final WaitForIdleTimeout idleTimeout =
+            (WaitForIdleTimeout) Settings.WAIT_FOR_IDLE_TIMEOUT.getSetting();
+        waitForIdle(idleTimeout.getValue());
     }
 
     public static void waitForIdle(long timeInMS) {

--- a/app/src/main/java/io/appium/uiautomator2/utils/Device.java
+++ b/app/src/main/java/io/appium/uiautomator2/utils/Device.java
@@ -76,6 +76,7 @@ public abstract class Device {
      * https://code.google.com/p/android/issues/detail?id=73297
      */
     public static void waitForIdle() {
+        Logger.info("Waiting for device to be idle");
         try {
             getUiDevice().waitForIdle();
         } catch (Exception e) {
@@ -84,10 +85,11 @@ public abstract class Device {
     }
 
     public static void waitForIdle(long timeInMS) {
+        Logger.info(String.format("Waiting up to %sms for device to be idle", timeInMS));
         try {
             getUiDevice().waitForIdle(timeInMS);
         } catch (Exception e) {
-            Logger.error(String.format("Unable wait %s for AUT to idle", timeInMS));
+            Logger.error(String.format("Unable wait %sms for AUT to idle", timeInMS));
         }
     }
 }


### PR DESCRIPTION
Each `find` called ended up calling `Device.waitForIdle` three times, which is not necessary. Also make use of the `waitForIdleTimeout`.

This has been tested with the `appium-uiautomator2-driver` as well (https://travis-ci.org/appium/appium-uiautomator2-driver/builds/539680318).