### PR TITLE
fix: Do not add fake root for searches with context

### DIFF
--- a/app/src/androidTestE2eTest/java/io/appium/uiautomator2/unittest/test/DeviceCommandsTest.java
+++ b/app/src/androidTestE2eTest/java/io/appium/uiautomator2/unittest/test/DeviceCommandsTest.java
@@ -314,8 +314,7 @@ public class DeviceCommandsTest extends BaseTest {
         String contextId = response.getElementId();
 
         //child element - By.xpath  (UiObject2)
-        response = findElement(By.xpath("//hierarchy//*[@class='android.widget.TextView'][2]"),
-                contextId);
+        response = findElement(By.xpath("(//*[@class='android.widget.TextView'])[2]"), contextId);
         response = getText(response.getElementId());
         assertEquals("Accessibility", response.getValue());
     }

--- a/app/src/androidTestE2eTest/java/io/appium/uiautomator2/unittest/test/DeviceCommandsTest.java
+++ b/app/src/androidTestE2eTest/java/io/appium/uiautomator2/unittest/test/DeviceCommandsTest.java
@@ -380,6 +380,18 @@ public class DeviceCommandsTest extends BaseTest {
     }
 
     @Test
+    public void findElementWithContextId10() {
+        //parent element - By.androidUiAutomator (UiObject)
+        Response response = findElement(By.androidUiAutomator("new UiSelector().resourceId" +
+                "(\"android:id/list\")"));
+        String contextId = response.getElementId();
+
+        //child element - relative By.xpath
+        response = findElement(By.xpath("./*"), contextId);
+        assertTrue(response.isSuccessful());
+    }
+
+    @Test
     public void findElementWithAttributes() throws JSONException {
         scrollToText("Views");
         Response response = findElement(By.accessibilityId("Views"));

--- a/app/src/main/java/io/appium/uiautomator2/core/AccessibilityNodeInfoDumper.java
+++ b/app/src/main/java/io/appium/uiautomator2/core/AccessibilityNodeInfoDumper.java
@@ -45,6 +45,7 @@ import java.util.concurrent.Semaphore;
 import io.appium.uiautomator2.common.exceptions.InvalidSelectorException;
 import io.appium.uiautomator2.common.exceptions.UiAutomator2Exception;
 import io.appium.uiautomator2.model.NotificationListener;
+import io.appium.uiautomator2.model.UiAutomationElement;
 import io.appium.uiautomator2.model.UiElement;
 import io.appium.uiautomator2.model.settings.NormalizeTagNames;
 import io.appium.uiautomator2.model.settings.Settings;
@@ -174,7 +175,7 @@ public class AccessibilityNodeInfoDumper {
             serializer.setFeature("http://xmlpull.org/v1/doc/features.html#indent-output", true);
             final UiElement<?, ?> xpathRoot = root == null
                     ? rebuildForNewRoots(getCachedWindowRoots(), NotificationListener.getInstance().getToastMessage())
-                    : rebuildForNewRoots(new AccessibilityNodeInfo[]{root});
+                    : new UiAutomationElement(root, 0);
             serializeUiElement(xpathRoot, 0);
             serializer.endDocument();
             Logger.debug(String.format("The source XML tree (%s bytes) has been fetched in %sms",
@@ -223,7 +224,7 @@ public class AccessibilityNodeInfoDumper {
             final NodeInfoList matchedNodes = new NodeInfoList();
             final long timeStarted = SystemClock.uptimeMillis();
             for (org.jdom2.Attribute uiElementId : expr.evaluate(document)) {
-                @SuppressWarnings("rawtypes") final UiElement uiElement = uiElementsMapping.get(uiElementId.getIntValue());
+                UiElement<?, ?> uiElement = uiElementsMapping.get(uiElementId.getIntValue());
                 if (uiElement == null || uiElement.getNode() == null) {
                     continue;
                 }
@@ -233,7 +234,7 @@ public class AccessibilityNodeInfoDumper {
                     break;
                 }
             }
-            Logger.debug(String.format("Took %sms to retrieve %s matches for '%s' XPath query",
+            Logger.info(String.format("Took %sms to retrieve %s matches for '%s' XPath query",
                     SystemClock.uptimeMillis() - timeStarted, matchedNodes.size(), xpathSelector));
             return matchedNodes;
         } catch (JDOMParseException e) {

--- a/app/src/main/java/io/appium/uiautomator2/core/AccessibilityNodeInfoDumper.java
+++ b/app/src/main/java/io/appium/uiautomator2/core/AccessibilityNodeInfoDumper.java
@@ -46,7 +46,7 @@ import io.appium.uiautomator2.common.exceptions.InvalidSelectorException;
 import io.appium.uiautomator2.common.exceptions.StaleElementReferenceException;
 import io.appium.uiautomator2.common.exceptions.UiAutomator2Exception;
 import io.appium.uiautomator2.model.NotificationListener;
-import io.appium.uiautomator2.model.UiAutomationElement;
+import io.appium.uiautomator2.model.UiElementSnapshot;
 import io.appium.uiautomator2.model.UiElement;
 import io.appium.uiautomator2.model.settings.NormalizeTagNames;
 import io.appium.uiautomator2.model.settings.Settings;
@@ -55,7 +55,7 @@ import io.appium.uiautomator2.utils.Logger;
 import io.appium.uiautomator2.utils.NodeInfoList;
 import io.appium.uiautomator2.utils.StringHelpers;
 
-import static io.appium.uiautomator2.model.UiAutomationElement.rebuildForNewRoots;
+import static io.appium.uiautomator2.model.UiElementSnapshot.rebuildForNewRoots;
 import static io.appium.uiautomator2.utils.AXWindowHelpers.getCachedWindowRoots;
 import static io.appium.uiautomator2.utils.XMLHelpers.toNodeName;
 import static io.appium.uiautomator2.utils.XMLHelpers.toSafeString;
@@ -176,7 +176,7 @@ public class AccessibilityNodeInfoDumper {
             serializer.setFeature("http://xmlpull.org/v1/doc/features.html#indent-output", true);
             final UiElement<?, ?> xpathRoot = root == null
                     ? rebuildForNewRoots(getCachedWindowRoots(), NotificationListener.getInstance().getToastMessage())
-                    : UiAutomationElement.getCachedElement(root);
+                    : UiElementSnapshot.getFromCache(root);
             if (xpathRoot == null) {
                 throw new StaleElementReferenceException(
                         String.format("The element %s does not exist in DOM anymore", root));

--- a/app/src/main/java/io/appium/uiautomator2/core/AccessibilityNodeInfoDumper.java
+++ b/app/src/main/java/io/appium/uiautomator2/core/AccessibilityNodeInfoDumper.java
@@ -43,6 +43,7 @@ import java.util.Set;
 import java.util.concurrent.Semaphore;
 
 import io.appium.uiautomator2.common.exceptions.InvalidSelectorException;
+import io.appium.uiautomator2.common.exceptions.StaleElementReferenceException;
 import io.appium.uiautomator2.common.exceptions.UiAutomator2Exception;
 import io.appium.uiautomator2.model.NotificationListener;
 import io.appium.uiautomator2.model.UiAutomationElement;
@@ -175,7 +176,11 @@ public class AccessibilityNodeInfoDumper {
             serializer.setFeature("http://xmlpull.org/v1/doc/features.html#indent-output", true);
             final UiElement<?, ?> xpathRoot = root == null
                     ? rebuildForNewRoots(getCachedWindowRoots(), NotificationListener.getInstance().getToastMessage())
-                    : new UiAutomationElement(root, 0);
+                    : UiAutomationElement.getCachedElement(root);
+            if (xpathRoot == null) {
+                throw new StaleElementReferenceException(
+                        String.format("The element %s does not exist in DOM anymore", root));
+            }
             serializeUiElement(xpathRoot, 0);
             serializer.endDocument();
             Logger.debug(String.format("The source XML tree (%s bytes) has been fetched in %sms",

--- a/app/src/main/java/io/appium/uiautomator2/handler/FindElement.java
+++ b/app/src/main/java/io/appium/uiautomator2/handler/FindElement.java
@@ -60,19 +60,15 @@ public class FindElement extends SafeRequestHandler {
         final String method = model.strategy;
         final String selector = model.selector;
         final String contextId = model.context;
-
-        Logger.info(String.format("Find element command using '%s' with selector '%s'.", method, selector));
+        if (contextId == null) {
+            Logger.info(String.format("method: '%s', selector: '%s'", method, selector));
+        } else {
+            Logger.info(String.format("method: '%s', selector: '%s', contextId: '%s'",
+                    method, selector, contextId));
+        }
 
         final By by = new NativeAndroidBySelector().pickFrom(method, selector);
-
-        final Object element;
-        try {
-            element = isBlank(contextId)
-                    ? this.findElement(by)
-                    : this.findElement(by, contextId);
-        } catch (ClassNotFoundException e) {
-            throw new UiAutomator2Exception(e);
-        }
+        final Object element = isBlank(contextId) ? this.findElement(by) : this.findElement(by, contextId);
         if (element == null) {
             throw new ElementNotFoundException();
         }
@@ -112,8 +108,7 @@ public class FindElement extends SafeRequestHandler {
     }
 
     @Nullable
-    private Object findElement(By by, String contextId) throws ClassNotFoundException,
-            UiAutomator2Exception, UiObjectNotFoundException {
+    private Object findElement(By by, String contextId) throws UiAutomator2Exception, UiObjectNotFoundException {
         Session session = AppiumUIA2Driver.getInstance().getSessionOrThrow();
         AndroidElement element = session.getKnownElements().getElementFromCache(contextId);
         if (element == null) {

--- a/app/src/main/java/io/appium/uiautomator2/handler/FindElements.java
+++ b/app/src/main/java/io/appium/uiautomator2/handler/FindElements.java
@@ -68,16 +68,18 @@ public class FindElements extends SafeRequestHandler {
         final String method = model.strategy;
         final String selector = model.selector;
         final String contextId = model.context;
-
-        Logger.info(String.format("Find elements command using '%s' with selector '%s'.", method, selector));
+        if (contextId == null) {
+            Logger.info(String.format("method: '%s', selector: '%s'", method, selector));
+        } else {
+            Logger.info(String.format("method: '%s', selector: '%s', contextId: '%s'",
+                    method, selector, contextId));
+        }
 
         By by = new NativeAndroidBySelector().pickFrom(method, selector);
 
         final List<?> elements;
         try {
-            elements = isBlank(contextId)
-                    ? this.findElements(by)
-                    : this.findElements(by, contextId);
+            elements = isBlank(contextId) ? this.findElements(by) : this.findElements(by, contextId);
 
             Session session = AppiumUIA2Driver.getInstance().getSessionOrThrow();
             for (Object element : elements) {
@@ -88,10 +90,8 @@ public class FindElements extends SafeRequestHandler {
             }
             return new AppiumResponse(getSessionId(request), result);
         } catch (ElementNotFoundException ignored) {
-            /* For findElements up on no Element. instead of throwing exception unlike in findElement,
-               empty array should be return. for more info refer:
-               https://github.com/SeleniumHQ/selenium/wiki/JsonWireProtocol#sessionsessionidelements
-              */
+            // Return an empty array:
+            // https://github.com/SeleniumHQ/selenium/wiki/JsonWireProtocol#sessionsessionidelements
             return new AppiumResponse(getSessionId(request), result);
         }
     }

--- a/app/src/main/java/io/appium/uiautomator2/model/CustomUiSelector.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/CustomUiSelector.java
@@ -22,9 +22,6 @@ import androidx.test.uiautomator.UiSelector;
 
 import io.appium.uiautomator2.utils.Attribute;
 
-import static io.appium.uiautomator2.utils.AXWindowHelpers.getCachedWindowRoots;
-
-
 public class CustomUiSelector {
     private UiSelector selector;
 
@@ -33,11 +30,11 @@ public class CustomUiSelector {
     }
 
     /**
-     * @param node
+     * @param node the source accessibility node
      * @return UiSelector object, based on UiAutomationElement attributes
      */
     public UiSelector getUiSelector(AccessibilityNodeInfo node) {
-        UiAutomationElement uiAutomationElement = UiAutomationElement.getCachedElement(node, getCachedWindowRoots());
+        UiAutomationElement uiAutomationElement = UiAutomationElement.getCachedElement(node);
         if (uiAutomationElement == null) {
             throw new IllegalArgumentException(String.format("The '%s' node is not found in the cache", node));
         }

--- a/app/src/main/java/io/appium/uiautomator2/model/CustomUiSelector.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/CustomUiSelector.java
@@ -34,27 +34,27 @@ public class CustomUiSelector {
      * @return UiSelector object, based on UiAutomationElement attributes
      */
     public UiSelector getUiSelector(AccessibilityNodeInfo node) {
-        UiAutomationElement uiAutomationElement = UiAutomationElement.getCachedElement(node);
-        if (uiAutomationElement == null) {
+        UiElementSnapshot uiElementSnapshot = UiElementSnapshot.getFromCache(node);
+        if (uiElementSnapshot == null) {
             throw new IllegalArgumentException(String.format("The '%s' node is not found in the cache", node));
         }
-        put(Attribute.PACKAGE, uiAutomationElement.getPackageName());
-        put(Attribute.CLASS, uiAutomationElement.getClassName());
+        put(Attribute.PACKAGE, uiElementSnapshot.getPackageName());
+        put(Attribute.CLASS, uiElementSnapshot.getClassName());
         // For proper selector matching it is important to not replace nulls with empty strings
-        put(Attribute.TEXT, uiAutomationElement.getOriginalText());
-        put(Attribute.CONTENT_DESC, uiAutomationElement.getContentDescription());
-        put(Attribute.RESOURCE_ID, uiAutomationElement.getResourceId());
-        put(Attribute.CHECKABLE, uiAutomationElement.isCheckable());
-        put(Attribute.CHECKED, uiAutomationElement.isChecked());
-        put(Attribute.CLICKABLE, uiAutomationElement.isClickable());
-        put(Attribute.ENABLED, uiAutomationElement.isEnabled());
-        put(Attribute.FOCUSABLE, uiAutomationElement.isFocusable());
-        put(Attribute.FOCUSED, uiAutomationElement.isFocused());
-        put(Attribute.LONG_CLICKABLE, uiAutomationElement.isLongClickable());
-        put(Attribute.PASSWORD, uiAutomationElement.isPassword());
-        put(Attribute.SCROLLABLE, uiAutomationElement.isScrollable());
-        put(Attribute.SELECTED, uiAutomationElement.isSelected());
-        put(Attribute.INDEX, uiAutomationElement.getIndex());
+        put(Attribute.TEXT, uiElementSnapshot.getOriginalText());
+        put(Attribute.CONTENT_DESC, uiElementSnapshot.getContentDescription());
+        put(Attribute.RESOURCE_ID, uiElementSnapshot.getResourceId());
+        put(Attribute.CHECKABLE, uiElementSnapshot.isCheckable());
+        put(Attribute.CHECKED, uiElementSnapshot.isChecked());
+        put(Attribute.CLICKABLE, uiElementSnapshot.isClickable());
+        put(Attribute.ENABLED, uiElementSnapshot.isEnabled());
+        put(Attribute.FOCUSABLE, uiElementSnapshot.isFocusable());
+        put(Attribute.FOCUSED, uiElementSnapshot.isFocused());
+        put(Attribute.LONG_CLICKABLE, uiElementSnapshot.isLongClickable());
+        put(Attribute.PASSWORD, uiElementSnapshot.isPassword());
+        put(Attribute.SCROLLABLE, uiElementSnapshot.isScrollable());
+        put(Attribute.SELECTED, uiElementSnapshot.isSelected());
+        put(Attribute.INDEX, uiElementSnapshot.getIndex());
 
         return selector;
     }

--- a/app/src/main/java/io/appium/uiautomator2/model/UiAutomationElement.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/UiAutomationElement.java
@@ -36,6 +36,7 @@ import io.appium.uiautomator2.utils.Logger;
 
 import static androidx.test.internal.util.Checks.checkNotNull;
 import static io.appium.uiautomator2.model.settings.Settings.ALLOW_INVISIBLE_ELEMENTS;
+import static io.appium.uiautomator2.utils.AXWindowHelpers.getCachedWindowRoots;
 import static io.appium.uiautomator2.utils.ReflectionUtils.setField;
 import static io.appium.uiautomator2.utils.StringHelpers.charSequenceToNullableString;
 
@@ -59,7 +60,7 @@ public class UiAutomationElement extends UiElement<AccessibilityNodeInfo, UiAuto
      * {@link AccessibilityNodeInfo} is updated, a new {@code UiAutomationElement}
      * instance will be created in
      */
-    public UiAutomationElement(AccessibilityNodeInfo node, int index) {
+    private UiAutomationElement(AccessibilityNodeInfo node, int index) {
         super(checkNotNull(node));
 
         Map<Attribute, Object> attributes = new LinkedHashMap<>();
@@ -129,9 +130,9 @@ public class UiAutomationElement extends UiElement<AccessibilityNodeInfo, UiAuto
     }
 
     @Nullable
-    public static UiAutomationElement getCachedElement(AccessibilityNodeInfo rawElement, AccessibilityNodeInfo[] windowRoots) {
+    public static UiAutomationElement getCachedElement(AccessibilityNodeInfo rawElement) {
         if (cache.get(rawElement) == null) {
-            rebuildForNewRoots(windowRoots);
+            rebuildForNewRoots(getCachedWindowRoots());
         }
         return cache.get(rawElement);
     }

--- a/app/src/main/java/io/appium/uiautomator2/model/UiAutomationElement.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/UiAutomationElement.java
@@ -59,7 +59,7 @@ public class UiAutomationElement extends UiElement<AccessibilityNodeInfo, UiAuto
      * {@link AccessibilityNodeInfo} is updated, a new {@code UiAutomationElement}
      * instance will be created in
      */
-    private UiAutomationElement(AccessibilityNodeInfo node, int index) {
+    public UiAutomationElement(AccessibilityNodeInfo node, int index) {
         super(checkNotNull(node));
 
         Map<Attribute, Object> attributes = new LinkedHashMap<>();

--- a/app/src/main/java/io/appium/uiautomator2/model/UiElement.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/UiElement.java
@@ -35,8 +35,6 @@ import io.appium.uiautomator2.utils.Attribute;
  * @param <E> the type of the concrete subclass of UiElement
  */
 public abstract class UiElement<R, E extends UiElement<R, E>> {
-    // These two attribute names are used for debugging only.
-    // The two constants are used internally and must match to-uiautomator.xsl.
     private final AccessibilityNodeInfo node;
 
     public UiElement(AccessibilityNodeInfo node) {

--- a/app/src/main/java/io/appium/uiautomator2/model/UiElementSnapshot.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/UiElementSnapshot.java
@@ -65,30 +65,30 @@ public class UiElementSnapshot extends UiElement<AccessibilityNodeInfo, UiElemen
 
         Map<Attribute, Object> attributes = new LinkedHashMap<>();
         // The same sequence will be used for node attributes in xml page source
-        put(attributes, Attribute.INDEX, index);
-        put(attributes, Attribute.PACKAGE, charSequenceToNullableString(node.getPackageName()));
-        put(attributes, Attribute.CLASS, charSequenceToNullableString(node.getClassName()));
-        put(attributes, Attribute.TEXT, AccessibilityNodeInfoHelpers.getText(node, true));
-        put(attributes, Attribute.ORIGINAL_TEXT, AccessibilityNodeInfoHelpers.getText(node, false));
-        put(attributes, Attribute.CONTENT_DESC, charSequenceToNullableString(node.getContentDescription()));
-        put(attributes, Attribute.RESOURCE_ID, node.getViewIdResourceName());
-        put(attributes, Attribute.CHECKABLE, node.isCheckable());
-        put(attributes, Attribute.CHECKED, node.isChecked());
-        put(attributes, Attribute.CLICKABLE, node.isClickable());
-        put(attributes, Attribute.ENABLED, node.isEnabled());
-        put(attributes, Attribute.FOCUSABLE, node.isFocusable());
-        put(attributes, Attribute.FOCUSED, node.isFocused());
-        put(attributes, Attribute.LONG_CLICKABLE, node.isLongClickable());
-        put(attributes, Attribute.PASSWORD, node.isPassword());
-        put(attributes, Attribute.SCROLLABLE, node.isScrollable());
+        setAttribute(attributes, Attribute.INDEX, index);
+        setAttribute(attributes, Attribute.PACKAGE, charSequenceToNullableString(node.getPackageName()));
+        setAttribute(attributes, Attribute.CLASS, charSequenceToNullableString(node.getClassName()));
+        setAttribute(attributes, Attribute.TEXT, AccessibilityNodeInfoHelpers.getText(node, true));
+        setAttribute(attributes, Attribute.ORIGINAL_TEXT, AccessibilityNodeInfoHelpers.getText(node, false));
+        setAttribute(attributes, Attribute.CONTENT_DESC, charSequenceToNullableString(node.getContentDescription()));
+        setAttribute(attributes, Attribute.RESOURCE_ID, node.getViewIdResourceName());
+        setAttribute(attributes, Attribute.CHECKABLE, node.isCheckable());
+        setAttribute(attributes, Attribute.CHECKED, node.isChecked());
+        setAttribute(attributes, Attribute.CLICKABLE, node.isClickable());
+        setAttribute(attributes, Attribute.ENABLED, node.isEnabled());
+        setAttribute(attributes, Attribute.FOCUSABLE, node.isFocusable());
+        setAttribute(attributes, Attribute.FOCUSED, node.isFocused());
+        setAttribute(attributes, Attribute.LONG_CLICKABLE, node.isLongClickable());
+        setAttribute(attributes, Attribute.PASSWORD, node.isPassword());
+        setAttribute(attributes, Attribute.SCROLLABLE, node.isScrollable());
         Range<Integer> selectionRange = AccessibilityNodeInfoHelpers.getSelectionRange(node);
         if (selectionRange != null) {
             attributes.put(Attribute.SELECTION_START, selectionRange.getLower());
             attributes.put(Attribute.SELECTION_END, selectionRange.getUpper());
         }
-        put(attributes, Attribute.SELECTED, node.isSelected());
-        put(attributes, Attribute.BOUNDS, AccessibilityNodeInfoHelpers.getBounds(node).toShortString());
-        put(attributes, Attribute.DISPLAYED, node.isVisibleToUser());
+        setAttribute(attributes, Attribute.SELECTED, node.isSelected());
+        setAttribute(attributes, Attribute.BOUNDS, AccessibilityNodeInfoHelpers.getBounds(node).toShortString());
+        setAttribute(attributes, Attribute.DISPLAYED, node.isVisibleToUser());
         // Skip CONTENT_SIZE as it is quite expensive to compute it for each element
         this.attributes = Collections.unmodifiableMap(attributes);
         this.children = buildChildren(node);
@@ -97,14 +97,20 @@ public class UiElementSnapshot extends UiElement<AccessibilityNodeInfo, UiElemen
     private UiElementSnapshot(String hierarchyClassName, AccessibilityNodeInfo[] childNodes, int index) {
         super(null);
         Map<Attribute, Object> attribs = new LinkedHashMap<>();
-        put(attribs, Attribute.INDEX, index);
-        put(attribs, Attribute.CLASS, hierarchyClassName);
+        setAttribute(attribs, Attribute.INDEX, index);
+        setAttribute(attribs, Attribute.CLASS, hierarchyClassName);
         this.attributes = Collections.unmodifiableMap(attribs);
         List<UiElementSnapshot> children = new ArrayList<>();
         for (AccessibilityNodeInfo childNode : childNodes) {
             children.add(new UiElementSnapshot(childNode, children.size()));
         }
         this.children = children;
+    }
+
+    private static void setAttribute(Map<Attribute, Object> attribs, Attribute key, Object value) {
+        if (value != null) {
+            attribs.put(key, value);
+        }
     }
 
     private int getDepth() {
@@ -145,12 +151,6 @@ public class UiElementSnapshot extends UiElement<AccessibilityNodeInfo, UiElemen
             cache.put(rawElement, element);
         }
         return element;
-    }
-
-    private void put(Map<Attribute, Object> attribs, Attribute key, Object value) {
-        if (value != null) {
-            attribs.put(key, value);
-        }
     }
 
     private void addToastMsgToRoot(CharSequence tokenMSG) {

--- a/app/src/main/java/io/appium/uiautomator2/model/UiElementSnapshot.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/UiElementSnapshot.java
@@ -44,14 +44,14 @@ import static io.appium.uiautomator2.utils.StringHelpers.charSequenceToNullableS
  * A UiElement that gets attributes via the Accessibility API.
  */
 @TargetApi(18)
-public class UiAutomationElement extends UiElement<AccessibilityNodeInfo, UiAutomationElement> {
+public class UiElementSnapshot extends UiElement<AccessibilityNodeInfo, UiElementSnapshot> {
     private final static String ROOT_NODE_NAME = "hierarchy";
     // https://github.com/appium/appium/issues/12545
     private final static int MAX_DEPTH = 70;
 
-    private final static Map<AccessibilityNodeInfo, UiAutomationElement> cache = new WeakHashMap<>();
+    private final static Map<AccessibilityNodeInfo, UiElementSnapshot> cache = new WeakHashMap<>();
     private final Map<Attribute, Object> attributes;
-    private final List<UiAutomationElement> children;
+    private final List<UiElementSnapshot> children;
     private int depth = 0;
 
     /**
@@ -60,7 +60,7 @@ public class UiAutomationElement extends UiElement<AccessibilityNodeInfo, UiAuto
      * {@link AccessibilityNodeInfo} is updated, a new {@code UiAutomationElement}
      * instance will be created in
      */
-    private UiAutomationElement(AccessibilityNodeInfo node, int index) {
+    private UiElementSnapshot(AccessibilityNodeInfo node, int index) {
         super(checkNotNull(node));
 
         Map<Attribute, Object> attributes = new LinkedHashMap<>();
@@ -94,15 +94,15 @@ public class UiAutomationElement extends UiElement<AccessibilityNodeInfo, UiAuto
         this.children = buildChildren(node);
     }
 
-    private UiAutomationElement(String hierarchyClassName, AccessibilityNodeInfo[] childNodes, int index) {
+    private UiElementSnapshot(String hierarchyClassName, AccessibilityNodeInfo[] childNodes, int index) {
         super(null);
         Map<Attribute, Object> attribs = new LinkedHashMap<>();
         put(attribs, Attribute.INDEX, index);
         put(attribs, Attribute.CLASS, hierarchyClassName);
         this.attributes = Collections.unmodifiableMap(attribs);
-        List<UiAutomationElement> children = new ArrayList<>();
+        List<UiElementSnapshot> children = new ArrayList<>();
         for (AccessibilityNodeInfo childNode : childNodes) {
-            children.add(new UiAutomationElement(childNode, children.size()));
+            children.add(new UiElementSnapshot(childNode, children.size()));
         }
         this.children = children;
     }
@@ -115,13 +115,13 @@ public class UiAutomationElement extends UiElement<AccessibilityNodeInfo, UiAuto
         this.depth = depth;
     }
 
-    public static UiAutomationElement rebuildForNewRoots(AccessibilityNodeInfo[] roots) {
+    public static UiElementSnapshot rebuildForNewRoots(AccessibilityNodeInfo[] roots) {
         return rebuildForNewRoots(roots, Collections.<CharSequence>emptyList());
     }
 
-    public static UiAutomationElement rebuildForNewRoots(AccessibilityNodeInfo[] roots, List<CharSequence> toastMSGs) {
+    public static UiElementSnapshot rebuildForNewRoots(AccessibilityNodeInfo[] roots, List<CharSequence> toastMSGs) {
         cache.clear();
-        UiAutomationElement root = new UiAutomationElement(ROOT_NODE_NAME, roots, 0);
+        UiElementSnapshot root = new UiElementSnapshot(ROOT_NODE_NAME, roots, 0);
         for (CharSequence toastMSG : toastMSGs) {
             Logger.debug(String.format("Adding toast message to root: %s", toastMSG));
             root.addToastMsgToRoot(toastMSG);
@@ -130,17 +130,17 @@ public class UiAutomationElement extends UiElement<AccessibilityNodeInfo, UiAuto
     }
 
     @Nullable
-    public static UiAutomationElement getCachedElement(AccessibilityNodeInfo rawElement) {
+    public static UiElementSnapshot getFromCache(AccessibilityNodeInfo rawElement) {
         if (cache.get(rawElement) == null) {
             rebuildForNewRoots(getCachedWindowRoots());
         }
         return cache.get(rawElement);
     }
 
-    private static UiAutomationElement getOrCreateElement(AccessibilityNodeInfo rawElement, int index, int depth) {
-        UiAutomationElement element = cache.get(rawElement);
+    private static UiElementSnapshot getFromCacheOrCreate(AccessibilityNodeInfo rawElement, int index, int depth) {
+        UiElementSnapshot element = cache.get(rawElement);
         if (element == null) {
-            element = new UiAutomationElement(rawElement, index);
+            element = new UiElementSnapshot(rawElement, index);
             element.setDepth(depth);
             cache.put(rawElement, element);
         }
@@ -160,10 +160,10 @@ public class UiAutomationElement extends UiElement<AccessibilityNodeInfo, UiAuto
         node.setPackageName("com.android.settings");
         setField("mSealed", true, node);
 
-        this.children.add(new UiAutomationElement(node, this.children.size()));
+        this.children.add(new UiElementSnapshot(node, this.children.size()));
     }
 
-    private List<UiAutomationElement> buildChildren(AccessibilityNodeInfo node) {
+    private List<UiElementSnapshot> buildChildren(AccessibilityNodeInfo node) {
         final int childCount = node.getChildCount();
         if (childCount == 0 || getDepth() >= MAX_DEPTH) {
             if (getDepth() >= MAX_DEPTH) {
@@ -173,7 +173,7 @@ public class UiAutomationElement extends UiElement<AccessibilityNodeInfo, UiAuto
             return Collections.emptyList();
         }
 
-        List<UiAutomationElement> children = new ArrayList<>(childCount);
+        List<UiElementSnapshot> children = new ArrayList<>(childCount);
         boolean areInvisibleElementsAllowed = AppiumUIA2Driver
                 .getInstance()
                 .getSessionOrThrow()
@@ -182,14 +182,14 @@ public class UiAutomationElement extends UiElement<AccessibilityNodeInfo, UiAuto
             AccessibilityNodeInfo child = node.getChild(i);
             //Ignore if element is not visible on the screen
             if (child != null && (child.isVisibleToUser() || areInvisibleElementsAllowed)) {
-                children.add(getOrCreateElement(child, i, getDepth() + 1));
+                children.add(getFromCacheOrCreate(child, i, getDepth() + 1));
             }
         }
         return children;
     }
 
     @Override
-    public List<UiAutomationElement> getChildren() {
+    public List<UiElementSnapshot> getChildren() {
         return children;
     }
 

--- a/app/src/main/java/io/appium/uiautomator2/server/AppiumServlet.java
+++ b/app/src/main/java/io/appium/uiautomator2/server/AppiumServlet.java
@@ -18,6 +18,8 @@ package io.appium.uiautomator2.server;
 
 import androidx.annotation.Nullable;
 
+import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -281,7 +283,11 @@ public class AppiumServlet implements IHttpServlet {
 
         String id = getParameter(mappedUri, request.uri(), ":id");
         if (id != null) {
-            request.data().put(ELEMENT_ID_KEY, StandardCharsets.UTF_8.name());
+            try {
+                request.data().put(ELEMENT_ID_KEY, URLDecoder.decode(id, StandardCharsets.UTF_8.name()));
+            } catch (UnsupportedEncodingException e) {
+                throw new RuntimeException(e);
+            }
         }
         for (int elementIdx = SECOND_ELEMENT_IDX; elementIdx < MAX_ELEMENTS + SECOND_ELEMENT_IDX; ++elementIdx) {
             String elementId = getParameter(mappedUri, request.uri(), ":id" + elementIdx);

--- a/app/src/main/java/io/appium/uiautomator2/server/AppiumServlet.java
+++ b/app/src/main/java/io/appium/uiautomator2/server/AppiumServlet.java
@@ -307,7 +307,7 @@ public class AppiumServlet implements IHttpServlet {
             try {
                 return URLDecoder.decode(currentSections[i], StandardCharsets.UTF_8.name());
             } catch (UnsupportedEncodingException e) {
-                throw new RuntimeException(e);
+                throw new IllegalArgumentException(e);
             }
         }
         return null;

--- a/app/src/main/java/io/appium/uiautomator2/server/AppiumServlet.java
+++ b/app/src/main/java/io/appium/uiautomator2/server/AppiumServlet.java
@@ -283,11 +283,7 @@ public class AppiumServlet implements IHttpServlet {
 
         String id = getParameter(mappedUri, request.uri(), ":id");
         if (id != null) {
-            try {
-                request.data().put(ELEMENT_ID_KEY, URLDecoder.decode(id, StandardCharsets.UTF_8.name()));
-            } catch (UnsupportedEncodingException e) {
-                throw new RuntimeException(e);
-            }
+            request.data().put(ELEMENT_ID_KEY, id);
         }
         for (int elementIdx = SECOND_ELEMENT_IDX; elementIdx < MAX_ELEMENTS + SECOND_ELEMENT_IDX; ++elementIdx) {
             String elementId = getParameter(mappedUri, request.uri(), ":id" + elementIdx);
@@ -305,8 +301,13 @@ public class AppiumServlet implements IHttpServlet {
             return null;
         }
         for (int i = 0; i < currentSections.length; i++) {
-            if (configuredSections[i].contains(param)) {
-                return currentSections[i];
+            if (!configuredSections[i].contains(param)) {
+                continue;
+            }
+            try {
+                return URLDecoder.decode(currentSections[i], StandardCharsets.UTF_8.name());
+            } catch (UnsupportedEncodingException e) {
+                throw new RuntimeException(e);
             }
         }
         return null;

--- a/app/src/main/java/io/appium/uiautomator2/server/AppiumServlet.java
+++ b/app/src/main/java/io/appium/uiautomator2/server/AppiumServlet.java
@@ -18,7 +18,7 @@ package io.appium.uiautomator2.server;
 
 import androidx.annotation.Nullable;
 
-import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -281,7 +281,7 @@ public class AppiumServlet implements IHttpServlet {
 
         String id = getParameter(mappedUri, request.uri(), ":id");
         if (id != null) {
-            request.data().put(ELEMENT_ID_KEY, URLDecoder.decode(id));
+            request.data().put(ELEMENT_ID_KEY, StandardCharsets.UTF_8.name());
         }
         for (int elementIdx = SECOND_ELEMENT_IDX; elementIdx < MAX_ELEMENTS + SECOND_ELEMENT_IDX; ++elementIdx) {
             String elementId = getParameter(mappedUri, request.uri(), ":id" + elementIdx);
@@ -293,14 +293,9 @@ public class AppiumServlet implements IHttpServlet {
 
     @Nullable
     private String getParameter(String configuredUri, String actualUri, String param) {
-        return getParameter(configuredUri, actualUri, param, true);
-    }
-
-    @Nullable
-    private String getParameter(String configuredUri, String actualUri, String param, boolean sectionLengthValidation) {
         String[] configuredSections = configuredUri.split("/");
         String[] currentSections = actualUri.split("/");
-        if (sectionLengthValidation && configuredSections.length != currentSections.length) {
+        if (configuredSections.length != currentSections.length) {
             return null;
         }
         for (int i = 0; i < currentSections.length; i++) {


### PR DESCRIPTION
When page source is built for the whole elements hierarchy that a fake `hierarchy` root is added, which contains some additional info about the display. It is also used as a holder for toast elements. Although, it makes no sense to add the same stuff to context searches where the xml root is some subelement.

https://github.com/appium/appium/issues/14509