### PR TITLE
fix: Discard caching for element snapshots

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         maven { url 'https://jitpack.io' }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.0.0'
+        classpath 'com.android.tools.build:gradle:4.0.1'
         classpath 'com.github.JakeWharton:sdk-manager-plugin:0ce4cdf08009d79223850a59959d9d6e774d0f77'
         classpath 'de.mobilej.unmock:UnMockPlugin:0.6.4'
     }

--- a/app/src/main/java/io/appium/uiautomator2/core/AccessibilityNodeInfoDumper.java
+++ b/app/src/main/java/io/appium/uiautomator2/core/AccessibilityNodeInfoDumper.java
@@ -43,7 +43,6 @@ import java.util.Set;
 import java.util.concurrent.Semaphore;
 
 import io.appium.uiautomator2.common.exceptions.InvalidSelectorException;
-import io.appium.uiautomator2.common.exceptions.StaleElementReferenceException;
 import io.appium.uiautomator2.common.exceptions.UiAutomator2Exception;
 import io.appium.uiautomator2.model.NotificationListener;
 import io.appium.uiautomator2.model.UiElementSnapshot;
@@ -55,7 +54,6 @@ import io.appium.uiautomator2.utils.Logger;
 import io.appium.uiautomator2.utils.NodeInfoList;
 import io.appium.uiautomator2.utils.StringHelpers;
 
-import static io.appium.uiautomator2.model.UiElementSnapshot.rebuildForNewRoots;
 import static io.appium.uiautomator2.utils.AXWindowHelpers.getCachedWindowRoots;
 import static io.appium.uiautomator2.utils.XMLHelpers.toNodeName;
 import static io.appium.uiautomator2.utils.XMLHelpers.toSafeString;
@@ -175,12 +173,8 @@ public class AccessibilityNodeInfoDumper {
             serializer.startDocument(XML_ENCODING, true);
             serializer.setFeature("http://xmlpull.org/v1/doc/features.html#indent-output", true);
             final UiElement<?, ?> xpathRoot = root == null
-                    ? rebuildForNewRoots(getCachedWindowRoots(), NotificationListener.getInstance().getToastMessage())
-                    : UiElementSnapshot.getFromCache(root);
-            if (xpathRoot == null) {
-                throw new StaleElementReferenceException(
-                        String.format("The element %s does not exist in DOM anymore", root));
-            }
+                    ? UiElementSnapshot.take(getCachedWindowRoots(), NotificationListener.getInstance().getToastMessage())
+                    : UiElementSnapshot.take(root);
             serializeUiElement(xpathRoot, 0);
             serializer.endDocument();
             Logger.debug(String.format("The source XML tree (%s bytes) has been fetched in %sms",

--- a/app/src/main/java/io/appium/uiautomator2/model/CustomUiSelector.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/CustomUiSelector.java
@@ -34,10 +34,7 @@ public class CustomUiSelector {
      * @return UiSelector object, based on UiAutomationElement attributes
      */
     public UiSelector getUiSelector(AccessibilityNodeInfo node) {
-        UiElementSnapshot uiElementSnapshot = UiElementSnapshot.getFromCache(node);
-        if (uiElementSnapshot == null) {
-            throw new IllegalArgumentException(String.format("The '%s' node is not found in the cache", node));
-        }
+        UiElementSnapshot uiElementSnapshot = UiElementSnapshot.take(node);
         put(Attribute.PACKAGE, uiElementSnapshot.getPackageName());
         put(Attribute.CLASS, uiElementSnapshot.getClassName());
         // For proper selector matching it is important to not replace nulls with empty strings

--- a/app/src/main/java/io/appium/uiautomator2/model/CustomUiSelector.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/CustomUiSelector.java
@@ -34,7 +34,7 @@ public class CustomUiSelector {
      * @return UiSelector object, based on UiAutomationElement attributes
      */
     public UiSelector getUiSelector(AccessibilityNodeInfo node) {
-        UiElementSnapshot uiElementSnapshot = UiElementSnapshot.take(node);
+        UiElementSnapshot uiElementSnapshot = UiElementSnapshot.take(node, 0);
         put(Attribute.PACKAGE, uiElementSnapshot.getPackageName());
         put(Attribute.CLASS, uiElementSnapshot.getClassName());
         // For proper selector matching it is important to not replace nulls with empty strings

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.0.0'
+        classpath 'com.android.tools.build:gradle:4.0.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files


### PR DESCRIPTION
Unfortunately UiAutomator does not tell us anything about accessibility tree changes between findElement invokations. That is why caching of snapshots could cause the unconsistent behaviour described in https://github.com/appium/appium/issues/14586. This PR eliminates snapshots caching, so now we are going to refresh the tree for each element being snapshotted.