### PR TITLE
Fix getText bug for UiObject element

### DIFF
--- a/app/src/main/java/io/appium/uiautomator2/utils/ElementHelpers.java
+++ b/app/src/main/java/io/appium/uiautomator2/utils/ElementHelpers.java
@@ -197,10 +197,9 @@ public abstract class ElementHelpers {
             if (nodeInfo != null && Objects.equals(nodeInfo.getClassName(), Toast.class.getName())) {
                 return charSequenceToString(nodeInfo.getText(), replaceNull);
             }
-
-            return AccessibilityNodeInfoHelpers.getText(AccessibilityNodeInfoGetter.fromUiObject(element), replaceNull);
         }
-        return toNullableString(((UiObject) element).getText(), replaceNull);
+
+        return AccessibilityNodeInfoHelpers.getText(AccessibilityNodeInfoGetter.fromUiObject(element), replaceNull);
     }
 
     public static String getContentSize(AndroidElement element) throws UiObjectNotFoundException {


### PR DESCRIPTION
For an UiObject element (e.g. Seekbar) the text value returned is not correct.
The page source contains the correct value but for a request of type getText,
the value is different.