### PR TITLE
Improve support for multi windows and add capability "enableMultiWindows"

### DIFF
--- a/app/src/main/java/io/appium/uiautomator2/core/AccessibilityNodeInfoDumper.java
+++ b/app/src/main/java/io/appium/uiautomator2/core/AccessibilityNodeInfoDumper.java
@@ -41,6 +41,7 @@ import java.io.InputStream;
 import java.util.concurrent.Semaphore;
 
 import androidx.annotation.Nullable;
+
 import io.appium.uiautomator2.common.exceptions.InvalidSelectorException;
 import io.appium.uiautomator2.common.exceptions.UiAutomator2Exception;
 import io.appium.uiautomator2.model.NotificationListener;
@@ -52,7 +53,7 @@ import io.appium.uiautomator2.utils.Logger;
 import io.appium.uiautomator2.utils.NodeInfoList;
 
 import static io.appium.uiautomator2.model.UiAutomationElement.rebuildForNewRoot;
-import static io.appium.uiautomator2.utils.AXWindowHelpers.currentActiveWindowRoot;
+import static io.appium.uiautomator2.utils.AXWindowHelpers.getWindowRoots;
 import static io.appium.uiautomator2.utils.XMLHelpers.toNodeName;
 import static io.appium.uiautomator2.utils.XMLHelpers.toSafeString;
 import static net.gcardone.junidecode.Junidecode.unidecode;
@@ -166,8 +167,8 @@ public class AccessibilityNodeInfoDumper {
             serializer.startDocument(XML_ENCODING, true);
             serializer.setFeature("http://xmlpull.org/v1/doc/features.html#indent-output", true);
             final UiElement<?, ?> xpathRoot = root == null
-                    ? rebuildForNewRoot(currentActiveWindowRoot(), NotificationListener.getInstance().getToastMessage())
-                    : rebuildForNewRoot(root, null);
+                    ? rebuildForNewRoot(getWindowRoots(), NotificationListener.getInstance().getToastMessage())
+                    : rebuildForNewRoot(new AccessibilityNodeInfo[]{root}, null);
             serializeUiElement(xpathRoot, 0);
             serializer.endDocument();
             Logger.debug(String.format("The source XML tree (%s bytes) has been fetched in %sms",

--- a/app/src/main/java/io/appium/uiautomator2/model/CustomUiSelector.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/CustomUiSelector.java
@@ -21,7 +21,7 @@ import android.view.accessibility.AccessibilityNodeInfo;
 import androidx.test.uiautomator.UiSelector;
 import io.appium.uiautomator2.utils.Attribute;
 
-import static io.appium.uiautomator2.utils.AXWindowHelpers.currentActiveWindowRoot;
+import static io.appium.uiautomator2.utils.AXWindowHelpers.getWindowRoots;
 
 public class CustomUiSelector {
     private UiSelector selector;
@@ -35,10 +35,7 @@ public class CustomUiSelector {
      * @return UiSelector object, based on UiAutomationElement attributes
      */
     public UiSelector getUiSelector(AccessibilityNodeInfo node) {
-        UiAutomationElement uiAutomationElement = UiAutomationElement.getCachedElement(node, currentActiveWindowRoot());
-        if (uiAutomationElement == null) {
-            throw new IllegalArgumentException(String.format("The '%s' node is not found in the cache", node));
-        }
+        UiAutomationElement uiAutomationElement = getCachedElement(node);
         put(Attribute.PACKAGE, uiAutomationElement.getPackageName());
         put(Attribute.CLASS, uiAutomationElement.getClassName());
         // For proper selector matching it is important to not replace nulls with empty strings
@@ -58,6 +55,18 @@ public class CustomUiSelector {
         put(Attribute.INDEX, uiAutomationElement.getIndex());
 
         return selector;
+    }
+
+    private static UiAutomationElement getCachedElement(AccessibilityNodeInfo node) {
+        UiAutomationElement uiAutomationElement = UiAutomationElement.getCachedElement(node);
+        if (uiAutomationElement == null) {
+            UiAutomationElement.rebuildForNewRoot(getWindowRoots(), null);
+        }
+        uiAutomationElement = UiAutomationElement.getCachedElement(node);
+        if (uiAutomationElement == null) {
+            throw new IllegalArgumentException(String.format("The '%s' node is not found in the cache", node));
+        }
+        return uiAutomationElement;
     }
 
     private void put(Attribute key, Object value) {

--- a/app/src/main/java/io/appium/uiautomator2/model/settings/EnableMultiWindows.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/settings/EnableMultiWindows.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.appium.uiautomator2.model.settings;
+
+import io.appium.uiautomator2.model.AppiumUIA2Driver;
+import io.appium.uiautomator2.utils.Logger;
+
+public class EnableMultiWindows extends AbstractSetting<Boolean> {
+
+    private static final String SETTING_NAME = "enableMultiWindows";
+
+    public EnableMultiWindows() {
+        super(Boolean.class, SETTING_NAME);
+    }
+
+    @Override
+    public Boolean getValue() {
+        return AppiumUIA2Driver.getInstance()
+                .getSessionOrThrow()
+                .getCapability(getName(), false);
+    }
+
+    @Override
+    protected void apply(Boolean multiWindowsEnabled) {
+        Logger.debug("Dummy setting. Maintained in Session.capabilities.");
+        AppiumUIA2Driver
+                .getInstance()
+                .getSessionOrThrow()
+                .setCapability(getName(), multiWindowsEnabled);
+    }
+
+}

--- a/app/src/main/java/io/appium/uiautomator2/model/settings/Settings.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/settings/Settings.java
@@ -24,6 +24,7 @@ public enum Settings {
     ALLOW_INVISIBLE_ELEMENTS(new AllowInvisibleElements()),
     COMPRESSED_LAYOUT_HIERARCHY(new CompressedLayoutHierarchy()),
     ELEMENT_RESPONSE_ATTRIBUTES(new ElementResponseAttributes()),
+    ENABLE_MULTI_WINDOWS(new EnableMultiWindows()),
     ENABLE_NOTIFICATION_LISTENER(new EnableNotificationListener()),
     KEY_INJECTION_DELAY(new KeyInjectionDelay()),
     SCROLL_ACKNOWLEDGMENT_TIMEOUT(new ScrollAcknowledgmentTimeout()),

--- a/app/src/main/java/io/appium/uiautomator2/utils/AXWindowHelpers.java
+++ b/app/src/main/java/io/appium/uiautomator2/utils/AXWindowHelpers.java
@@ -27,11 +27,13 @@ import java.util.List;
 import androidx.annotation.NonNull;
 import io.appium.uiautomator2.common.exceptions.UiAutomator2Exception;
 import io.appium.uiautomator2.core.UiAutomatorBridge;
+import io.appium.uiautomator2.model.AppiumUIA2Driver;
 import io.appium.uiautomator2.model.internal.CustomUiDevice;
+
+import static io.appium.uiautomator2.model.settings.Settings.ENABLE_MULTI_WINDOWS;
 
 public class AXWindowHelpers {
     public static final long AX_ROOT_RETRIEVAL_TIMEOUT = 10000;
-    private static final boolean MULTI_WINDOW = false;
     private static AccessibilityNodeInfo currentActiveWindowRoot = null;
 
     /**
@@ -85,13 +87,20 @@ public class AXWindowHelpers {
      */
     public static AccessibilityNodeInfo[] getWindowRoots() {
         List<AccessibilityNodeInfo> ret = new ArrayList<>();
+
         /*
-         * TODO: MULTI_WINDOW is disabled, UIAutomatorViewer captures active window properties and
-         * end users always relay on UIAutomatorViewer while writing tests.
+         * TODO: MULTI_WINDOW is disabled by default, UIAutomatorViewer captures active window
+         * properties and end users always relay on UIAutomatorViewer while writing tests.
          * If we enable MULTI_WINDOW it effects end users.
          * https://code.google.com/p/android/issues/detail?id=207569
          */
-        if (CustomUiDevice.getInstance().getApiLevelActual() >= Build.VERSION_CODES.LOLLIPOP && MULTI_WINDOW) {
+
+        boolean multiWindowsEnabled = AppiumUIA2Driver
+                .getInstance()
+                .getSessionOrThrow()
+                .getCapability(ENABLE_MULTI_WINDOWS.toString(), false);
+
+        if (CustomUiDevice.getInstance().getApiLevelActual() >= Build.VERSION_CODES.LOLLIPOP && multiWindowsEnabled) {
             // Support multi-window searches for API level 21 and up
             for (AccessibilityWindowInfo window : CustomUiDevice.getInstance().getInstrumentation()
                     .getUiAutomation().getWindows()) {


### PR DESCRIPTION
## Motivation

This PR is initially to resolve an issue with `android.widget.PopupWindow`, where appium cannot interact with a PopupWindow which is not *focusable* (because it is not made the current window).
Also see [UIAutomator not able to access android.widget.PopupWindow](https://issuetracker.google.com/issues/37017411)


## Changes

- Use `getWindowRoots()` instead of `currentActiveWindowRoot()` wherever possible
- Add capability `enableMultiWindows` to enable multi windows. It was previously hardcoded as disabled because of [UiAutomatorViewer should Support multi-window to make it compatible with UiAutomator V2](https://issuetracker.google.com/issues/37095166)
- The capability is `false` by default, so no behavior change by default.

## Tests

- No new automated tests (advice welcome if needed)
- Ran existing tests
- Manually tested with appium desktop and option enabled/disabled
