### PR TITLE
feat: update gradle version and test libraries

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         maven { url 'https://jitpack.io' }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.4.2'
+        classpath 'com.android.tools.build:gradle:3.5.2'
         classpath 'com.github.JakeWharton:sdk-manager-plugin:0ce4cdf08009d79223850a59959d9d6e774d0f77'
         classpath 'de.mobilej.unmock:UnMockPlugin:0.6.4'
     }
@@ -73,8 +73,8 @@ unMock {
 dependencies {
     implementation fileTree(include: ['*.jar'], dir: 'libs')
     implementation 'androidx.test.uiautomator:uiautomator:2.2.0'
-    implementation 'androidx.test:core:1.1.0'
-    implementation 'androidx.test:runner:1.1.1'
+    implementation 'androidx.test:core:1.2.0'
+    implementation 'androidx.test:runner:1.2.0'
     implementation 'com.jayway.jsonpath:json-path:0.8.1'
     implementation 'com.squareup.okhttp:okhttp:2.5.0'
     implementation 'commons-io:commons-io:2.6'
@@ -90,7 +90,7 @@ dependencies {
     testImplementation 'org.powermock:powermock-module-junit4-rule:1.7.4'
     testImplementation 'org.powermock:powermock-module-junit4:1.7.4'
     testImplementation 'org.robolectric:robolectric:4.0.2'
-    androidTestImplementation 'androidx.test.espresso:espresso-web:3.1.1'
+    androidTestImplementation 'androidx.test.espresso:espresso-web:3.2.0'
     androidTestImplementation 'androidx.test.uiautomator:uiautomator:2.2.0'
     androidTestImplementation 'junit:junit:4.12'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.4.2'
+        classpath 'com.android.tools.build:gradle:3.5.2'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.1.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip


### PR DESCRIPTION
Let me update grade and test library's versions
This should not break anything.

----

note:

From targetSdkVersion 29, `NetworkInfo` was marked as deprecated. So, we should update them before Android 11.
https://github.com/appium/appium-uiautomator2-server/compare/master...KazuCocoa:update-for-api-level29?expand=1