### PR TITLE
Fix `ClassCastException` for `Integer` settings values

### DIFF
--- a/app/src/main/java/io/appium/uiautomator2/model/settings/AbstractSetting.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/settings/AbstractSetting.java
@@ -53,8 +53,12 @@ public abstract class AbstractSetting<T> implements ISetting {
 
     private T convertValue(Object value) {
         try {
-            if (valueType == Long.class && value instanceof Number) {
-                return valueType.cast(((Number) value).longValue());
+            if (value instanceof Number) {
+                if (valueType == Integer.class) {
+                    return valueType.cast(((Number) value).intValue());
+                } else if (valueType == Long.class) {
+                    return valueType.cast(((Number) value).longValue());
+                }
             }
             return valueType.cast(value);
         } catch (ClassCastException e) {

--- a/app/src/test/java/io/appium/uiautomator2/model/settings/AbstractSettingTests.java
+++ b/app/src/test/java/io/appium/uiautomator2/model/settings/AbstractSettingTests.java
@@ -18,25 +18,23 @@ package io.appium.uiautomator2.model.settings;
 
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.mockito.Spy;
 
 import io.appium.uiautomator2.common.exceptions.UiAutomator2Exception;
 
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
 import static org.mockito.MockitoAnnotations.initMocks;
 
 public class AbstractSettingTests {
-
-    @Rule
-    public ExpectedException thrown = ExpectedException.none();
+    @Spy
+    private DummyIntegerSetting dummyIntegerSetting;
 
     @Spy
-    private DummySetting dummySetting;
+    private DummyLongSetting dummyLongSetting;
 
     @Before
     public void setUp() {
@@ -44,44 +42,108 @@ public class AbstractSettingTests {
     }
 
     @Test
-    public void shouldThrowExceptionIfTypeIsNotValid() {
-        thrown.expect(UiAutomator2Exception.class);
-        thrown.expectMessage("Invalid setting value type. Got: java.lang.String. Expected: java.lang.Long");
-        dummySetting.update("test");
+    public void dummyIntegerSettingShouldThrowExceptionIfTypeIsNotValid() {
+        boolean exceptionThrown = false;
+        try {
+            dummyIntegerSetting.update("test");
+        } catch (UiAutomator2Exception e) {
+            exceptionThrown = true;
+        }
+        Assert.assertTrue(exceptionThrown);
     }
 
     @Test
-    public void shouldNotThrowExceptionIfApplyFailed() {
-        doThrow(new UiAutomator2Exception("error")).when(dummySetting).apply(anyLong());
-        dummySetting.update(10);
+    public void dummyIntegerSettingShouldNotThrowExceptionIfApplyFailed() {
+        doThrow(new UiAutomator2Exception("error")).when(dummyIntegerSetting).apply(anyInt());
+        boolean exceptionThrown = false;
+        try {
+            dummyIntegerSetting.update(10);
+        } catch (Exception e) {
+            exceptionThrown = true;
+        }
+        Assert.assertFalse(exceptionThrown);
     }
 
     @Test
-    public void shouldReturnValidValueType() {
-        Assert.assertEquals(Long.class, dummySetting.getValueType());
+    public void dummyIntegerSettingShouldReturnValidValueType() {
+        Assert.assertEquals(Integer.class, dummyIntegerSetting.getValueType());
     }
 
     @Test
-    public void shouldCallApplyWithValidValue() {
-        dummySetting.update(123);
-        verify(dummySetting).apply(123L);
+    public void dummyIntegerSettingShouldCallApplyWithValidValue() {
+        dummyIntegerSetting.update(123);
+        verify(dummyIntegerSetting).apply(123);
+        Assert.assertEquals(Integer.valueOf(123), dummyIntegerSetting.getValue());
     }
 
-    private class DummySetting extends AbstractSetting<Long> {
+    private class DummyIntegerSetting extends AbstractSetting<Integer> {
+        private Integer value = null;
 
-        public DummySetting() {
-            super(Long.class, "dummy");
+        public DummyIntegerSetting() {
+            super(Integer.class, "dummyInteger");
+        }
+
+        @Override
+        public Integer getValue() {
+            return value;
+        }
+
+        @Override
+        protected void apply(Integer value) {
+            this.value = value;
+        }
+    }
+
+    @Test
+    public void dummyLongSettingShouldThrowExceptionIfTypeIsNotValid() {
+        boolean exceptionThrown = false;
+        try {
+            dummyLongSetting.update("test");
+        } catch (UiAutomator2Exception e) {
+            exceptionThrown = true;
+        }
+        Assert.assertTrue(exceptionThrown);
+    }
+
+    @Test
+    public void dummyLongSettingShouldNotThrowExceptionIfApplyFailed() {
+        doThrow(new UiAutomator2Exception("error")).when(dummyLongSetting).apply(anyLong());
+        boolean exceptionThrown = false;
+        try {
+            dummyLongSetting.update(10L);
+        } catch (Exception e) {
+            exceptionThrown = true;
+        }
+        Assert.assertFalse(exceptionThrown);
+    }
+
+    @Test
+    public void dummyLongSettingShouldReturnValidValueType() {
+        Assert.assertEquals(Long.class, dummyLongSetting.getValueType());
+    }
+
+    @Test
+    public void dummyLongSettingShouldCallApplyWithValidValue() {
+        dummyLongSetting.update(123L);
+        verify(dummyLongSetting).apply(123L);
+        Assert.assertEquals(Long.valueOf(123), dummyLongSetting.getValue());
+    }
+
+    private class DummyLongSetting extends AbstractSetting<Long> {
+        private Long value = null;
+
+        public DummyLongSetting() {
+            super(Long.class, "dummyLong");
         }
 
         @Override
         public Long getValue() {
-            return 123L;
+            return value;
         }
 
         @Override
         protected void apply(Long value) {
-            // do nothing
+            this.value = value;
         }
     }
-
 }

--- a/app/src/test/java/io/appium/uiautomator2/model/settings/ActionAcknowledgmentTimeoutTests.java
+++ b/app/src/test/java/io/appium/uiautomator2/model/settings/ActionAcknowledgmentTimeoutTests.java
@@ -28,14 +28,12 @@ import org.powermock.modules.junit4.PowerMockRunner;
 import androidx.test.uiautomator.Configurator;
 
 import static org.mockito.Matchers.anyLong;
-import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({Configurator.class})
 public class ActionAcknowledgmentTimeoutTests {
-
     private ActionAcknowledgmentTimeout actionAcknowledgmentTimeout;
 
     @Mock
@@ -61,13 +59,13 @@ public class ActionAcknowledgmentTimeoutTests {
 
     @Test
     public void shouldBeAbleToSetActionAcknowledgmentTimeout() {
-        actionAcknowledgmentTimeout.update(123);
-        verify(configurator).setActionAcknowledgmentTimeout(123);
+        actionAcknowledgmentTimeout.update(123L);
+        verify(configurator).setActionAcknowledgmentTimeout(123L);
     }
 
     @Test
     public void shouldBeAbleToGetActionAcknowledgmentTimeout() {
-        doReturn(123L).when(configurator).getActionAcknowledgmentTimeout();
+        when(configurator.getActionAcknowledgmentTimeout()).thenReturn(123L);
         Assert.assertEquals(Long.valueOf(123), actionAcknowledgmentTimeout.getValue());
     }
 }

--- a/app/src/test/java/io/appium/uiautomator2/model/settings/KeyInjectionDelayTests.java
+++ b/app/src/test/java/io/appium/uiautomator2/model/settings/KeyInjectionDelayTests.java
@@ -34,7 +34,6 @@ import static org.mockito.Mockito.when;
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({Configurator.class})
 public class KeyInjectionDelayTests {
-
     private KeyInjectionDelay keyInjectionDelay;
 
     @Mock
@@ -60,13 +59,13 @@ public class KeyInjectionDelayTests {
 
     @Test
     public void shouldBeAbleToSetKeyInjectionDelay() {
-        keyInjectionDelay.update(123);
-        verify(configurator).setKeyInjectionDelay(123);
+        keyInjectionDelay.update(123L);
+        verify(configurator).setKeyInjectionDelay(123L);
     }
 
     @Test
     public void shouldBeAbleToGetKeyInjectionDelay() {
-        when(configurator.getKeyInjectionDelay()).thenReturn((long) 123);
+        when(configurator.getKeyInjectionDelay()).thenReturn(123L);
         Assert.assertEquals(Long.valueOf(123), keyInjectionDelay.getValue());
     }
 }

--- a/app/src/test/java/io/appium/uiautomator2/model/settings/ScrollAcknowledgmentTimeoutTests.java
+++ b/app/src/test/java/io/appium/uiautomator2/model/settings/ScrollAcknowledgmentTimeoutTests.java
@@ -34,7 +34,6 @@ import static org.mockito.Mockito.when;
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({Configurator.class})
 public class ScrollAcknowledgmentTimeoutTests {
-
     private ScrollAcknowledgmentTimeout scrollAcknowledgmentTimeout;
 
     @Mock
@@ -60,13 +59,13 @@ public class ScrollAcknowledgmentTimeoutTests {
 
     @Test
     public void shouldBeAbleToSetScrollAcknowledgmentTimeout() {
-        scrollAcknowledgmentTimeout.update(123);
-        verify(configurator).setScrollAcknowledgmentTimeout(123);
+        scrollAcknowledgmentTimeout.update(123L);
+        verify(configurator).setScrollAcknowledgmentTimeout(123L);
     }
 
     @Test
     public void shouldBeAbleToGetScrollAcknowledgmentTimeout() {
-        when(configurator.getScrollAcknowledgmentTimeout()).thenReturn((long) 123);
+        when(configurator.getScrollAcknowledgmentTimeout()).thenReturn(123L);
         Assert.assertEquals(Long.valueOf(123), scrollAcknowledgmentTimeout.getValue());
     }
 }

--- a/app/src/test/java/io/appium/uiautomator2/model/settings/WaitForIdleTimeoutTests.java
+++ b/app/src/test/java/io/appium/uiautomator2/model/settings/WaitForIdleTimeoutTests.java
@@ -34,15 +34,14 @@ import static org.mockito.Mockito.when;
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({Configurator.class})
 public class WaitForIdleTimeoutTests {
-
-    private WaitForIdleTimeout waitForIdeTimeout;
+    private WaitForIdleTimeout waitForIdleTimeout;
 
     @Mock
     private Configurator configurator;
 
     @Before
     public void setup() {
-        waitForIdeTimeout = new WaitForIdleTimeout();
+        waitForIdleTimeout = new WaitForIdleTimeout();
         PowerMockito.mockStatic(Configurator.class);
         when(Configurator.getInstance()).thenReturn(configurator);
         when(configurator.setWaitForIdleTimeout(anyLong())).thenReturn(configurator);
@@ -50,23 +49,23 @@ public class WaitForIdleTimeoutTests {
 
     @Test
     public void shouldBeLong() {
-        Assert.assertEquals(Long.class, waitForIdeTimeout.getValueType());
+        Assert.assertEquals(Long.class, waitForIdleTimeout.getValueType());
     }
 
     @Test
     public void shouldReturnValidSettingName() {
-        Assert.assertEquals("waitForIdleTimeout", waitForIdeTimeout.getName());
+        Assert.assertEquals("waitForIdleTimeout", waitForIdleTimeout.getName());
     }
 
     @Test
     public void shouldBeAbleToSetIdleTimeout() {
-        waitForIdeTimeout.update(123);
-        verify(configurator).setWaitForIdleTimeout(123);
+        waitForIdleTimeout.update(123L);
+        verify(configurator).setWaitForIdleTimeout(123L);
     }
 
     @Test
     public void shouldBeAbleToGetIdleTimeout() {
-        when(configurator.getWaitForIdleTimeout()).thenReturn((long) 123);
-        Assert.assertEquals(Long.valueOf(123), waitForIdeTimeout.getValue());
+        when(configurator.getWaitForIdleTimeout()).thenReturn(123L);
+        Assert.assertEquals(Long.valueOf(123), waitForIdleTimeout.getValue());
     }
 }

--- a/app/src/test/java/io/appium/uiautomator2/model/settings/WaitForSelectorTimeoutTests.java
+++ b/app/src/test/java/io/appium/uiautomator2/model/settings/WaitForSelectorTimeoutTests.java
@@ -34,7 +34,6 @@ import static org.mockito.Mockito.when;
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({Configurator.class})
 public class WaitForSelectorTimeoutTests {
-
     private WaitForSelectorTimeout waitForSelectorTimeout;
 
     @Mock
@@ -60,13 +59,13 @@ public class WaitForSelectorTimeoutTests {
 
     @Test
     public void shouldBeAbleToSetSelectorTimeout() {
-        waitForSelectorTimeout.update(123);
-        verify(configurator).setWaitForSelectorTimeout(123);
+        waitForSelectorTimeout.update(123L);
+        verify(configurator).setWaitForSelectorTimeout(123L);
     }
 
     @Test
     public void shouldBeAbleToGetSelectorTimeout() {
-        when(configurator.getWaitForSelectorTimeout()).thenReturn((long) 123);
+        when(configurator.getWaitForSelectorTimeout()).thenReturn(123L);
         Assert.assertEquals(Long.valueOf(123), waitForSelectorTimeout.getValue());
     }
 }


### PR DESCRIPTION
While adding support for _mjpeg-streaming_ some new `AbstractSetting(s)` were introduced that are / were `Integer` values (the first of their type).

While testing the integration it turns out that the values are being interpreted as `Double(s)` and as a result a `ClassCastException` is raised.

This change-set follows the pattern established for `Long` in the `convertValue` function and adds compatibility for `Integer` value(s) + related tests.