### PR TITLE
refactor: Tune the way progress values are set on Android API 24+

### DIFF
--- a/app/src/main/java/io/appium/uiautomator2/core/AccessibilityNodeInfoHelpers.java
+++ b/app/src/main/java/io/appium/uiautomator2/core/AccessibilityNodeInfoHelpers.java
@@ -156,7 +156,7 @@ public class AccessibilityNodeInfoHelpers {
         if (!node.getActionList().contains(AccessibilityAction.ACTION_SET_PROGRESS)) {
             throw new InvalidElementStateException(
                     String.format("The element '%s' does not support ACTION_SET_PROGRESS. " +
-                            "Did you locate a proper one?", node));
+                            "Did you interact with the correct element?", node));
         }
 
         float valueToSet = value;
@@ -174,7 +174,7 @@ public class AccessibilityNodeInfoHelpers {
         if (!node.performAction(AccessibilityAction.ACTION_SET_PROGRESS.getId(), args)) {
             throw new InvalidElementStateException(
                     String.format("ACTION_SET_PROGRESS has failed on the element '%s'. " +
-                            "Did you locate a proper one?", node));
+                            "Did you interact with the correct element?", node));
         }
     }
 

--- a/app/src/main/java/io/appium/uiautomator2/core/AccessibilityNodeInfoHelpers.java
+++ b/app/src/main/java/io/appium/uiautomator2/core/AccessibilityNodeInfoHelpers.java
@@ -158,8 +158,19 @@ public class AccessibilityNodeInfoHelpers {
                     String.format("The element '%s' does not support ACTION_SET_PROGRESS. " +
                             "Did you locate a proper one?", node));
         }
+
+        float valueToSet = value;
+        AccessibilityNodeInfo.RangeInfo rangeInfo = node.getRangeInfo();
+        if (rangeInfo != null) {
+            if (value < rangeInfo.getMin()) {
+                valueToSet = rangeInfo.getMin();
+            }
+            if (value > rangeInfo.getMax()) {
+                valueToSet = rangeInfo.getMax();
+            }
+        }
         final Bundle args = new Bundle();
-        args.putFloat(AccessibilityNodeInfo.ACTION_ARGUMENT_PROGRESS_VALUE, value);
+        args.putFloat(AccessibilityNodeInfo.ACTION_ARGUMENT_PROGRESS_VALUE, valueToSet);
         if (!node.performAction(AccessibilityAction.ACTION_SET_PROGRESS.getId(), args)) {
             throw new InvalidElementStateException(
                     String.format("ACTION_SET_PROGRESS has failed on the element '%s'. " +

--- a/app/src/main/java/io/appium/uiautomator2/core/AccessibilityNodeInfoHelpers.java
+++ b/app/src/main/java/io/appium/uiautomator2/core/AccessibilityNodeInfoHelpers.java
@@ -27,6 +27,7 @@ import android.view.accessibility.AccessibilityNodeInfo.AccessibilityAction;
 import androidx.annotation.Nullable;
 import androidx.test.uiautomator.UiDevice;
 
+import io.appium.uiautomator2.common.exceptions.InvalidElementStateException;
 import io.appium.uiautomator2.model.settings.Settings;
 import io.appium.uiautomator2.model.settings.SimpleBoundsCalculation;
 import io.appium.uiautomator2.utils.Logger;
@@ -148,19 +149,22 @@ public class AccessibilityNodeInfoHelpers {
      * Perform accessibility action ACTION_SET_PROGRESS on the node
      *
      * @param value desired progress value
-     * @return true if action performed successfully
+     * @throws InvalidElementStateException if there was a failure while setting the progress value
      */
     @TargetApi(Build.VERSION_CODES.N)
-    public static boolean setProgressValue(final AccessibilityNodeInfo node, final float value) {
+    public static void setProgressValue(final AccessibilityNodeInfo node, final float value) {
         if (!node.getActionList().contains(AccessibilityAction.ACTION_SET_PROGRESS)) {
-            Logger.debug("The element does not support ACTION_SET_PROGRESS action.");
-            return false;
+            throw new InvalidElementStateException(
+                    String.format("The element '%s' does not support ACTION_SET_PROGRESS. " +
+                            "Did you locate a proper one?", node));
         }
-        Logger.debug(String.format(
-                "Trying to perform ACTION_SET_PROGRESS accessibility action with value %s", value));
         final Bundle args = new Bundle();
         args.putFloat(AccessibilityNodeInfo.ACTION_ARGUMENT_PROGRESS_VALUE, value);
-        return node.performAction(AccessibilityAction.ACTION_SET_PROGRESS.getId(), args);
+        if (!node.performAction(AccessibilityAction.ACTION_SET_PROGRESS.getId(), args)) {
+            throw new InvalidElementStateException(
+                    String.format("ACTION_SET_PROGRESS has failed on the element '%s'. " +
+                            "Did you locate a proper one?", node));
+        }
     }
 
     /**

--- a/app/src/main/java/io/appium/uiautomator2/handler/SendKeysToElement.java
+++ b/app/src/main/java/io/appium/uiautomator2/handler/SendKeysToElement.java
@@ -16,9 +16,6 @@
 
 package io.appium.uiautomator2.handler;
 
-import android.os.Build;
-import android.view.accessibility.AccessibilityNodeInfo;
-
 import androidx.test.uiautomator.UiObjectNotFoundException;
 
 import io.appium.uiautomator2.common.exceptions.ElementNotFoundException;
@@ -48,25 +45,15 @@ public class SendKeysToElement extends SafeRequestHandler {
     }
 
     private static boolean setProgress(AndroidElement element, SendKeysModel model) {
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.N) {
+        if (!element.canSetProgress()) {
             return false;
         }
-        AccessibilityNodeInfo.RangeInfo rangeInfo = element.getRangeInfo();
-        if (rangeInfo == null) {
-            return false;
-        }
-        Logger.info(String.format("Element has range info: %s", rangeInfo));
+
         float value;
         try {
             value = Float.parseFloat(model.text);
         } catch (NumberFormatException | NullPointerException e) {
             throw new IllegalArgumentException(String.format("Cannot convert '%s' to float", model.text));
-        }
-        if (value < rangeInfo.getMin()) {
-            value = rangeInfo.getMin();
-        }
-        if (value > rangeInfo.getMax()) {
-            value = rangeInfo.getMax();
         }
         Logger.info(String.format("Setting the progress value to %s", value));
         element.setProgress(value);

--- a/app/src/main/java/io/appium/uiautomator2/model/AndroidElement.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/AndroidElement.java
@@ -17,7 +17,6 @@
 package io.appium.uiautomator2.model;
 
 import android.graphics.Rect;
-import android.view.accessibility.AccessibilityNodeInfo;
 
 import androidx.annotation.Nullable;
 import androidx.test.uiautomator.UiObjectNotFoundException;
@@ -46,7 +45,7 @@ public interface AndroidElement {
 
     boolean setText(final String text);
 
-    AccessibilityNodeInfo.RangeInfo getRangeInfo();
+    boolean canSetProgress();
 
     void setProgress(final float value);
 

--- a/app/src/main/java/io/appium/uiautomator2/model/AndroidElement.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/AndroidElement.java
@@ -17,6 +17,7 @@
 package io.appium.uiautomator2.model;
 
 import android.graphics.Rect;
+import android.view.accessibility.AccessibilityNodeInfo;
 
 import androidx.annotation.Nullable;
 import androidx.test.uiautomator.UiObjectNotFoundException;
@@ -44,6 +45,10 @@ public interface AndroidElement {
     String getAttribute(String attr) throws UiObjectNotFoundException;
 
     boolean setText(final String text);
+
+    AccessibilityNodeInfo.RangeInfo getRangeInfo();
+
+    void setProgress(final float value);
 
     String getId();
 

--- a/app/src/main/java/io/appium/uiautomator2/model/UiObject2Element.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/UiObject2Element.java
@@ -167,6 +167,17 @@ public class UiObject2Element extends BaseElement {
     }
 
     @Override
+    @Nullable
+    public AccessibilityNodeInfo.RangeInfo getRangeInfo() {
+        return ElementHelpers.getRangeInfo(element);
+    }
+
+    @Override
+    public void setProgress(float value) {
+        ElementHelpers.setProgress(element, value);
+    }
+
+    @Override
     public By getBy() {
         return by;
     }

--- a/app/src/main/java/io/appium/uiautomator2/model/UiObject2Element.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/UiObject2Element.java
@@ -167,14 +167,13 @@ public class UiObject2Element extends BaseElement {
     }
 
     @Override
-    @Nullable
-    public AccessibilityNodeInfo.RangeInfo getRangeInfo() {
-        return ElementHelpers.getRangeInfo(element);
+    public void setProgress(float value) {
+        ElementHelpers.setProgress(element, value);
     }
 
     @Override
-    public void setProgress(float value) {
-        ElementHelpers.setProgress(element, value);
+    public boolean canSetProgress() {
+        return ElementHelpers.canSetProgress(element);
     }
 
     @Override

--- a/app/src/main/java/io/appium/uiautomator2/model/UiObjectElement.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/UiObjectElement.java
@@ -172,9 +172,8 @@ public class UiObjectElement extends BaseElement {
     }
 
     @Override
-    @Nullable
-    public AccessibilityNodeInfo.RangeInfo getRangeInfo() {
-        return ElementHelpers.getRangeInfo(element);
+    public boolean canSetProgress() {
+        return ElementHelpers.canSetProgress(element);
     }
 
     @Override

--- a/app/src/main/java/io/appium/uiautomator2/model/UiObjectElement.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/UiObjectElement.java
@@ -172,6 +172,17 @@ public class UiObjectElement extends BaseElement {
     }
 
     @Override
+    @Nullable
+    public AccessibilityNodeInfo.RangeInfo getRangeInfo() {
+        return ElementHelpers.getRangeInfo(element);
+    }
+
+    @Override
+    public void setProgress(float value) {
+        ElementHelpers.setProgress(element, value);
+    }
+
+    @Override
     public By getBy() {
         return by;
     }

--- a/app/src/main/java/io/appium/uiautomator2/utils/ElementHelpers.java
+++ b/app/src/main/java/io/appium/uiautomator2/utils/ElementHelpers.java
@@ -56,6 +56,7 @@ import io.appium.uiautomator2.model.AppiumUIA2Driver;
 import io.appium.uiautomator2.model.Session;
 import io.appium.uiautomator2.model.UiObject2Element;
 
+import static android.view.accessibility.AccessibilityNodeInfo.AccessibilityAction.ACTION_SET_PROGRESS;
 import static io.appium.uiautomator2.model.internal.CustomUiDevice.getInstance;
 import static io.appium.uiautomator2.utils.Device.getAndroidElement;
 import static io.appium.uiautomator2.utils.Device.getUiDevice;
@@ -111,14 +112,16 @@ public abstract class ElementHelpers {
         return result;
     }
 
-    @Nullable
-    public static AccessibilityNodeInfo.RangeInfo getRangeInfo(Object element) {
+    public static boolean canSetProgress(Object element) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.N) {
+            return false;
+        }
+
         AccessibilityNodeInfo nodeInfo = AccessibilityNodeInfoGetter.fromUiObject(element);
         if (nodeInfo == null) {
             throw new ElementNotFoundException();
         }
-
-        return nodeInfo.getRangeInfo();
+        return nodeInfo.getActionList().contains(ACTION_SET_PROGRESS);
     }
 
     /**


### PR DESCRIPTION
There's some mess happening to the `text` property before it is passed to `setText`, so it makes sense to call setProgress before all these checks and make the necessary adjustments