### PR TITLE
feat: Add mjpeg [screen] streaming

### DIFF
--- a/app/src/androidTestE2eTest/java/io/appium/uiautomator2/unittest/test/DeviceCommandsTest.java
+++ b/app/src/androidTestE2eTest/java/io/appium/uiautomator2/unittest/test/DeviceCommandsTest.java
@@ -69,12 +69,18 @@ import static org.junit.Assert.assertTrue;
 
 @SuppressWarnings("JavaDoc")
 public class DeviceCommandsTest extends BaseTest {
-
     /**
      * Test for findElement
+     *
+     * While working on PR #340 to: `appium:appium-uiautomator2-server` we were
+     * seeing this test fail consistently on API-26. Ultimately we confirmed
+     * that it was a test-ordering issue. By prefixing the test-case w/ `"zzz"`
+     * we forced it to be run first which produced consistent result(s)
+     *
+     * TODO: Figure out test state ordering issue
      */
     @Test
-    public void findElementTest() {
+    public void zzzFindElementTest() {
         By by = By.xpath("//*[@text='API Demos']");
         Response response = findElement(by);
         assertTrue(by + " should be found", response.isSuccessful());

--- a/app/src/androidTestServer/java/io/appium/uiautomator2/server/test/AppiumUiAutomator2Server.java
+++ b/app/src/androidTestServer/java/io/appium/uiautomator2/server/test/AppiumUiAutomator2Server.java
@@ -27,6 +27,7 @@ public class AppiumUiAutomator2Server {
             try {
                 while (!serverInstrumentation.isServerStopped()) {
                     SystemClock.sleep(1000);
+                    serverInstrumentation.startMjpegServer();
                     serverInstrumentation.startServer();
                 }
             } catch (SessionRemovedException e) {

--- a/app/src/main/java/io/appium/uiautomator2/model/settings/MjpegBilinearFiltering.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/settings/MjpegBilinearFiltering.java
@@ -16,22 +16,37 @@
 
 package io.appium.uiautomator2.model.settings;
 
+import io.appium.uiautomator2.common.exceptions.InvalidArgumentException;
 import io.appium.uiautomator2.server.ServerConfig;
 
-public class MjpegFiltering extends AbstractSetting<Boolean> {
-    private static final String SETTING_NAME = "mjpegFiltering";
+/**
+ * Controls whether or not to apply bilinear filtering to source screenshot
+ * resize algorithm. Enabling this flag may improve the quality of the resulting
+ * scaled bitmap, but will introduce a [small] performance hit.
+ *
+ * Type: `Boolean`
+ * Acceptable values: `false`|`true`
+ * Default value: `false`
+ */
+public class MjpegBilinearFiltering extends AbstractSetting<Boolean> {
+    public static final String SETTING_NAME = "mjpegBilinearFiltering";
 
-    public MjpegFiltering() {
+    public MjpegBilinearFiltering() {
         super(Boolean.class, SETTING_NAME);
     }
 
     @Override
     public Boolean getValue() {
-        return ServerConfig.getMjpegFiltering();
+        return ServerConfig.isMjpegBilinearFiltering();
     }
 
     @Override
     protected void apply(Boolean value) {
-        ServerConfig.setMjpegFiltering(value);
+        if (value == null) {
+            throw new InvalidArgumentException(String.format(
+                "Invalid %s value specified, must be false|true. null was given",
+                SETTING_NAME));
+        }
+        ServerConfig.setMjpegBilinearFiltering(value);
     }
 }

--- a/app/src/main/java/io/appium/uiautomator2/model/settings/MjpegFiltering.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/settings/MjpegFiltering.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.appium.uiautomator2.model.settings;
+
+import io.appium.uiautomator2.server.ServerConfig;
+
+public class MjpegFiltering extends AbstractSetting<Boolean> {
+    private static final String SETTING_NAME = "mjpegFiltering";
+
+    public MjpegFiltering() {
+        super(Boolean.class, SETTING_NAME);
+    }
+
+    @Override
+    public Boolean getValue() {
+        return ServerConfig.getMjpegFiltering();
+    }
+
+    @Override
+    protected void apply(Boolean value) {
+        ServerConfig.setMjpegFiltering(value);
+    }
+}

--- a/app/src/main/java/io/appium/uiautomator2/model/settings/MjpegScalingFactor.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/settings/MjpegScalingFactor.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.appium.uiautomator2.model.settings;
+
+import io.appium.uiautomator2.server.ServerConfig;
+
+public class MjpegScalingFactor extends AbstractSetting<Integer> {
+    private static final String SETTING_NAME = "mjpegScalingFactor";
+
+    public MjpegScalingFactor() {
+        super(Integer.class, SETTING_NAME);
+    }
+
+    @Override
+    public Integer getValue() {
+        return ServerConfig.getMjpegScalingFactor();
+    }
+
+    @Override
+    protected void apply(Integer value) {
+        ServerConfig.setMjpegScalingFactor(value);
+    }
+}

--- a/app/src/main/java/io/appium/uiautomator2/model/settings/MjpegScalingFactor.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/settings/MjpegScalingFactor.java
@@ -16,10 +16,20 @@
 
 package io.appium.uiautomator2.model.settings;
 
+import io.appium.uiautomator2.common.exceptions.InvalidArgumentException;
 import io.appium.uiautomator2.server.ServerConfig;
 
+/**
+ * Controls the scaling factor of streamed screenshots. 100 means no scaling is
+ * applied (e.g. 100% of the original size). The bigger image size is the more
+ * CPU performance is needed to encode it.
+ *
+ * Type: `Integer`
+ * Acceptable range: `1` to `100`
+ * Default value: `50`
+ */
 public class MjpegScalingFactor extends AbstractSetting<Integer> {
-    private static final String SETTING_NAME = "mjpegScalingFactor";
+    public static final String SETTING_NAME = "mjpegScalingFactor";
 
     public MjpegScalingFactor() {
         super(Integer.class, SETTING_NAME);
@@ -32,6 +42,13 @@ public class MjpegScalingFactor extends AbstractSetting<Integer> {
 
     @Override
     protected void apply(Integer value) {
+        if (value == null || value < 1 || value > 100) {
+            throw new InvalidArgumentException(String.format(
+                "Invalid %s value specified, must be in range 1..100. %s was given",
+                SETTING_NAME,
+                value
+            ));
+        }
         ServerConfig.setMjpegScalingFactor(value);
     }
 }

--- a/app/src/main/java/io/appium/uiautomator2/model/settings/MjpegServerFramerate.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/settings/MjpegServerFramerate.java
@@ -16,10 +16,20 @@
 
 package io.appium.uiautomator2.model.settings;
 
+import io.appium.uiautomator2.common.exceptions.InvalidArgumentException;
 import io.appium.uiautomator2.server.ServerConfig;
 
+/**
+ * Controls the framerate of streamed screenshots. Greater framerate values
+ * create greater CPU load. That actual maximum framerate value is limited by
+ * the performance of the device under test.
+ *
+ * Type: `Integer`
+ * Acceptable range: `1` to `60`
+ * Default value: `10`
+ */
 public class MjpegServerFramerate extends AbstractSetting<Integer> {
-    private static final String SETTING_NAME = "mjpegServerFramerate";
+    public static final String SETTING_NAME = "mjpegServerFramerate";
 
     public MjpegServerFramerate() {
         super(Integer.class, SETTING_NAME);
@@ -32,6 +42,13 @@ public class MjpegServerFramerate extends AbstractSetting<Integer> {
 
     @Override
     protected void apply(Integer value) {
+        if (value == null || value < 1 || value > 60) {
+            throw new InvalidArgumentException(String.format(
+                "Invalid %s value specified, must be in range 1..60. %s was given",
+                SETTING_NAME,
+                value
+            ));
+        }
         ServerConfig.setMjpegServerFramerate(value);
     }
 }

--- a/app/src/main/java/io/appium/uiautomator2/model/settings/MjpegServerFramerate.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/settings/MjpegServerFramerate.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.appium.uiautomator2.model.settings;
+
+import io.appium.uiautomator2.server.ServerConfig;
+
+public class MjpegServerFramerate extends AbstractSetting<Integer> {
+    private static final String SETTING_NAME = "mjpegServerFramerate";
+
+    public MjpegServerFramerate() {
+        super(Integer.class, SETTING_NAME);
+    }
+
+    @Override
+    public Integer getValue() {
+        return ServerConfig.getMjpegServerFramerate();
+    }
+
+    @Override
+    protected void apply(Integer value) {
+        ServerConfig.setMjpegServerFramerate(value);
+    }
+}

--- a/app/src/main/java/io/appium/uiautomator2/model/settings/MjpegServerPort.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/settings/MjpegServerPort.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.appium.uiautomator2.model.settings;
+
+import io.appium.uiautomator2.server.ServerConfig;
+
+public class MjpegServerPort extends AbstractSetting<Integer> {
+    private static final String SETTING_NAME = "mjpegServerPort";
+
+    public MjpegServerPort() {
+        super(Integer.class, SETTING_NAME);
+    }
+
+    @Override
+    public Integer getValue() {
+        return ServerConfig.getMjpegServerPort();
+    }
+
+    @Override
+    protected void apply(Integer value) {
+        ServerConfig.setMjpegServerPort(value);
+    }
+}

--- a/app/src/main/java/io/appium/uiautomator2/model/settings/MjpegServerPort.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/settings/MjpegServerPort.java
@@ -16,10 +16,18 @@
 
 package io.appium.uiautomator2.model.settings;
 
+import io.appium.uiautomator2.common.exceptions.InvalidArgumentException;
 import io.appium.uiautomator2.server.ServerConfig;
 
+/**
+ * Controls the MJPEG server port
+ *
+ * Type: `Integer`
+ * Acceptable range: `1024` to `65535`
+ * Default value: `7810`
+ */
 public class MjpegServerPort extends AbstractSetting<Integer> {
-    private static final String SETTING_NAME = "mjpegServerPort";
+    public static final String SETTING_NAME = "mjpegServerPort";
 
     public MjpegServerPort() {
         super(Integer.class, SETTING_NAME);
@@ -32,6 +40,13 @@ public class MjpegServerPort extends AbstractSetting<Integer> {
 
     @Override
     protected void apply(Integer value) {
+        if (value == null || value < 1024 || value > 65535) {
+            throw new InvalidArgumentException(String.format(
+                "Invalid %s value specified, must be in range 1024..65535. %s was given",
+                SETTING_NAME,
+                value
+            ));
+        }
         ServerConfig.setMjpegServerPort(value);
     }
 }

--- a/app/src/main/java/io/appium/uiautomator2/model/settings/MjpegServerScreenshotQuality.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/settings/MjpegServerScreenshotQuality.java
@@ -16,10 +16,23 @@
 
 package io.appium.uiautomator2.model.settings;
 
+import io.appium.uiautomator2.common.exceptions.InvalidArgumentException;
 import io.appium.uiautomator2.server.ServerConfig;
 
+/**
+ * Controls the quality of streamed screenshots. Where the best quality is 100
+ * and the worst is 1. The greater the value is the more CPU time is needed to
+ * encode a single bitmap into JPEG format. Usually a value between 25 and 90 is
+ * fine for this setting. Greater values affect performance too much without
+ * visible quality improvements and lower ones introduce visible distortions
+ * into the resulting image.
+ *
+ * Type: `Integer`
+ * Acceptable range: `1` to `100`
+ * Default value: `50`
+ */
 public class MjpegServerScreenshotQuality extends AbstractSetting<Integer> {
-    private static final String SETTING_NAME = "mjpegServerScreenshotQuality";
+    public static final String SETTING_NAME = "mjpegServerScreenshotQuality";
 
     public MjpegServerScreenshotQuality() {
         super(Integer.class, SETTING_NAME);
@@ -32,6 +45,13 @@ public class MjpegServerScreenshotQuality extends AbstractSetting<Integer> {
 
     @Override
     protected void apply(Integer value) {
+        if (value == null || value < 1 || value > 100) {
+            throw new InvalidArgumentException(String.format(
+                "Invalid %s value specified, must be in range 1..100. %s was given",
+                SETTING_NAME,
+                value
+            ));
+        }
         ServerConfig.setMjpegServerScreenshotQuality(value);
     }
 }

--- a/app/src/main/java/io/appium/uiautomator2/model/settings/MjpegServerScreenshotQuality.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/settings/MjpegServerScreenshotQuality.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.appium.uiautomator2.model.settings;
+
+import io.appium.uiautomator2.server.ServerConfig;
+
+public class MjpegServerScreenshotQuality extends AbstractSetting<Integer> {
+    private static final String SETTING_NAME = "mjpegServerScreenshotQuality";
+
+    public MjpegServerScreenshotQuality() {
+        super(Integer.class, SETTING_NAME);
+    }
+
+    @Override
+    public Integer getValue() {
+        return ServerConfig.getMjpegServerScreenshotQuality();
+    }
+
+    @Override
+    protected void apply(Integer value) {
+        ServerConfig.setMjpegServerScreenshotQuality(value);
+    }
+}

--- a/app/src/main/java/io/appium/uiautomator2/model/settings/ServerPort.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/settings/ServerPort.java
@@ -16,10 +16,18 @@
 
 package io.appium.uiautomator2.model.settings;
 
+import io.appium.uiautomator2.common.exceptions.InvalidArgumentException;
 import io.appium.uiautomator2.server.ServerConfig;
 
+/**
+ * Controls the server port
+ *
+ * Type: `Integer`
+ * Acceptable range: `1024` to `65535`
+ * Default value: `6790`
+ */
 public class ServerPort extends AbstractSetting<Integer> {
-    private static final String SETTING_NAME = "serverPort";
+    public static final String SETTING_NAME = "serverPort";
 
     public ServerPort() {
         super(Integer.class, SETTING_NAME);
@@ -32,6 +40,13 @@ public class ServerPort extends AbstractSetting<Integer> {
 
     @Override
     protected void apply(Integer value) {
+        if (value == null || value < 1024 || value > 65535) {
+            throw new InvalidArgumentException(String.format(
+                "Invalid %s value specified, must be in range 1024..65535. %s was given",
+                SETTING_NAME,
+                value
+            ));
+        }
         ServerConfig.setServerPort(value);
     }
 }

--- a/app/src/main/java/io/appium/uiautomator2/model/settings/ServerPort.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/settings/ServerPort.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.appium.uiautomator2.model.settings;
+
+import io.appium.uiautomator2.server.ServerConfig;
+
+public class ServerPort extends AbstractSetting<Integer> {
+    private static final String SETTING_NAME = "serverPort";
+
+    public ServerPort() {
+        super(Integer.class, SETTING_NAME);
+    }
+
+    @Override
+    public Integer getValue() {
+        return ServerConfig.getServerPort();
+    }
+
+    @Override
+    protected void apply(Integer value) {
+        ServerConfig.setServerPort(value);
+    }
+}

--- a/app/src/main/java/io/appium/uiautomator2/model/settings/Settings.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/settings/Settings.java
@@ -34,7 +34,13 @@ public enum Settings {
     NORMALIZE_TAG_NAMES(new NormalizeTagNames()),
     SHUTDOWN_ON_POWER_DISCONNECT(new ShutdownOnPowerDisconnect()),
     TRACK_SCROLL_EVENTS(new TrackScrollEvents()),
-    WAKE_LOCK_TIMEOUT(new WakeLockTimeout());
+    WAKE_LOCK_TIMEOUT(new WakeLockTimeout()),
+    SERVER_PORT(new ServerPort()),
+    MJPEG_SERVER_PORT(new MjpegServerPort()),
+    MJPEG_SERVER_FRAMERATE(new MjpegServerFramerate()),
+    MJPEG_SCALING_FACTOR(new MjpegScalingFactor()),
+    MJPEG_SERVER_SCREENSHOT_QUALITY(new MjpegServerScreenshotQuality()),
+    MJPEG_FILTERING(new MjpegFiltering());
 
     private final ISetting setting;
 

--- a/app/src/main/java/io/appium/uiautomator2/model/settings/Settings.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/settings/Settings.java
@@ -40,7 +40,7 @@ public enum Settings {
     MJPEG_SERVER_FRAMERATE(new MjpegServerFramerate()),
     MJPEG_SCALING_FACTOR(new MjpegScalingFactor()),
     MJPEG_SERVER_SCREENSHOT_QUALITY(new MjpegServerScreenshotQuality()),
-    MJPEG_FILTERING(new MjpegFiltering());
+    MJPEG_BILINEAR_FILTERING(new MjpegBilinearFiltering());
 
     private final ISetting setting;
 

--- a/app/src/main/java/io/appium/uiautomator2/server/ServerConfig.java
+++ b/app/src/main/java/io/appium/uiautomator2/server/ServerConfig.java
@@ -16,10 +16,106 @@
 
 package io.appium.uiautomator2.server;
 
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
 public class ServerConfig {
-    private final static int PORT = 6790;
+    // server port (default: `6790`)
+    private final static int SERVER_PORT =
+        System.getenv("SERVER_PORT") == null ? 6790 :
+            Integer.parseInt(System.getenv("SERVER_PORT"));
+    // mjpeg server port (default: `7810`)
+    private final static int MJPEG_SERVER_PORT =
+        System.getenv("MJPEG_SERVER_PORT") == null ? 7810 :
+            Integer.parseInt(System.getenv("MJPEG_SERVER_PORT"));
+    // mjpeg stream will try to match this framerate (default: `10`)
+    private final static int MJPEG_SERVER_FRAMERATE =
+        System.getenv("MJPEG_SERVER_FRAMERATE") == null ? 10 :
+            Integer.parseInt(System.getenv("MJPEG_SERVER_FRAMERATE"));
+    // mjpeg scale should be between 1 and 100 (default: `50`)
+    private final static int MJPEG_SCALING_FACTOR =
+        System.getenv("MJPEG_SCALING_FACTOR") == null ? 50 :
+            Integer.parseInt(System.getenv("MJPEG_SCALING_FACTOR"));
+    // mjpeg quality is between 0 and 100 (default: `75`)
+    private final static int MJPEG_SERVER_SCREENSHOT_QUALITY =
+        System.getenv("MJPEG_SERVER_SCREENSHOT_QUALITY") == null ? 75 :
+            Integer.parseInt(System.getenv("MJPEG_SERVER_SCREENSHOT_QUALITY"));
+    // if filtering should be used in mjpeg resize operation (default: `false`)
+    private final static boolean MJPEG_FILTERING =
+        System.getenv("MJPEG_FILTERING") == null ? false :
+            System.getenv("MJPEG_FILTERING") == "true";
+
+    // In-memory overrides
+    private static ConcurrentMap<String, Object> overrides =
+        new ConcurrentHashMap<>();
+
+    /* Getter(s) */
 
     public static int getServerPort() {
-        return PORT;
+        if (overrides.containsKey("serverPort")) {
+            return (int) overrides.get("serverPort");
+        }
+        return SERVER_PORT;
+    }
+
+    public static int getMjpegServerPort() {
+        if (overrides.containsKey("mjpegServerPort")) {
+            return (int) overrides.get("mjpegServerPort");
+        }
+        return MJPEG_SERVER_PORT;
+    }
+
+    public static int getMjpegServerFramerate() {
+        if (overrides.containsKey("mjpegServerFramerate")) {
+            return (int) overrides.get("mjpegServerFramerate");
+        }
+        return MJPEG_SERVER_FRAMERATE;
+    }
+
+    public static int getMjpegServerScreenshotQuality() {
+        if (overrides.containsKey("mjpegServerScreenshotQuality")) {
+            return (int) overrides.get("mjpegServerScreenshotQuality");
+        }
+        return MJPEG_SERVER_SCREENSHOT_QUALITY;
+    }
+
+    public static int getMjpegScalingFactor() {
+        if (overrides.containsKey("mjpegScalingFactor")) {
+            return (int) overrides.get("mjpegScalingFactor");
+        }
+        return MJPEG_SCALING_FACTOR;
+    }
+
+    public static boolean getMjpegFiltering() {
+        if (overrides.containsKey("mjpegFiltering")) {
+            return (boolean) overrides.get("mjpegFiltering");
+        }
+        return MJPEG_FILTERING;
+    }
+
+    /* Setter(s) */
+
+    public static void setServerPort(int serverPort) {
+        overrides.put("serverPort", serverPort);
+    }
+
+    public static void setMjpegServerPort(int mjpegServerPort) {
+        overrides.put("mjpegServerPort", mjpegServerPort);
+    }
+
+    public static void setMjpegServerFramerate(int mjpegServerFramerate) {
+        overrides.put("mjpegServerFramerate", mjpegServerFramerate);
+    }
+
+    public static void setMjpegServerScreenshotQuality(int mjpegServerScreenshotQuality) {
+        overrides.put("mjpegServerScreenshotQuality", mjpegServerScreenshotQuality);
+    }
+
+    public static void setMjpegScalingFactor(int mjpegScalingFactor) {
+        overrides.put("mjpegScalingFactor", mjpegScalingFactor);
+    }
+
+    public static void setMjpegFiltering(boolean mjpegFiltering) {
+        overrides.put("mjpegFiltering", mjpegFiltering);
     }
 }

--- a/app/src/main/java/io/appium/uiautomator2/server/ServerConfig.java
+++ b/app/src/main/java/io/appium/uiautomator2/server/ServerConfig.java
@@ -16,106 +16,128 @@
 
 package io.appium.uiautomator2.server;
 
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
+import java.util.HashMap;
+import java.util.Map;
+
+import io.appium.uiautomator2.model.settings.MjpegBilinearFiltering;
+import io.appium.uiautomator2.model.settings.MjpegScalingFactor;
+import io.appium.uiautomator2.model.settings.MjpegServerFramerate;
+import io.appium.uiautomator2.model.settings.MjpegServerPort;
+import io.appium.uiautomator2.model.settings.MjpegServerScreenshotQuality;
+import io.appium.uiautomator2.model.settings.ServerPort;
 
 public class ServerConfig {
-    // server port (default: `6790`)
-    private final static int SERVER_PORT =
-        System.getenv("SERVER_PORT") == null ? 6790 :
-            Integer.parseInt(System.getenv("SERVER_PORT"));
-    // mjpeg server port (default: `7810`)
-    private final static int MJPEG_SERVER_PORT =
-        System.getenv("MJPEG_SERVER_PORT") == null ? 7810 :
-            Integer.parseInt(System.getenv("MJPEG_SERVER_PORT"));
-    // mjpeg stream will try to match this framerate (default: `10`)
-    private final static int MJPEG_SERVER_FRAMERATE =
-        System.getenv("MJPEG_SERVER_FRAMERATE") == null ? 10 :
-            Integer.parseInt(System.getenv("MJPEG_SERVER_FRAMERATE"));
-    // mjpeg scale should be between 1 and 100 (default: `50`)
-    private final static int MJPEG_SCALING_FACTOR =
-        System.getenv("MJPEG_SCALING_FACTOR") == null ? 50 :
-            Integer.parseInt(System.getenv("MJPEG_SCALING_FACTOR"));
-    // mjpeg quality is between 0 and 100 (default: `75`)
-    private final static int MJPEG_SERVER_SCREENSHOT_QUALITY =
-        System.getenv("MJPEG_SERVER_SCREENSHOT_QUALITY") == null ? 75 :
-            Integer.parseInt(System.getenv("MJPEG_SERVER_SCREENSHOT_QUALITY"));
-    // if filtering should be used in mjpeg resize operation (default: `false`)
-    private final static boolean MJPEG_FILTERING =
-        System.getenv("MJPEG_FILTERING") == null ? false :
-            System.getenv("MJPEG_FILTERING") == "true";
+    public static final int DEFAULT_SERVER_PORT = 6790;
+    public static final int DEFAULT_MJPEG_SERVER_PORT = 7810;
+    public static final int DEFAULT_MJPEG_SERVER_FRAMERATE = 10;
+    public static final int DEFAULT_MJPEG_SCALING_FACTOR = 50;
+    public static final int DEFAULT_MJPEG_SERVER_SCREENSHOT_QUALITY = 50;
+    public static final boolean DEFAULT_MJPEG_SERVER_BILINEAR_FILTERING = false;
+
+    private final static int SERVER_PORT = getValueFromEnvOrDefault(
+        "SERVER_PORT",
+        DEFAULT_SERVER_PORT);
+    private final static int MJPEG_SERVER_PORT = getValueFromEnvOrDefault(
+        "MJPEG_SERVER_PORT",
+        DEFAULT_MJPEG_SERVER_PORT);
+    private final static int MJPEG_SERVER_FRAMERATE = getValueFromEnvOrDefault(
+        "MJPEG_SERVER_FRAMERATE",
+        DEFAULT_MJPEG_SERVER_FRAMERATE);
+    private final static int MJPEG_SCALING_FACTOR = getValueFromEnvOrDefault(
+        "MJPEG_SCALING_FACTOR",
+        DEFAULT_MJPEG_SCALING_FACTOR);
+    private final static int MJPEG_SERVER_SCREENSHOT_QUALITY = getValueFromEnvOrDefault(
+        "MJPEG_SERVER_SCREENSHOT_QUALITY",
+        DEFAULT_MJPEG_SERVER_SCREENSHOT_QUALITY);
+    private final static boolean MJPEG_BILINEAR_FILTERING =
+        Boolean.parseBoolean(System.getenv("MJPEG_BILINEAR_FILTERING"));
 
     // In-memory overrides
-    private static ConcurrentMap<String, Object> overrides =
-        new ConcurrentHashMap<>();
+    private static Map<String, Object> overrides = new HashMap<>();
 
-    /* Getter(s) */
+    private static int getValueFromEnvOrDefault(String key, int defaultValue) {
+        return System.getenv(key) != null ?
+            Integer.parseInt(System.getenv(key)) :
+            defaultValue;
+    }
+
+    private static <T> T getValueFromOverridesOrDefault(String key, T defaultValue) {
+        synchronized (overrides) {
+            return overrides.containsKey(key) ?
+                ((T) overrides.get(key)) :
+                defaultValue;
+        }
+    }
+
+    private static void setOverridesValue(String key, Object value) {
+        synchronized (overrides) {
+            overrides.put(key, value);
+        }
+    }
 
     public static int getServerPort() {
-        if (overrides.containsKey("serverPort")) {
-            return (int) overrides.get("serverPort");
-        }
-        return SERVER_PORT;
+        return getValueFromOverridesOrDefault(
+            ServerPort.SETTING_NAME,
+            SERVER_PORT);
     }
 
     public static int getMjpegServerPort() {
-        if (overrides.containsKey("mjpegServerPort")) {
-            return (int) overrides.get("mjpegServerPort");
-        }
-        return MJPEG_SERVER_PORT;
+        return getValueFromOverridesOrDefault(
+            MjpegServerPort.SETTING_NAME,
+            MJPEG_SERVER_PORT);
     }
 
     public static int getMjpegServerFramerate() {
-        if (overrides.containsKey("mjpegServerFramerate")) {
-            return (int) overrides.get("mjpegServerFramerate");
-        }
-        return MJPEG_SERVER_FRAMERATE;
+        return getValueFromOverridesOrDefault(
+            MjpegServerFramerate.SETTING_NAME,
+            MJPEG_SERVER_FRAMERATE);
     }
 
     public static int getMjpegServerScreenshotQuality() {
-        if (overrides.containsKey("mjpegServerScreenshotQuality")) {
-            return (int) overrides.get("mjpegServerScreenshotQuality");
-        }
-        return MJPEG_SERVER_SCREENSHOT_QUALITY;
+        return getValueFromOverridesOrDefault(
+            MjpegServerScreenshotQuality.SETTING_NAME,
+            MJPEG_SERVER_SCREENSHOT_QUALITY);
     }
 
     public static int getMjpegScalingFactor() {
-        if (overrides.containsKey("mjpegScalingFactor")) {
-            return (int) overrides.get("mjpegScalingFactor");
-        }
-        return MJPEG_SCALING_FACTOR;
+        return getValueFromOverridesOrDefault(
+            MjpegScalingFactor.SETTING_NAME,
+            MJPEG_SCALING_FACTOR);
     }
 
-    public static boolean getMjpegFiltering() {
-        if (overrides.containsKey("mjpegFiltering")) {
-            return (boolean) overrides.get("mjpegFiltering");
-        }
-        return MJPEG_FILTERING;
+    public static boolean isMjpegBilinearFiltering() {
+        return getValueFromOverridesOrDefault(
+            MjpegBilinearFiltering.SETTING_NAME,
+            MJPEG_BILINEAR_FILTERING);
     }
-
-    /* Setter(s) */
 
     public static void setServerPort(int serverPort) {
-        overrides.put("serverPort", serverPort);
+        setOverridesValue(ServerPort.SETTING_NAME, serverPort);
     }
 
     public static void setMjpegServerPort(int mjpegServerPort) {
-        overrides.put("mjpegServerPort", mjpegServerPort);
+        setOverridesValue(MjpegServerPort.SETTING_NAME, mjpegServerPort);
     }
 
     public static void setMjpegServerFramerate(int mjpegServerFramerate) {
-        overrides.put("mjpegServerFramerate", mjpegServerFramerate);
+        setOverridesValue(
+            MjpegServerFramerate.SETTING_NAME,
+            mjpegServerFramerate);
     }
 
     public static void setMjpegServerScreenshotQuality(int mjpegServerScreenshotQuality) {
-        overrides.put("mjpegServerScreenshotQuality", mjpegServerScreenshotQuality);
+        setOverridesValue(
+            MjpegServerScreenshotQuality.SETTING_NAME,
+            mjpegServerScreenshotQuality);
     }
 
     public static void setMjpegScalingFactor(int mjpegScalingFactor) {
-        overrides.put("mjpegScalingFactor", mjpegScalingFactor);
+        setOverridesValue(MjpegScalingFactor.SETTING_NAME, mjpegScalingFactor);
     }
 
-    public static void setMjpegFiltering(boolean mjpegFiltering) {
-        overrides.put("mjpegFiltering", mjpegFiltering);
+    public static void setMjpegBilinearFiltering(boolean mjpegBilinearFiltering) {
+        setOverridesValue(
+            MjpegBilinearFiltering.SETTING_NAME,
+            mjpegBilinearFiltering);
     }
 }

--- a/app/src/main/java/io/appium/uiautomator2/server/ServerInstrumentation.java
+++ b/app/src/main/java/io/appium/uiautomator2/server/ServerInstrumentation.java
@@ -23,7 +23,6 @@ import android.content.Intent;
 import android.os.Build;
 import android.os.Looper;
 import android.os.PowerManager;
-
 import android.os.SystemClock;
 
 import androidx.test.platform.app.InstrumentationRegistry;
@@ -33,10 +32,12 @@ import io.appium.uiautomator2.common.exceptions.SessionRemovedException;
 import io.appium.uiautomator2.common.exceptions.UiAutomator2Exception;
 import io.appium.uiautomator2.model.settings.Settings;
 import io.appium.uiautomator2.model.settings.ShutdownOnPowerDisconnect;
+import io.appium.uiautomator2.server.mjpeg.MjpegScreenshotServer;
 import io.appium.uiautomator2.utils.Logger;
 
 import static android.content.Intent.ACTION_POWER_DISCONNECTED;
 import static androidx.test.core.app.ApplicationProvider.getApplicationContext;
+import static io.appium.uiautomator2.server.ServerConfig.getMjpegServerPort;
 import static io.appium.uiautomator2.server.ServerConfig.getServerPort;
 import static io.appium.uiautomator2.utils.Device.getUiDevice;
 
@@ -50,7 +51,9 @@ public class ServerInstrumentation {
 
     private final PowerManager powerManager;
     private final int serverPort;
+    private final int mjpegServerPort;
     private HttpdThread serverThread;
+    private MjpegScreenshotServer mjpegScreenshotServerThread;
     private PowerManager.WakeLock wakeLock;
     private long wakeLockAcquireTimestampMs = 0;
     private long wakeLockTimeoutMs = 0;
@@ -73,12 +76,27 @@ public class ServerInstrumentation {
         }
     }
 
-    private ServerInstrumentation(Context context, int serverPort) {
+    private ServerInstrumentation(Context context, int serverPort, int mjpegServerPort) {
         if (!isValidPort(serverPort)) {
             throw new UiAutomator2Exception(String.format(
-                    "The port is out of valid range [%s;%s]: %s", MIN_PORT, MAX_PORT, serverPort));
+                "The server port is out of valid range [%s;%s]: %s",
+                MIN_PORT,
+                MAX_PORT,
+                serverPort
+            ));
         }
         this.serverPort = serverPort;
+
+        if (!isValidPort(mjpegServerPort)) {
+            throw new UiAutomator2Exception(String.format(
+                "The mjpeg streaming server port is out of valid range [%s;%s]: %s",
+                MIN_PORT,
+                MAX_PORT,
+                mjpegServerPort
+            ));
+        }
+        this.mjpegServerPort = mjpegServerPort;
+
         this.powerManager = (PowerManager) context.getSystemService(Context.POWER_SERVICE);
 
         setAccessibilityServiceState();
@@ -86,7 +104,11 @@ public class ServerInstrumentation {
 
     public static synchronized ServerInstrumentation getInstance() {
         if (instance == null) {
-            instance = new ServerInstrumentation(getApplicationContext(), getServerPort());
+            instance = new ServerInstrumentation(
+                getApplicationContext(),
+                getServerPort(),
+                getMjpegServerPort()
+            );
         }
         return instance;
     }
@@ -203,8 +225,34 @@ public class ServerInstrumentation {
         isServerStopped = true;
     }
 
-    public static class PowerConnectionReceiver extends BroadcastReceiver {
+    public void startMjpegServer() {
+        if (mjpegScreenshotServerThread != null && mjpegScreenshotServerThread.isAlive()) {
+            return;
+        }
 
+        Logger.info("Starting MJPEG Server");
+        mjpegScreenshotServerThread = new MjpegScreenshotServer(mjpegServerPort);
+        mjpegScreenshotServerThread.start();
+        Logger.info("MJPEG Server started");
+    }
+
+    public void stopMjpegServer() {
+        if (mjpegScreenshotServerThread == null || !mjpegScreenshotServerThread.isAlive()) {
+            return;
+        }
+
+        Logger.info("Stopping MJPEG Server");
+        mjpegScreenshotServerThread.interrupt();
+        try {
+            mjpegScreenshotServerThread.join();
+        } catch (InterruptedException ignored) {
+            // swallow
+        }
+        mjpegScreenshotServerThread = null;
+        Logger.info("MJPEG Server stoppped");
+    }
+
+    public static class PowerConnectionReceiver extends BroadcastReceiver {
         @Override
         public void onReceive(Context context, Intent intent) {
             Logger.debug("Received broadcast action: " + intent.getAction());
@@ -227,12 +275,12 @@ public class ServerInstrumentation {
             }
 
             Logger.info("The device was disconnected from power source. Shutting down the server.");
+            getInstance().stopMjpegServer();
             getInstance().stopServer();
         }
     }
 
     private class HttpdThread extends Thread {
-
         private final AndroidServer server;
         private Looper looper;
 

--- a/app/src/main/java/io/appium/uiautomator2/server/ServerInstrumentation.java
+++ b/app/src/main/java/io/appium/uiautomator2/server/ServerInstrumentation.java
@@ -77,25 +77,31 @@ public class ServerInstrumentation {
     }
 
     private ServerInstrumentation(Context context, int serverPort, int mjpegServerPort) {
-        if (!isValidPort(serverPort)) {
-            throw new UiAutomator2Exception(String.format(
-                "The server port is out of valid range [%s;%s]: %s",
+        if (isValidPort(serverPort)) {
+            this.serverPort = serverPort;
+        } else {
+            Logger.warn(String.format(
+                "The server port is out of valid range [%s;%s]: %s -- using default: %s",
                 MIN_PORT,
                 MAX_PORT,
-                serverPort
+                serverPort,
+                ServerConfig.DEFAULT_SERVER_PORT
             ));
+            this.serverPort = ServerConfig.DEFAULT_SERVER_PORT;
         }
-        this.serverPort = serverPort;
 
-        if (!isValidPort(mjpegServerPort)) {
-            throw new UiAutomator2Exception(String.format(
-                "The mjpeg streaming server port is out of valid range [%s;%s]: %s",
+        if (isValidPort(mjpegServerPort)) {
+            this.mjpegServerPort = mjpegServerPort;
+        } else {
+            Logger.warn(String.format(
+                "The MJPEG server port is out of valid range [%s;%s]: %s -- using default: %s",
                 MIN_PORT,
                 MAX_PORT,
-                mjpegServerPort
+                mjpegServerPort,
+                ServerConfig.DEFAULT_MJPEG_SERVER_PORT
             ));
+            this.mjpegServerPort = ServerConfig.DEFAULT_MJPEG_SERVER_PORT;
         }
-        this.mjpegServerPort = mjpegServerPort;
 
         this.powerManager = (PowerManager) context.getSystemService(Context.POWER_SERVICE);
 
@@ -201,6 +207,7 @@ public class ServerInstrumentation {
 
         serverThread = new HttpdThread(this.serverPort);
         serverThread.start();
+
         //client to wait for io.appium.uiautomator2.server to up
         Logger.info("io.appium.uiautomator2.server started:");
     }
@@ -209,6 +216,7 @@ public class ServerInstrumentation {
         if (serverThread == null) {
             return;
         }
+
         if (!serverThread.isAlive()) {
             serverThread = null;
             return;

--- a/app/src/main/java/io/appium/uiautomator2/server/mjpeg/MjpegScreenshotClient.java
+++ b/app/src/main/java/io/appium/uiautomator2/server/mjpeg/MjpegScreenshotClient.java
@@ -1,0 +1,112 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.appium.uiautomator2.server.mjpeg;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.net.Socket;
+import java.util.Locale;
+
+import io.appium.uiautomator2.utils.Logger;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+class MjpegScreenshotClient {
+    private final Socket socket;
+    private boolean closed = false;
+    private boolean initialized = false;
+    private OutputStream out;
+    private BufferedReader in;
+
+    MjpegScreenshotClient(Socket socket) {
+        this.socket = socket;
+    }
+
+    boolean getInitialized() {
+        return initialized;
+    }
+
+    boolean getClosed() {
+        return closed;
+    }
+
+    private String getRemoteAddress() {
+        if (socket == null) {
+            return "";
+        }
+        return socket.getRemoteSocketAddress().toString().replaceAll("^/+", "");
+    }
+
+    void closeSocket() {
+        try {
+            socket.close();
+        } catch (IOException closeError) {
+            Logger.error("Error closing socket.", closeError);
+        }
+
+        this.closed = true;
+    }
+
+    void initialize() {
+        Logger.info(String.format(
+            Locale.ROOT,
+            "Screenshot broadcast client opened a connection %s",
+            getRemoteAddress()
+        ));
+
+        try {
+            this.in = new BufferedReader(new InputStreamReader(socket.getInputStream()));
+            this.out = socket.getOutputStream();
+        } catch (IOException e) {
+            Logger.error("Client failed to initialize");
+            closeSocket();
+            return;
+        }
+
+        try {
+            String line = in.readLine();
+            while (line == null) {
+                line = in.readLine();
+            }
+
+            Logger.info(String.format(
+                Locale.ROOT,
+                "Screenshot broadcast starting for %s",
+                getRemoteAddress()
+            ));
+            String start = "HTTP/1.0 200 OK\r\nServer: AQI Android Screenshot Socket Server\r\nConnection: close\r\nMax-Age: 0\r\nExpires: 0\r\nCache-Control: no-cache, private\r\nPragma: no-cache\r\nContent-Type: multipart/x-mixed-replace; boundary=--BoundaryString\r\n\r\n";
+            out.write(start.getBytes(UTF_8));
+        } catch (IOException e) {
+            Logger.info("Client socket connection could not be read.", e);
+            closeSocket();
+            return;
+        }
+
+        this.initialized = true;
+    }
+
+    void write(byte[] data) {
+        try {
+            out.write(data);
+        } catch (IOException e) {
+            Logger.info("Client socket connection not writable. Closing... ", e);
+            closeSocket();
+        }
+    }
+}

--- a/app/src/main/java/io/appium/uiautomator2/server/mjpeg/MjpegScreenshotServer.java
+++ b/app/src/main/java/io/appium/uiautomator2/server/mjpeg/MjpegScreenshotServer.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.appium.uiautomator2.server.mjpeg;
+
+import java.io.IOException;
+import java.net.ServerSocket;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+
+import io.appium.uiautomator2.utils.Logger;
+
+public class MjpegScreenshotServer extends Thread {
+    private final List<MjpegScreenshotClient> clients =
+        Collections.synchronizedList(new ArrayList<MjpegScreenshotClient>());
+    private final MjpegScreenshotStream mjpegScreenshotStream =
+        new MjpegScreenshotStream(clients);
+    private boolean stopped = false;
+    private int port;
+    private ServerSocket serverSocket;
+
+    public MjpegScreenshotServer(int port) {
+        this.port = port;
+    }
+
+    @Override
+    public void interrupt() {
+        closeServer();
+        super.interrupt();
+    }
+
+    @Override
+    public void run() {
+        try {
+            serverSocket = new ServerSocket(port);
+            Logger.info(String.format(
+                Locale.ROOT,
+                "ServerSocket created on port %d", port));
+        } catch (IOException e) {
+            Logger.error("Failed to create Socket Server.", e);
+            return;
+        }
+
+        mjpegScreenshotStream.start();
+        while (!stopped) {
+            try {
+                Logger.debug("Socket Server waiting for connections.");
+                MjpegScreenshotClient newClient =
+                    new MjpegScreenshotClient(serverSocket.accept());
+                clients.add(newClient);
+            } catch (IOException e) {
+                Logger.error("Socket Server failed to open connection.", e);
+            }
+        }
+
+        closeAllClients();
+    }
+
+    private void closeServer() {
+        closeAllClients();
+
+        try {
+            serverSocket.close();
+        } catch (IOException e) {
+            Logger.error("Socket Server failed to close socket.", e);
+        }
+
+        this.stopped = true;
+    }
+
+    private void closeAllClients() {
+        for (MjpegScreenshotClient client : clients) {
+            client.closeSocket();
+        }
+    }
+}

--- a/app/src/main/java/io/appium/uiautomator2/server/mjpeg/MjpegScreenshotStream.java
+++ b/app/src/main/java/io/appium/uiautomator2/server/mjpeg/MjpegScreenshotStream.java
@@ -1,0 +1,142 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.appium.uiautomator2.server.mjpeg;
+
+import android.app.UiAutomation;
+import android.graphics.Bitmap;
+
+import java.lang.Math;
+import java.util.List;
+import java.util.Iterator;
+import java.util.Locale;
+
+import io.appium.uiautomator2.model.internal.CustomUiDevice;
+import io.appium.uiautomator2.server.ServerConfig;
+import io.appium.uiautomator2.utils.ScreenshotHelper;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+public class MjpegScreenshotStream extends Thread {
+    private static final UiAutomation uia =
+        CustomUiDevice.getInstance().getInstrumentation().getUiAutomation();
+    private final List<MjpegScreenshotClient> clients;
+    private boolean stopped = false;
+
+    MjpegScreenshotStream(List<MjpegScreenshotClient> clients) {
+        this.clients = clients;
+    }
+
+    @Override
+    public void interrupt() {
+        this.stopped = true;
+        super.interrupt();
+    }
+
+    @Override
+    public void run() {
+        while (!stopped) {
+            if (clients.size() == 0) {
+                try {
+                    sleep(500);
+                } catch (InterruptedException e) {
+                    e.printStackTrace();
+                }
+                continue;
+            }
+
+            // how long each loop should take in milliseconds
+            long targetInterval =
+                Math.round((1.0f / ServerConfig.getMjpegServerFramerate()) * 1000.0f);
+            long start = System.currentTimeMillis();
+
+            byte[] screenshotData = getScreenshot();
+            if (screenshotData.length > 0) {
+                MjpegScreenshotClient client;
+                for (Iterator<MjpegScreenshotClient> iterator = clients.iterator(); iterator.hasNext();) {
+                    client = iterator.next();
+                    if (client.getClosed()) {
+                        iterator.remove();
+                        continue;
+                    }
+
+                    if (!client.getInitialized()) {
+                        client.initialize();
+                    }
+
+                    client.write(screenshotData);
+                }
+            }
+            matchFramerate(targetInterval, start);
+        }
+    }
+
+    private void matchFramerate(long targetInterval, long start) {
+        long end = System.currentTimeMillis();
+        long duration = end - start;
+
+        if (duration < targetInterval) {
+            try {
+                sleep(targetInterval - duration);
+            } catch (InterruptedException e) {
+                e.printStackTrace();
+            }
+        }
+    }
+
+    private byte[] getScreenshot() {
+        Bitmap screenshot = uia.takeScreenshot();
+        byte[] jpeg = ScreenshotHelper.compressJpeg(
+            screenshot,
+            ServerConfig.getMjpegScalingFactor() / 100.0f,
+            ServerConfig.getMjpegServerScreenshotQuality(),
+            ServerConfig.getMjpegFiltering()
+        );
+        screenshot.recycle();
+
+        byte[] header = String.format(
+            Locale.ROOT,
+            "--BoundaryString\r\nContent-type: image/jpg\r\nContent-Length: %d\r\n\r\n",
+            jpeg.length
+        ).getBytes(UTF_8);
+        byte[] end = "\r\n\r\n".getBytes(UTF_8);
+        byte[] data = new byte[jpeg.length + header.length + end.length];
+
+        System.arraycopy(
+            header,
+            0,
+            data,
+            0,
+            header.length
+        );
+        System.arraycopy(
+            jpeg,
+            0,
+            data,
+            header.length,
+            jpeg.length
+        );
+        System.arraycopy(
+            end,
+            0,
+            data,
+            header.length + jpeg.length,
+            end.length
+        );
+
+        return data;
+    }
+}

--- a/app/src/main/java/io/appium/uiautomator2/utils/ScreenshotHelper.java
+++ b/app/src/main/java/io/appium/uiautomator2/utils/ScreenshotHelper.java
@@ -26,6 +26,8 @@ import android.util.Base64;
 import android.util.DisplayMetrics;
 import android.view.Display;
 
+import androidx.annotation.Nullable;
+
 import org.apache.commons.io.IOUtils;
 
 import java.io.ByteArrayOutputStream;
@@ -33,7 +35,6 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 
-import androidx.annotation.Nullable;
 import io.appium.uiautomator2.common.exceptions.CompressScreenshotException;
 import io.appium.uiautomator2.common.exceptions.CropScreenshotException;
 import io.appium.uiautomator2.common.exceptions.TakeScreenshotException;
@@ -41,12 +42,13 @@ import io.appium.uiautomator2.core.UiAutomatorBridge;
 import io.appium.uiautomator2.model.internal.CustomUiDevice;
 
 import static android.graphics.Bitmap.CompressFormat.PNG;
+import static android.graphics.Bitmap.CompressFormat.JPEG;
 import static android.util.DisplayMetrics.DENSITY_DEFAULT;
 
 public class ScreenshotHelper {
     private static final int PNG_MAGIC_LENGTH = 8;
-    private static final UiAutomation uia = CustomUiDevice.getInstance().getInstrumentation()
-            .getUiAutomation();
+    private static final UiAutomation uia =
+        CustomUiDevice.getInstance().getInstrumentation().getUiAutomation();
 
     /**
      * Grab device screenshot and crop it to specifyed area if cropArea is not null.
@@ -103,7 +105,11 @@ public class ScreenshotHelper {
                     if (outputType == String.class) {
                         return outputType.cast(Base64.encodeToString(pngBytes, Base64.DEFAULT));
                     }
-                    screenshot = BitmapFactory.decodeByteArray(pngBytes, 0, pngBytes.length);
+                    screenshot = BitmapFactory.decodeByteArray(
+                        pngBytes,
+                        0,
+                        pngBytes.length
+                    );
                 } finally {
                     try {
                         pfd.close();
@@ -116,6 +122,7 @@ public class ScreenshotHelper {
                 Logger.info("Falling back to UiAutomator-based screenshoting");
             }
         }
+
         if (screenshot == null) {
             screenshot = uia.takeScreenshot();
         }
@@ -124,8 +131,12 @@ public class ScreenshotHelper {
             throw new TakeScreenshotException();
         }
 
-        Logger.info(String.format("Got screenshot with resolution: %sx%s", screenshot.getWidth(),
-                screenshot.getHeight()));
+        Logger.info(String.format(
+            "Got screenshot with resolution: %sx%s",
+            screenshot.getWidth(),
+            screenshot.getHeight()
+        ));
+
         if (outputType == String.class) {
             try {
                 return outputType.cast(Base64.encodeToString(compress(screenshot), Base64.DEFAULT));
@@ -147,17 +158,51 @@ public class ScreenshotHelper {
         }
     }
 
+    public static byte[] compressJpeg(final Bitmap bitmap, float scale, int quality, boolean filter) throws TakeScreenshotException {
+        Bitmap resultBitmap;
+        if (scale == 1.0) {
+            resultBitmap = bitmap;
+        } else {
+            int width = Math.round(bitmap.getWidth() * scale);
+            int height = Math.round(bitmap.getHeight() * scale);
+            resultBitmap = Bitmap.createScaledBitmap(
+                bitmap,
+                width,
+                height,
+                filter
+            );
+            bitmap.recycle();
+        }
+
+        try (final ByteArrayOutputStream stream = new ByteArrayOutputStream()) {
+            if (!resultBitmap.compress(JPEG, quality, stream)) {
+                throw new CompressScreenshotException(JPEG);
+            }
+            return stream.toByteArray();
+        } catch (IOException e) {
+            throw new CompressScreenshotException(JPEG, e);
+        }
+    }
+
     private static Bitmap crop(Bitmap bitmap, Rect cropArea) throws CropScreenshotException {
-        final Rect bitmapRect = new Rect(0, 0, bitmap.getWidth(), bitmap.getHeight());
+        final Rect bitmapRect = new Rect(
+            0,
+            0,
+            bitmap.getWidth(),
+            bitmap.getHeight()
+         );
         final Rect intersectionRect = new Rect();
 
         if (!intersectionRect.setIntersect(bitmapRect, cropArea)) {
             throw new CropScreenshotException(bitmapRect, cropArea);
         }
 
-        return Bitmap.createBitmap(bitmap,
-                intersectionRect.left, intersectionRect.top,
-                intersectionRect.width(), intersectionRect.height());
+        return Bitmap.createBitmap(
+            bitmap,
+            intersectionRect.left,
+            intersectionRect.top,
+            intersectionRect.width(),
+            intersectionRect.height()
+        );
     }
-
 }

--- a/app/src/main/java/io/appium/uiautomator2/utils/ScreenshotHelper.java
+++ b/app/src/main/java/io/appium/uiautomator2/utils/ScreenshotHelper.java
@@ -160,7 +160,7 @@ public class ScreenshotHelper {
 
     public static byte[] compressJpeg(final Bitmap bitmap, float scale, int quality, boolean filter) throws TakeScreenshotException {
         Bitmap resultBitmap;
-        if (scale == 1.0) {
+        if (Math.abs(scale - 1.0f) < Float.MIN_NORMAL) {
             resultBitmap = bitmap;
         } else {
             int width = Math.round(bitmap.getWidth() * scale);

--- a/app/src/test/java/io/appium/uiautomator2/handler/UpdateSettingsTests.java
+++ b/app/src/test/java/io/appium/uiautomator2/handler/UpdateSettingsTests.java
@@ -45,7 +45,13 @@ import io.appium.uiautomator2.model.settings.CompressedLayoutHierarchy;
 import io.appium.uiautomator2.model.settings.ElementResponseAttributes;
 import io.appium.uiautomator2.model.settings.EnableNotificationListener;
 import io.appium.uiautomator2.model.settings.KeyInjectionDelay;
+import io.appium.uiautomator2.model.settings.MjpegFiltering;
+import io.appium.uiautomator2.model.settings.MjpegScalingFactor;
+import io.appium.uiautomator2.model.settings.MjpegServerFramerate;
+import io.appium.uiautomator2.model.settings.MjpegServerPort;
+import io.appium.uiautomator2.model.settings.MjpegServerScreenshotQuality;
 import io.appium.uiautomator2.model.settings.ScrollAcknowledgmentTimeout;
+import io.appium.uiautomator2.model.settings.ServerPort;
 import io.appium.uiautomator2.model.settings.Settings;
 import io.appium.uiautomator2.model.settings.ShouldUseCompactResponses;
 import io.appium.uiautomator2.model.settings.ShutdownOnPowerDisconnect;
@@ -58,7 +64,13 @@ import static io.appium.uiautomator2.model.settings.Settings.COMPRESSED_LAYOUT_H
 import static io.appium.uiautomator2.model.settings.Settings.ELEMENT_RESPONSE_ATTRIBUTES;
 import static io.appium.uiautomator2.model.settings.Settings.ENABLE_NOTIFICATION_LISTENER;
 import static io.appium.uiautomator2.model.settings.Settings.KEY_INJECTION_DELAY;
+import static io.appium.uiautomator2.model.settings.Settings.MJPEG_FILTERING;
+import static io.appium.uiautomator2.model.settings.Settings.MJPEG_SCALING_FACTOR;
+import static io.appium.uiautomator2.model.settings.Settings.MJPEG_SERVER_FRAMERATE;
+import static io.appium.uiautomator2.model.settings.Settings.MJPEG_SERVER_PORT;
+import static io.appium.uiautomator2.model.settings.Settings.MJPEG_SERVER_SCREENSHOT_QUALITY;
 import static io.appium.uiautomator2.model.settings.Settings.SCROLL_ACKNOWLEDGMENT_TIMEOUT;
+import static io.appium.uiautomator2.model.settings.Settings.SERVER_PORT;
 import static io.appium.uiautomator2.model.settings.Settings.SHOULD_USE_COMPACT_RESPONSES;
 import static io.appium.uiautomator2.model.settings.Settings.SHUTDOWN_ON_POWER_DISCONNECT;
 import static io.appium.uiautomator2.model.settings.Settings.WAIT_FOR_IDLE_TIMEOUT;
@@ -159,6 +171,36 @@ public class UpdateSettingsTests {
     @Test
     public void shouldBeAbleToReturnShutdownOnPowerDisconnectSetting() {
         verifySettingIsAvailable(SHUTDOWN_ON_POWER_DISCONNECT, ShutdownOnPowerDisconnect.class);
+    }
+
+    @Test
+    public void shouldBeAbleToReturnServerPortSetting() {
+        verifySettingIsAvailable(SERVER_PORT, ServerPort.class);
+    }
+
+    @Test
+    public void shouldBeAbleToReturnMjpegServerPortSetting() {
+        verifySettingIsAvailable(MJPEG_SERVER_PORT, MjpegServerPort.class);
+    }
+
+    @Test
+    public void shouldBeAbleToReturnMjpegServerFramerateSetting() {
+        verifySettingIsAvailable(MJPEG_SERVER_FRAMERATE, MjpegServerFramerate.class);
+    }
+
+    @Test
+    public void shouldBeAbleToReturnMjpegScalingFactorSetting() {
+        verifySettingIsAvailable(MJPEG_SCALING_FACTOR, MjpegScalingFactor.class);
+    }
+
+    @Test
+    public void shouldBeAbleToReturnMjpeqServerScreenshotQualitySetting() {
+        verifySettingIsAvailable(MJPEG_SERVER_SCREENSHOT_QUALITY, MjpegServerScreenshotQuality.class);
+    }
+
+    @Test
+    public void shouldBeAbleToReturnMjpegFilteringSetting() {
+        verifySettingIsAvailable(MJPEG_FILTERING, MjpegFiltering.class);
     }
 
     @Test(expected=UnsupportedSettingException.class)

--- a/app/src/test/java/io/appium/uiautomator2/handler/UpdateSettingsTests.java
+++ b/app/src/test/java/io/appium/uiautomator2/handler/UpdateSettingsTests.java
@@ -45,7 +45,7 @@ import io.appium.uiautomator2.model.settings.CompressedLayoutHierarchy;
 import io.appium.uiautomator2.model.settings.ElementResponseAttributes;
 import io.appium.uiautomator2.model.settings.EnableNotificationListener;
 import io.appium.uiautomator2.model.settings.KeyInjectionDelay;
-import io.appium.uiautomator2.model.settings.MjpegFiltering;
+import io.appium.uiautomator2.model.settings.MjpegBilinearFiltering;
 import io.appium.uiautomator2.model.settings.MjpegScalingFactor;
 import io.appium.uiautomator2.model.settings.MjpegServerFramerate;
 import io.appium.uiautomator2.model.settings.MjpegServerPort;
@@ -64,7 +64,7 @@ import static io.appium.uiautomator2.model.settings.Settings.COMPRESSED_LAYOUT_H
 import static io.appium.uiautomator2.model.settings.Settings.ELEMENT_RESPONSE_ATTRIBUTES;
 import static io.appium.uiautomator2.model.settings.Settings.ENABLE_NOTIFICATION_LISTENER;
 import static io.appium.uiautomator2.model.settings.Settings.KEY_INJECTION_DELAY;
-import static io.appium.uiautomator2.model.settings.Settings.MJPEG_FILTERING;
+import static io.appium.uiautomator2.model.settings.Settings.MJPEG_BILINEAR_FILTERING;
 import static io.appium.uiautomator2.model.settings.Settings.MJPEG_SCALING_FACTOR;
 import static io.appium.uiautomator2.model.settings.Settings.MJPEG_SERVER_FRAMERATE;
 import static io.appium.uiautomator2.model.settings.Settings.MJPEG_SERVER_PORT;
@@ -185,22 +185,30 @@ public class UpdateSettingsTests {
 
     @Test
     public void shouldBeAbleToReturnMjpegServerFramerateSetting() {
-        verifySettingIsAvailable(MJPEG_SERVER_FRAMERATE, MjpegServerFramerate.class);
+        verifySettingIsAvailable(
+            MJPEG_SERVER_FRAMERATE,
+            MjpegServerFramerate.class);
     }
 
     @Test
     public void shouldBeAbleToReturnMjpegScalingFactorSetting() {
-        verifySettingIsAvailable(MJPEG_SCALING_FACTOR, MjpegScalingFactor.class);
+        verifySettingIsAvailable(
+            MJPEG_SCALING_FACTOR,
+            MjpegScalingFactor.class);
     }
 
     @Test
     public void shouldBeAbleToReturnMjpeqServerScreenshotQualitySetting() {
-        verifySettingIsAvailable(MJPEG_SERVER_SCREENSHOT_QUALITY, MjpegServerScreenshotQuality.class);
+        verifySettingIsAvailable(
+            MJPEG_SERVER_SCREENSHOT_QUALITY,
+            MjpegServerScreenshotQuality.class);
     }
 
     @Test
-    public void shouldBeAbleToReturnMjpegFilteringSetting() {
-        verifySettingIsAvailable(MJPEG_FILTERING, MjpegFiltering.class);
+    public void shouldBeAbleToReturnMjpegBilinearFilteringSetting() {
+        verifySettingIsAvailable(
+            MJPEG_BILINEAR_FILTERING,
+            MjpegBilinearFiltering.class);
     }
 
     @Test(expected=UnsupportedSettingException.class)


### PR DESCRIPTION
While working on a project spanning both _Android_ and _iOS_ automation my team noticed that that there was `mjpeg` streaming support for _iOS_ but not _Android_. We built this internally and wanted to give it back to the open-source community.

This change-set adds mjpeg [screen] steaming support for _Android_, with reasonable defaults, configurable via the environment.

---

(Special thanks to @lc-applause for building this out, he made my job, prepping this for PR, easy)