### PR TITLE
fix: Avoid throwing exceptions for UiObject selectors containing methods like scrollToEnd

### DIFF
--- a/app/src/main/java/io/appium/uiautomator2/utils/UiExpressionParser.java
+++ b/app/src/main/java/io/appium/uiautomator2/utils/UiExpressionParser.java
@@ -57,7 +57,7 @@ abstract class UiExpressionParser<T, U> {
     }
 
     @SuppressWarnings("unchecked")
-    protected void consumeConstructor() throws UiSelectorSyntaxException,
+    protected T consumeConstructor() throws UiSelectorSyntaxException,
             UiObjectNotFoundException {
         skipLeadingSpaces();
         final String constructorExpression = getConstructorExpression();
@@ -76,6 +76,7 @@ abstract class UiExpressionParser<T, U> {
             throw new UiAutomator2Exception("Can not create instance of " +
                     clazz.getSimpleName(), e);
         }
+        return target;
     }
 
     protected void consumePeriod() throws UiSelectorSyntaxException {

--- a/app/src/test/java/io/appium/uiautomator2/utils/UiScrollableParserTests.java
+++ b/app/src/test/java/io/appium/uiautomator2/utils/UiScrollableParserTests.java
@@ -197,15 +197,6 @@ public class UiScrollableParserTests {
     }
 
     @Test
-    public void shouldThrowExceptionIfLastMethodDoesNotReturnUiObject() throws
-            UiSelectorSyntaxException, UiObjectNotFoundException {
-        expectedException.expect(UiSelectorSyntaxException.class);
-        expectedException.expectMessage("Last method called on a UiScrollable object must return " +
-                "a UiObject object");
-        new UiScrollableParserSpy("new UiScrollable(new UiSelector()).scrollForward(5)").parse();
-    }
-
-    @Test
     public void shouldReThrowUiObjectNotFoundException() throws UiSelectorSyntaxException,
             UiObjectNotFoundException {
         expectedException.expect(UiObjectNotFoundException.class);

--- a/app/src/test/java/io/appium/uiautomator2/utils/UiScrollableParserTests.java
+++ b/app/src/test/java/io/appium/uiautomator2/utils/UiScrollableParserTests.java
@@ -90,6 +90,15 @@ public class UiScrollableParserTests {
     }
 
     @Test
+    public void shouldBeAbleToParseUiSelectorInConstructorIfTheFinalMethodDoesNotReturnUiObject()
+            throws UiSelectorSyntaxException, UiObjectNotFoundException {
+        new UiScrollableParserSpy("new UiScrollable(new UiSelector().text(\"test\"))" +
+                ".scrollToEnd(20)").parse();
+        UiSelector expectedUiScrollableSelector = new UiSelector().text("test");
+        assertEquals(expectedUiScrollableSelector, uiScrollableSpy.getSelector());
+    }
+
+    @Test
     public void shouldBeAbleToChainUiScrollableMethods() throws UiSelectorSyntaxException,
             UiObjectNotFoundException {
         final String locator = "new UiScrollable(new UiSelector()).setAsHorizontalList()" +
@@ -232,9 +241,9 @@ public class UiScrollableParserTests {
         }
 
         @Override
-        protected void consumeConstructor() throws UiSelectorSyntaxException,
+        protected UiScrollable consumeConstructor() throws UiSelectorSyntaxException,
                 UiObjectNotFoundException {
-            super.consumeConstructor();
+            UiScrollable self = super.consumeConstructor();
             uiScrollableSpy = spy(getTarget());
             doReturn(true).when(uiScrollableSpy).scrollIntoView(any(UiSelector.class));
             doReturn(true).when(uiScrollableSpy).scrollIntoView(any(UiObject.class));
@@ -244,6 +253,7 @@ public class UiScrollableParserTests {
                     .getChildByText(any(UiSelector.class), anyString());
             doReturn(true).when(uiScrollableSpy).scrollForward(anyInt());
             setTarget(uiScrollableSpy);
+            return self;
         }
 
         @Override


### PR DESCRIPTION
https://github.com/appium/appium/issues/4733