### PR TITLE
fix: Limit the maximum size of logged responses

### DIFF
--- a/app/src/main/java/io/appium/uiautomator2/common/exceptions/CompressScreenshotException.java
+++ b/app/src/main/java/io/appium/uiautomator2/common/exceptions/CompressScreenshotException.java
@@ -19,9 +19,13 @@ package io.appium.uiautomator2.common.exceptions;
 import android.graphics.Bitmap;
 
 public class CompressScreenshotException extends TakeScreenshotException {
-    private static final String message = "Screenshot cannot be compressed to %s format";
+    private static final String MESSAGE = "Screenshot cannot be compressed to %s format";
 
     public CompressScreenshotException(Bitmap.CompressFormat format) {
-        super(String.format(message, format));
+        super(String.format(MESSAGE, format));
+    }
+
+    public CompressScreenshotException(Bitmap.CompressFormat format, Throwable cause) {
+        super(String.format(MESSAGE, format), cause);
     }
 }

--- a/app/src/main/java/io/appium/uiautomator2/common/exceptions/TakeScreenshotException.java
+++ b/app/src/main/java/io/appium/uiautomator2/common/exceptions/TakeScreenshotException.java
@@ -19,8 +19,15 @@ package io.appium.uiautomator2.common.exceptions;
 import io.netty.handler.codec.http.HttpResponseStatus;
 
 public class TakeScreenshotException extends UiAutomator2Exception {
+    private static final String DEFAULT_MESSAGE =
+            "Failed to capture a screenshot. Does the current view have 'secure' flag set?";
+
     public TakeScreenshotException() {
-        super("Failed to capture a screenshot. Does the current view have 'secure' flag set?");
+        super(DEFAULT_MESSAGE);
+    }
+
+    public TakeScreenshotException(String message, Throwable cause) {
+        super(message, cause);
     }
 
     public TakeScreenshotException(String message) {

--- a/app/src/main/java/io/appium/uiautomator2/http/AppiumResponse.java
+++ b/app/src/main/java/io/appium/uiautomator2/http/AppiumResponse.java
@@ -30,6 +30,7 @@ import io.appium.uiautomator2.utils.Logger;
 import io.netty.handler.codec.http.HttpResponseStatus;
 
 import static io.appium.uiautomator2.utils.JSONUtils.formatNull;
+import static org.apache.commons.lang.StringUtils.abbreviate;
 
 public class AppiumResponse {
     private final Object value;
@@ -67,13 +68,14 @@ public class AppiumResponse {
         response.setContentType("application/json");
         response.setEncoding(StandardCharsets.UTF_8);
         response.setStatus(getHttpStatus().code());
-        JSONObject o = new JSONObject();
         try {
+            JSONObject o = new JSONObject();
             o.put("sessionId", formatNull(sessionId));
-            o.put("value",
-                    (value instanceof Throwable) ? formatException((Throwable) value) : formatNull(value));
+            o.put("value", (value instanceof Throwable)
+                    ? formatException((Throwable) value)
+                    : formatNull(value));
             final String responseString = o.toString();
-            Logger.info(String.format("AppiumResponse: %s", responseString));
+            Logger.info(String.format("AppiumResponse: %s", abbreviate(responseString, 300)));
             response.setContent(responseString);
         } catch (JSONException e) {
             Logger.error("Unable to create JSON Object", e);

--- a/app/src/main/java/io/appium/uiautomator2/utils/ScreenshotHelper.java
+++ b/app/src/main/java/io/appium/uiautomator2/utils/ScreenshotHelper.java
@@ -137,11 +137,14 @@ public class ScreenshotHelper {
     }
 
     private static byte[] compress(final Bitmap bitmap) throws TakeScreenshotException {
-        final ByteArrayOutputStream stream = new ByteArrayOutputStream();
-        if (!bitmap.compress(PNG, 100, stream)) {
-            throw new CompressScreenshotException(PNG);
+        try (final ByteArrayOutputStream stream = new ByteArrayOutputStream()) {
+            if (!bitmap.compress(PNG, 100, stream)) {
+                throw new CompressScreenshotException(PNG);
+            }
+            return stream.toByteArray();
+        } catch (IOException e) {
+            throw new CompressScreenshotException(PNG, e);
         }
-        return stream.toByteArray();
     }
 
     private static Bitmap crop(Bitmap bitmap, Rect cropArea) throws CropScreenshotException {


### PR DESCRIPTION
There is no need to log the whole response value (especially if it is some long base64-encoded image)