### PR TITLE
Make scroll tracking configurable with a cap

### DIFF
--- a/app/src/main/java/io/appium/uiautomator2/core/InteractionController.java
+++ b/app/src/main/java/io/appium/uiautomator2/core/InteractionController.java
@@ -73,7 +73,7 @@ public class InteractionController {
         if (session.hasCapability(TRACK_SCROLL_EVENT_CAP)) {
           try {
               trackScrollEvents = (Boolean) session.getCapability(TRACK_SCROLL_EVENT_CAP);
-              Logger.error("Capability '" + TRACK_SCROLL_EVENT_CAP + "': " + trackScrollEvents);
+              Logger.debug("Capability '" + TRACK_SCROLL_EVENT_CAP + "': " + trackScrollEvents);
           } catch (Exception e) {
               Logger.error("Could not set '" + TRACK_SCROLL_EVENT_CAP + "' from capability: ", e);
               trackScrollEvents = true;
@@ -114,9 +114,9 @@ public class InteractionController {
                     setResult(doTouchUp(x, y));
                 }
             });
-      } else {
-        return doTouchUp(x, y);
-      }
+        } else {
+            return doTouchUp(x, y);
+        }
     }
 
     private boolean doTouchMove(final int x, final int y) {

--- a/app/src/main/java/io/appium/uiautomator2/core/InteractionController.java
+++ b/app/src/main/java/io/appium/uiautomator2/core/InteractionController.java
@@ -20,6 +20,10 @@ import android.view.MotionEvent.PointerCoords;
 
 import io.appium.uiautomator2.common.exceptions.UiAutomator2Exception;
 
+import io.appium.uiautomator2.model.AppiumUIA2Driver;
+import io.appium.uiautomator2.model.Session;
+import io.appium.uiautomator2.utils.Logger;
+
 import static io.appium.uiautomator2.utils.ReflectionUtils.invoke;
 import static io.appium.uiautomator2.utils.ReflectionUtils.method;
 
@@ -32,6 +36,7 @@ public class InteractionController {
     private static final String METHOD_TOUCH_DOWN = "touchDown";
     private static final String METHOD_TOUCH_UP = "touchUp";
     private static final String METHOD_TOUCH_MOVE = "touchMove";
+    private static final String TRACK_SCROLL_EVENT_CAP = "trackScrollEvents";
     private final Object interactionController;
 
     public InteractionController(Object interactionController) {
@@ -62,48 +67,92 @@ public class InteractionController {
         return injectEventSync(event, true);
     }
 
+    public boolean shouldTrackScrollEvents() {
+        Session session = AppiumUIA2Driver.getInstance().getSessionOrThrow();
+        Boolean trackScrollEvents = true;
+        if (session.hasCapability(TRACK_SCROLL_EVENT_CAP)) {
+          try {
+              trackScrollEvents = (Boolean) session.getCapability(TRACK_SCROLL_EVENT_CAP);
+              Logger.error("Capability '" + TRACK_SCROLL_EVENT_CAP + "': " + trackScrollEvents);
+          } catch (Exception e) {
+              Logger.error("Could not set '" + TRACK_SCROLL_EVENT_CAP + "' from capability: ", e);
+              trackScrollEvents = true;
+          }
+        }
+
+        return trackScrollEvents;
+    }
+
+    private boolean doTouchDown(final int x, final int y) {
+        return (Boolean) invoke(method(CLASS_INTERACTION_CONTROLLER,
+                METHOD_TOUCH_DOWN, int.class, int.class), interactionController, x, y);
+    }
+
     public boolean touchDown(final int x, final int y) throws UiAutomator2Exception {
-        return EventRegister.runAndRegisterScrollEvents(new ReturningRunnable<Boolean>() {
-            @Override
-            public void run() {
-                Boolean result = (Boolean) invoke(method(CLASS_INTERACTION_CONTROLLER,
-                        METHOD_TOUCH_DOWN, int.class, int.class), interactionController, x, y);
-                setResult(result);
-            }
-        });
+        if (shouldTrackScrollEvents()) {
+            return EventRegister.runAndRegisterScrollEvents(new ReturningRunnable<Boolean>() {
+                @Override
+                public void run() {
+                    setResult(doTouchDown(x, y));
+                }
+            });
+        } else {
+            return doTouchDown(x, y);
+        }
+    }
+
+    private boolean doTouchUp(final int x, final int y) {
+        return (Boolean) invoke(method(CLASS_INTERACTION_CONTROLLER, METHOD_TOUCH_UP,
+                int.class, int.class), interactionController, x, y);
     }
 
     public boolean touchUp(final int x, final int y) throws UiAutomator2Exception {
-        return EventRegister.runAndRegisterScrollEvents(new ReturningRunnable<Boolean>() {
-            @Override
-            public void run() {
-                Boolean result = (Boolean) invoke(method(CLASS_INTERACTION_CONTROLLER, METHOD_TOUCH_UP,
-                        int.class, int.class), interactionController, x, y);
-                setResult(result);
-            }
-        });
+        if (shouldTrackScrollEvents()) {
+            return EventRegister.runAndRegisterScrollEvents(new ReturningRunnable<Boolean>() {
+                @Override
+                public void run() {
+                    setResult(doTouchUp(x, y));
+                }
+            });
+      } else {
+        return doTouchUp(x, y);
+      }
+    }
+
+    private boolean doTouchMove(final int x, final int y) {
+        return (Boolean) invoke(method(CLASS_INTERACTION_CONTROLLER,
+                METHOD_TOUCH_MOVE, int.class, int.class), interactionController, x, y);
     }
 
     public boolean touchMove(final int x, final int y) throws UiAutomator2Exception {
-        return EventRegister.runAndRegisterScrollEvents(new ReturningRunnable<Boolean>() {
-            @Override
-            public void run() {
-                Boolean result = (Boolean) invoke(method(CLASS_INTERACTION_CONTROLLER,
-                        METHOD_TOUCH_MOVE, int.class, int.class), interactionController, x, y);
-                setResult(result);
-            }
-        });
+        if (shouldTrackScrollEvents()) {
+            return EventRegister.runAndRegisterScrollEvents(new ReturningRunnable<Boolean>() {
+                @Override
+                public void run() {;
+                    setResult(doTouchMove(x, y));
+                }
+            });
+        } else {
+            return doTouchMove(x, y);
+        }
+    }
+
+    private boolean doPerformMultiPointerGesture(final PointerCoords[][] pcs) {
+        return (Boolean) invoke(method(CLASS_INTERACTION_CONTROLLER,
+                METHOD_PERFORM_MULTI_POINTER_GESTURE, PointerCoords[][].class),
+                interactionController, (Object) pcs);
     }
 
     public Boolean performMultiPointerGesture(final PointerCoords[][] pcs) throws UiAutomator2Exception {
-        return EventRegister.runAndRegisterScrollEvents(new ReturningRunnable<Boolean>() {
-            @Override
-            public void run() {
-                Boolean result = (Boolean) invoke(method(CLASS_INTERACTION_CONTROLLER,
-                        METHOD_PERFORM_MULTI_POINTER_GESTURE, PointerCoords[][].class),
-                        interactionController, (Object) pcs);
-                setResult(result);
-            }
-        });
+        if (shouldTrackScrollEvents()) {
+            return EventRegister.runAndRegisterScrollEvents(new ReturningRunnable<Boolean>() {
+                @Override
+                public void run() {
+                    setResult(doPerformMultiPointerGesture(pcs));
+                }
+            });
+        } else {
+            return doPerformMultiPointerGesture(pcs);
+        }
     }
 }

--- a/app/src/main/java/io/appium/uiautomator2/core/InteractionController.java
+++ b/app/src/main/java/io/appium/uiautomator2/core/InteractionController.java
@@ -22,6 +22,8 @@ import io.appium.uiautomator2.common.exceptions.UiAutomator2Exception;
 
 import io.appium.uiautomator2.model.AppiumUIA2Driver;
 import io.appium.uiautomator2.model.Session;
+import io.appium.uiautomator2.model.settings.Settings;
+import io.appium.uiautomator2.model.settings.TrackScrollEvents;
 import io.appium.uiautomator2.utils.Logger;
 
 import static io.appium.uiautomator2.utils.ReflectionUtils.invoke;
@@ -36,7 +38,6 @@ public class InteractionController {
     private static final String METHOD_TOUCH_DOWN = "touchDown";
     private static final String METHOD_TOUCH_UP = "touchUp";
     private static final String METHOD_TOUCH_MOVE = "touchMove";
-    private static final String TRACK_SCROLL_EVENT_CAP = "trackScrollEvents";
     private final Object interactionController;
 
     public InteractionController(Object interactionController) {
@@ -69,16 +70,11 @@ public class InteractionController {
 
     public boolean shouldTrackScrollEvents() {
         Session session = AppiumUIA2Driver.getInstance().getSessionOrThrow();
-        Boolean trackScrollEvents = true;
-        if (session.hasCapability(TRACK_SCROLL_EVENT_CAP)) {
-          try {
-              trackScrollEvents = (Boolean) session.getCapability(TRACK_SCROLL_EVENT_CAP);
-              Logger.debug("Capability '" + TRACK_SCROLL_EVENT_CAP + "': " + trackScrollEvents);
-          } catch (Exception e) {
-              Logger.error("Could not set '" + TRACK_SCROLL_EVENT_CAP + "' from capability: ", e);
-              trackScrollEvents = true;
-          }
-        }
+        final TrackScrollEvents trackScrollEventsSetting =
+                (TrackScrollEvents) Settings.TRACK_SCROLL_EVENTS.getSetting();
+        Boolean trackScrollEvents = (Boolean) trackScrollEventsSetting.getValue();
+        Logger.error(String.format("Setting '%s' is set to %b",
+                trackScrollEventsSetting.getName(), trackScrollEvents));
 
         return trackScrollEvents;
     }
@@ -89,16 +85,14 @@ public class InteractionController {
     }
 
     public boolean touchDown(final int x, final int y) throws UiAutomator2Exception {
-        if (shouldTrackScrollEvents()) {
-            return EventRegister.runAndRegisterScrollEvents(new ReturningRunnable<Boolean>() {
+        return shouldTrackScrollEvents()
+            ? EventRegister.runAndRegisterScrollEvents(new ReturningRunnable<Boolean>() {
                 @Override
                 public void run() {
                     setResult(doTouchDown(x, y));
                 }
-            });
-        } else {
-            return doTouchDown(x, y);
-        }
+            })
+            : doTouchDown(x, y);
     }
 
     private boolean doTouchUp(final int x, final int y) {
@@ -107,16 +101,14 @@ public class InteractionController {
     }
 
     public boolean touchUp(final int x, final int y) throws UiAutomator2Exception {
-        if (shouldTrackScrollEvents()) {
-            return EventRegister.runAndRegisterScrollEvents(new ReturningRunnable<Boolean>() {
+        return shouldTrackScrollEvents()
+            ? EventRegister.runAndRegisterScrollEvents(new ReturningRunnable<Boolean>() {
                 @Override
                 public void run() {
                     setResult(doTouchUp(x, y));
                 }
-            });
-        } else {
-            return doTouchUp(x, y);
-        }
+            })
+            : doTouchUp(x, y);
     }
 
     private boolean doTouchMove(final int x, final int y) {
@@ -125,16 +117,14 @@ public class InteractionController {
     }
 
     public boolean touchMove(final int x, final int y) throws UiAutomator2Exception {
-        if (shouldTrackScrollEvents()) {
-            return EventRegister.runAndRegisterScrollEvents(new ReturningRunnable<Boolean>() {
+        return shouldTrackScrollEvents()
+            ? EventRegister.runAndRegisterScrollEvents(new ReturningRunnable<Boolean>() {
                 @Override
                 public void run() {;
                     setResult(doTouchMove(x, y));
                 }
-            });
-        } else {
-            return doTouchMove(x, y);
-        }
+            })
+            : doTouchMove(x, y);
     }
 
     private boolean doPerformMultiPointerGesture(final PointerCoords[][] pcs) {

--- a/app/src/main/java/io/appium/uiautomator2/model/settings/Settings.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/settings/Settings.java
@@ -31,7 +31,8 @@ public enum Settings {
     WAIT_FOR_IDLE_TIMEOUT(new WaitForIdleTimeout()),
     WAIT_FOR_SELECTOR_TIMEOUT(new WaitForSelectorTimeout()),
     NORMALIZE_TAG_NAMES(new NormalizeTagNames()),
-    SHUTDOWN_ON_POWER_DISCONNECT(new ShutdownOnPowerDisconnect());
+    SHUTDOWN_ON_POWER_DISCONNECT(new ShutdownOnPowerDisconnect()),
+    TRACK_SCROLL_EVENTS(new TrackScrollEvents());
 
     private final ISetting setting;
 

--- a/app/src/main/java/io/appium/uiautomator2/model/settings/TrackScrollEvents.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/settings/TrackScrollEvents.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.appium.uiautomator2.model.settings;
+
+public class TrackScrollEvents extends AbstractSetting<Boolean> {
+    private static final String SETTING_NAME = "trackScrollEvents";
+
+    private boolean value = true;
+
+    public TrackScrollEvents() {
+        super(Boolean.class, SETTING_NAME);
+    }
+
+    @Override
+    public Boolean getValue() {
+        return value;
+    }
+
+    @Override
+    protected void apply(Boolean value) {
+        this.value = value;
+    }
+}


### PR DESCRIPTION
Add `trackScrollEvents ` cap, to configure the tracking of scroll movement. This improves performance of touch actions significantly:

Using a simple touch action:
```js
const action = new wd.TouchAction();
action.press({x: 100, y: 100})
  .wait(100)
  .release();
await driver.performTouchAction(action);
```
- `trackScrollEvents ` set to `true`, averages 1710ms
- `trackScrollEvents` set to `false`, averages 194ms

This could be changed to a setting if it is found to be necessary to switch between configurations mid-session.