### PR TITLE
feat: Add gesture shortcuts

### DIFF
--- a/app/src/androidTestE2eTest/java/io/appium/uiautomator2/unittest/test/ActionsCommandsTest.java
+++ b/app/src/androidTestE2eTest/java/io/appium/uiautomator2/unittest/test/ActionsCommandsTest.java
@@ -16,6 +16,7 @@
 
 package io.appium.uiautomator2.unittest.test;
 
+import android.graphics.Rect;
 import android.os.SystemClock;
 
 import org.json.JSONArray;
@@ -23,6 +24,7 @@ import org.json.JSONException;
 import org.junit.Test;
 
 import io.appium.uiautomator2.model.By;
+import io.appium.uiautomator2.model.Point;
 import io.appium.uiautomator2.unittest.test.internal.BaseTest;
 import io.appium.uiautomator2.unittest.test.internal.Response;
 
@@ -30,9 +32,17 @@ import static io.appium.uiautomator2.unittest.test.internal.commands.DeviceComma
 import static io.appium.uiautomator2.unittest.test.internal.commands.DeviceCommands.performActions;
 import static io.appium.uiautomator2.unittest.test.internal.commands.DeviceCommands.scrollToText;
 import static io.appium.uiautomator2.unittest.test.internal.commands.ElementCommands.click;
+import static io.appium.uiautomator2.unittest.test.internal.commands.ElementCommands.drag;
+import static io.appium.uiautomator2.unittest.test.internal.commands.ElementCommands.fling;
 import static io.appium.uiautomator2.unittest.test.internal.commands.ElementCommands.getText;
+import static io.appium.uiautomator2.unittest.test.internal.commands.ElementCommands.longClick;
+import static io.appium.uiautomator2.unittest.test.internal.commands.ElementCommands.pinchClose;
+import static io.appium.uiautomator2.unittest.test.internal.commands.ElementCommands.pinchOpen;
+import static io.appium.uiautomator2.unittest.test.internal.commands.ElementCommands.scroll;
+import static io.appium.uiautomator2.unittest.test.internal.commands.ElementCommands.swipe;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -118,5 +128,147 @@ public class ActionsCommandsTest extends BaseTest {
         assertTrue(actionsResponse.isSuccessful());
         Response response = getText(edit.getElementId());
         assertThat((String) response.getValue(), equalTo("hi"));
+    }
+
+    @Test
+    public void verifyLongClickGesture() throws JSONException {
+        setupDragDropView();
+
+        Response dot1Response = findElement(By.id(dotIdByIdx(1)));
+        Response longClickResponse = longClick(dot1Response.getElementId(), null, null);
+        assertTrue(longClickResponse.isSuccessful());
+        longClickResponse = longClick(dot1Response.getElementId(), new Point(1,1), null);
+        assertTrue(longClickResponse.isSuccessful());
+        longClickResponse = longClick(null, new Point(200,200), 2000L);
+        assertTrue(longClickResponse.isSuccessful());
+        // negative
+        longClickResponse = longClick(null, null, 2000L);
+        assertFalse(longClickResponse.isSuccessful());
+        longClickResponse = longClick(dot1Response.getElementId(), null, -1L);
+        assertFalse(longClickResponse.isSuccessful());
+    }
+
+    @Test
+    public void verifyDragGesture() throws JSONException {
+        setupDragDropView();
+
+        Response dot1Response = findElement(By.id(dotIdByIdx(1)));
+        Response dragResponse = drag(dot1Response.getElementId(), null, new Point(1,1), null);
+        assertTrue(dragResponse.isSuccessful());
+        dragResponse = drag(null, new Point(200,200), new Point(1,1), null);
+        assertTrue(dragResponse.isSuccessful());
+        dragResponse = drag(null, new Point(200,200), new Point(1,1), 200);
+        assertTrue(dragResponse.isSuccessful());
+        // negative
+        dragResponse = drag(null, new Point(200,200), null, 200);
+        assertFalse(dragResponse.isSuccessful());
+        dragResponse = drag(null, null, new Point(1,1), 200);
+        assertFalse(dragResponse.isSuccessful());
+        dragResponse = drag(dot1Response.getElementId(), null, new Point(1,1), -1);
+        assertFalse(dragResponse.isSuccessful());
+    }
+
+    @Test
+    public void verifyFlingGesture() throws JSONException {
+        setupDragDropView();
+
+        Response dot1Response = findElement(By.id(dotIdByIdx(1)));
+        Response flingResponse = fling(dot1Response.getElementId(), null, "down", null);
+        assertTrue(flingResponse.isSuccessful());
+        flingResponse = fling(null, new Rect(200, 200, 300, 300), "left", null);
+        assertTrue(flingResponse.isSuccessful());
+        flingResponse = fling(null, new Rect(200, 200, 300, 300), "left", 1000);
+        assertTrue(flingResponse.isSuccessful());
+        // negative
+        flingResponse = fling(null, new Rect(200, 200, 300, 300), "foo", null);
+        assertFalse(flingResponse.isSuccessful());
+        flingResponse = fling(null, null, "left", null);
+        assertFalse(flingResponse.isSuccessful());
+        flingResponse = fling(null, new Rect(200, 200, 300, 300), "left", -1);
+        assertFalse(flingResponse.isSuccessful());
+    }
+
+    @Test
+    public void verifyPinchCloseGesture() throws JSONException {
+        setupDragDropView();
+
+        Response dot1Response = findElement(By.id(dotIdByIdx(1)));
+        Response pinchCloseResponse = pinchClose(dot1Response.getElementId(), null, 0.5f, null);
+        assertTrue(pinchCloseResponse.isSuccessful());
+        pinchCloseResponse = pinchClose(null, new Rect(200, 200, 300, 300), 0.5f, null);
+        assertTrue(pinchCloseResponse.isSuccessful());
+        pinchCloseResponse = pinchClose(null, new Rect(200, 200, 300, 300), 0.5f, 1000);
+        assertTrue(pinchCloseResponse.isSuccessful());
+        // negative
+        pinchCloseResponse = pinchClose(null, new Rect(200, 200, 300, 300), -1f, null);
+        assertFalse(pinchCloseResponse.isSuccessful());
+        pinchCloseResponse = pinchClose(null, null, 0.5f, null);
+        assertFalse(pinchCloseResponse.isSuccessful());
+        pinchCloseResponse = pinchClose(null, new Rect(200, 200, 300, 300), 0.5f, -1);
+        assertFalse(pinchCloseResponse.isSuccessful());
+    }
+
+    @Test
+    public void verifyPinchOpenGesture() throws JSONException {
+        setupDragDropView();
+
+        Response dot1Response = findElement(By.id(dotIdByIdx(1)));
+        Response pinchOpenResponse = pinchOpen(dot1Response.getElementId(), null, 0.5f, null);
+        assertTrue(pinchOpenResponse.isSuccessful());
+        pinchOpenResponse = pinchOpen(null, new Rect(200, 200, 300, 300), 0.5f, null);
+        assertTrue(pinchOpenResponse.isSuccessful());
+        pinchOpenResponse = pinchOpen(null, new Rect(200, 200, 300, 300), 0.5f, 1000);
+        assertTrue(pinchOpenResponse.isSuccessful());
+        // negative
+        pinchOpenResponse = pinchOpen(null, new Rect(200, 200, 300, 300), -1f, null);
+        assertFalse(pinchOpenResponse.isSuccessful());
+        pinchOpenResponse = pinchOpen(null, null, 0.5f, null);
+        assertFalse(pinchOpenResponse.isSuccessful());
+        pinchOpenResponse = pinchOpen(null, new Rect(200, 200, 300, 300), 0.5f, -1);
+        assertFalse(pinchOpenResponse.isSuccessful());
+    }
+
+    @Test
+    public void verifyScrollGesture() throws JSONException {
+        setupDragDropView();
+
+        Response dot1Response = findElement(By.id(dotIdByIdx(1)));
+        Response scrollResponse = scroll(dot1Response.getElementId(), null, 0.5f, "left", null);
+        assertTrue(scrollResponse.isSuccessful());
+        scrollResponse = scroll(null, new Rect(200, 200, 300, 300), 0.5f, "left", null);
+        assertTrue(scrollResponse.isSuccessful());
+        scrollResponse = scroll(null, new Rect(200, 200, 300, 300), 0.5f, "left",1000);
+        assertTrue(scrollResponse.isSuccessful());
+        // negative
+        scrollResponse = scroll(null, new Rect(200, 200, 300, 300), -1f, "up", null);
+        assertFalse(scrollResponse.isSuccessful());
+        scrollResponse = scroll(null, null, 0.5f, "up",null);
+        assertFalse(scrollResponse.isSuccessful());
+        scrollResponse = scroll(null, new Rect(200, 200, 300, 300), 0.5f, "up",-1);
+        assertFalse(scrollResponse.isSuccessful());
+        scrollResponse = scroll(dot1Response.getElementId(), null, 0.5f, "foo", null);
+        assertFalse(scrollResponse.isSuccessful());
+    }
+
+    @Test
+    public void verifySwipeGesture() throws JSONException {
+        setupDragDropView();
+
+        Response dot1Response = findElement(By.id(dotIdByIdx(1)));
+        Response swipeResponse = swipe(dot1Response.getElementId(), null, 0.5f, "left", null);
+        assertTrue(swipeResponse.isSuccessful());
+        swipeResponse = swipe(null, new Rect(200, 200, 300, 300), 0.5f, "left", null);
+        assertTrue(swipeResponse.isSuccessful());
+        swipeResponse = swipe(null, new Rect(200, 200, 300, 300), 0.5f, "left",1000);
+        assertTrue(swipeResponse.isSuccessful());
+        // negative
+        swipeResponse = swipe(null, new Rect(200, 200, 300, 300), -1f, "up", null);
+        assertFalse(swipeResponse.isSuccessful());
+        swipeResponse = swipe(null, null, 0.5f, "up",null);
+        assertFalse(swipeResponse.isSuccessful());
+        swipeResponse = swipe(null, new Rect(200, 200, 300, 300), 0.5f, "up",-1);
+        assertFalse(swipeResponse.isSuccessful());
+        swipeResponse = swipe(dot1Response.getElementId(), null, 0.5f, "foo", null);
+        assertFalse(swipeResponse.isSuccessful());
     }
 }

--- a/app/src/androidTestE2eTest/java/io/appium/uiautomator2/unittest/test/internal/commands/ElementCommands.java
+++ b/app/src/androidTestE2eTest/java/io/appium/uiautomator2/unittest/test/internal/commands/ElementCommands.java
@@ -104,7 +104,7 @@ public class ElementCommands {
      * @throws JSONException
      */
     public static Response drag(@Nullable String elementId, @Nullable Point start,
-                                Point end, @Nullable Integer speed) throws JSONException {
+                                @Nullable Point end, @Nullable Integer speed) throws JSONException {
         JSONObject jsonObject = new JSONObject();
         if (elementId != null) {
             jsonObject.put("origin", toOrigin(elementId));
@@ -112,7 +112,9 @@ public class ElementCommands {
         if (start != null) {
             jsonObject.put("start", toPoint(start));
         }
-        jsonObject.put("end", toPoint(end));
+        if (end != null) {
+            jsonObject.put("end", toPoint(end));
+        }
         if (speed != null) {
             jsonObject.put("speed", speed);
         }

--- a/app/src/androidTestE2eTest/java/io/appium/uiautomator2/unittest/test/internal/commands/ElementCommands.java
+++ b/app/src/androidTestE2eTest/java/io/appium/uiautomator2/unittest/test/internal/commands/ElementCommands.java
@@ -15,14 +15,43 @@
  */
 package io.appium.uiautomator2.unittest.test.internal.commands;
 
+import android.graphics.Rect;
+
+import androidx.annotation.Nullable;
+
 import org.json.JSONException;
 import org.json.JSONObject;
 
+import io.appium.uiautomator2.model.Point;
 import io.appium.uiautomator2.unittest.test.internal.Client;
 import io.appium.uiautomator2.unittest.test.internal.Response;
 
 @SuppressWarnings("JavaDoc")
 public class ElementCommands {
+
+    private static final String W3C_ELEMENT_ID_KEY_NAME = "element-6066-11e4-a52e-4f735466cecf";
+
+    private static JSONObject toOrigin(String elementId) throws JSONException {
+        JSONObject jsonObject = new JSONObject();
+        jsonObject.put(W3C_ELEMENT_ID_KEY_NAME, elementId);
+        return jsonObject;
+    }
+
+    private static JSONObject toPoint(Point point) throws JSONException {
+        JSONObject jsonObject = new JSONObject();
+        jsonObject.put("x", point.x);
+        jsonObject.put("y", point.y);
+        return jsonObject;
+    }
+
+    private static JSONObject toArea(Rect rect) throws JSONException {
+        JSONObject jsonObject = new JSONObject();
+        jsonObject.put("left", rect.left);
+        jsonObject.put("top", rect.top);
+        jsonObject.put("width", rect.width());
+        jsonObject.put("height", rect.height());
+        return jsonObject;
+    }
 
     /**
      * performs click on the given element
@@ -36,6 +65,197 @@ public class ElementCommands {
         JSONObject jsonObject = new JSONObject();
         jsonObject.put("element", elementId);
         return Client.post("/element/" + elementId + "/click", jsonObject);
+    }
+
+    /**
+     * performs long click gesture
+     * POST /appium/gestures/long_click
+     *
+     * @param elementId
+     * @param offset
+     * @param duration
+     * @return Response from UiAutomator2 server
+     * @throws JSONException
+     */
+    public static Response longClick(@Nullable String elementId, @Nullable Point offset,
+                                     @Nullable Long duration) throws JSONException {
+        JSONObject jsonObject = new JSONObject();
+        if (elementId != null) {
+            jsonObject.put("origin", toOrigin(elementId));
+        }
+        if (offset != null) {
+            jsonObject.put("offset", toPoint(offset));
+        }
+        if (duration != null) {
+            jsonObject.put("duration", duration);
+        }
+        return Client.post("/appium/gestures/long_click", jsonObject);
+    }
+
+    /**
+     * performs drag gesture
+     * POST /appium/gestures/drag
+     *
+     * @param elementId
+     * @param start
+     * @param end
+     * @param speed
+     * @return Response from UiAutomator2 server
+     * @throws JSONException
+     */
+    public static Response drag(@Nullable String elementId, @Nullable Point start,
+                                Point end, @Nullable Integer speed) throws JSONException {
+        JSONObject jsonObject = new JSONObject();
+        if (elementId != null) {
+            jsonObject.put("origin", toOrigin(elementId));
+        }
+        if (start != null) {
+            jsonObject.put("start", toPoint(start));
+        }
+        jsonObject.put("end", toPoint(end));
+        if (speed != null) {
+            jsonObject.put("speed", speed);
+        }
+        return Client.post("/appium/gestures/drag", jsonObject);
+    }
+
+    /**
+     * performs fling gesture
+     * POST /appium/gestures/fling
+     *
+     * @param elementId
+     * @param area
+     * @param direction
+     * @param speed
+     * @return Response from UiAutomator2 server
+     * @throws JSONException
+     */
+    public static Response fling(@Nullable String elementId, @Nullable Rect area,
+                                 String direction, @Nullable Integer speed) throws JSONException {
+        JSONObject jsonObject = new JSONObject();
+        if (elementId != null) {
+            jsonObject.put("origin", toOrigin(elementId));
+        }
+        if (area != null) {
+            jsonObject.put("area", toArea(area));
+        }
+        jsonObject.put("direction", direction);
+        if (speed != null) {
+            jsonObject.put("speed", speed);
+        }
+        return Client.post("/appium/gestures/fling", jsonObject);
+    }
+
+    /**
+     * performs pinch close gesture
+     * POST /appium/gestures/pinch_close
+     *
+     * @param elementId
+     * @param area
+     * @param percent
+     * @param speed
+     * @return Response from UiAutomator2 server
+     * @throws JSONException
+     */
+    public static Response pinchClose(@Nullable String elementId, @Nullable Rect area,
+                                      float percent, @Nullable Integer speed) throws JSONException {
+        JSONObject jsonObject = new JSONObject();
+        if (elementId != null) {
+            jsonObject.put("origin", toOrigin(elementId));
+        }
+        if (area != null) {
+            jsonObject.put("area", toArea(area));
+        }
+        jsonObject.put("percent", percent);
+        if (speed != null) {
+            jsonObject.put("speed", speed);
+        }
+        return Client.post("/appium/gestures/pinch_close", jsonObject);
+    }
+
+    /**
+     * performs pinch open gesture
+     * POST /appium/gestures/pinch_open
+     *
+     * @param elementId
+     * @param area
+     * @param percent
+     * @param speed
+     * @return Response from UiAutomator2 server
+     * @throws JSONException
+     */
+    public static Response pinchOpen(@Nullable String elementId, @Nullable Rect area,
+                                     float percent, @Nullable Integer speed) throws JSONException {
+        JSONObject jsonObject = new JSONObject();
+        if (elementId != null) {
+            jsonObject.put("origin", toOrigin(elementId));
+        }
+        if (area != null) {
+            jsonObject.put("area", toArea(area));
+        }
+        jsonObject.put("percent", percent);
+        if (speed != null) {
+            jsonObject.put("speed", speed);
+        }
+        return Client.post("/appium/gestures/pinch_open", jsonObject);
+    }
+
+    /**
+     * performs scroll gesture
+     * POST /appium/gestures/scroll
+     *
+     * @param elementId
+     * @param area
+     * @param percent
+     * @param direction
+     * @param speed
+     * @return Response from UiAutomator2 server
+     * @throws JSONException
+     */
+    public static Response scroll(@Nullable String elementId, @Nullable Rect area,
+                                  float percent, String direction, @Nullable Integer speed) throws JSONException {
+        JSONObject jsonObject = new JSONObject();
+        if (elementId != null) {
+            jsonObject.put("origin", toOrigin(elementId));
+        }
+        if (area != null) {
+            jsonObject.put("area", toArea(area));
+        }
+        jsonObject.put("percent", percent);
+        jsonObject.put("direction", direction);
+        if (speed != null) {
+            jsonObject.put("speed", speed);
+        }
+        return Client.post("/appium/gestures/scroll", jsonObject);
+    }
+
+    /**
+     * performs swipe gesture
+     * POST /appium/gestures/swipe
+     *
+     * @param elementId
+     * @param area
+     * @param percent
+     * @param direction
+     * @param speed
+     * @return Response from UiAutomator2 server
+     * @throws JSONException
+     */
+    public static Response swipe(@Nullable String elementId, @Nullable Rect area,
+                                 float percent, String direction, @Nullable Integer speed) throws JSONException {
+        JSONObject jsonObject = new JSONObject();
+        if (elementId != null) {
+            jsonObject.put("origin", toOrigin(elementId));
+        }
+        if (area != null) {
+            jsonObject.put("area", toArea(area));
+        }
+        jsonObject.put("percent", percent);
+        jsonObject.put("direction", direction);
+        if (speed != null) {
+            jsonObject.put("speed", speed);
+        }
+        return Client.post("/appium/gestures/swipe", jsonObject);
     }
 
     /**
@@ -57,9 +277,9 @@ public class ElementCommands {
     /**
      * Send a keycode with particular parameters
      *
-     * @param keyCode Android key code
+     * @param keyCode   Android key code
      * @param metaState the state of meta keys
-     * @param flags KeyEvent flags
+     * @param flags     KeyEvent flags
      * @return Response from UiAutomator2 server
      * @throws JSONException
      */

--- a/app/src/main/java/io/appium/uiautomator2/core/AccessibilityNodeInfoHelpers.java
+++ b/app/src/main/java/io/appium/uiautomator2/core/AccessibilityNodeInfoHelpers.java
@@ -93,6 +93,12 @@ public class AccessibilityNodeInfoHelpers {
                 .click(new Point(bounds.centerX(), bounds.centerY()));
     }
 
+    public static void longClick(AccessibilityNodeInfo node) {
+        Rect bounds = getBounds(node);
+        CustomUiDevice.getInstance().getGestureController()
+                .longClick(new Point(bounds.centerX(), bounds.centerY()));
+    }
+
     /**
      * Returns the node's bounds clipped to the size of the display
      *

--- a/app/src/main/java/io/appium/uiautomator2/core/AxNodeInfoExtractor.java
+++ b/app/src/main/java/io/appium/uiautomator2/core/AxNodeInfoExtractor.java
@@ -27,7 +27,7 @@ import androidx.test.uiautomator.UiObject2;
 import io.appium.uiautomator2.common.exceptions.StaleElementReferenceException;
 
 import static io.appium.uiautomator2.utils.ReflectionUtils.invoke;
-import static io.appium.uiautomator2.utils.ReflectionUtils.method;
+import static io.appium.uiautomator2.utils.ReflectionUtils.getMethod;
 
 public abstract class AxNodeInfoExtractor {
 
@@ -48,11 +48,11 @@ public abstract class AxNodeInfoExtractor {
     @Nullable
     private static AccessibilityNodeInfo extractAxNodeInfo(Object object) {
         if (object instanceof UiObject2) {
-            return (AccessibilityNodeInfo) invoke(method(UiObject2.class,
+            return (AccessibilityNodeInfo) invoke(getMethod(UiObject2.class,
                     "getAccessibilityNodeInfo"), object);
         } else if (object instanceof UiObject) {
             long timeout = Configurator.getInstance().getWaitForSelectorTimeout();
-            return (AccessibilityNodeInfo) invoke(method(UiObject.class,
+            return (AccessibilityNodeInfo) invoke(getMethod(UiObject.class,
                     "findAccessibilityNodeInfo", long.class), object, timeout);
         }
         throw new IllegalArgumentException(String.format("Unknown object type '%s'",

--- a/app/src/main/java/io/appium/uiautomator2/core/AxNodeInfoHelper.java
+++ b/app/src/main/java/io/appium/uiautomator2/core/AxNodeInfoHelper.java
@@ -45,7 +45,7 @@ import static io.appium.uiautomator2.utils.StringHelpers.charSequenceToString;
 /**
  * This class contains static helper methods to work with {@link AccessibilityNodeInfo}
  */
-public class AxNodeInfoHelpers {
+public class AxNodeInfoHelper {
     // https://github.com/appium/appium/issues/12892
     private final static int MAX_DEPTH = 70;
 
@@ -94,6 +94,11 @@ public class AxNodeInfoHelpers {
 
     private static Rect getBoundsForGestures(AccessibilityNodeInfo node) {
         Rect bounds = getBounds(node);
+        // The default margin values are copied from UiObject2 class:
+        // private int mMarginLeft   = 5;
+        // private int mMarginTop    = 5;
+        // private int mMarginRight  = 5;
+        // private int mMarginBottom = 5;
         bounds.left = bounds.left + 5;
         bounds.top = bounds.top + 5;
         bounds.right = bounds.right - 5;

--- a/app/src/main/java/io/appium/uiautomator2/core/AxNodeInfoHelpers.java
+++ b/app/src/main/java/io/appium/uiautomator2/core/AxNodeInfoHelpers.java
@@ -26,6 +26,7 @@ import android.view.accessibility.AccessibilityNodeInfo;
 import android.view.accessibility.AccessibilityNodeInfo.AccessibilityAction;
 
 import androidx.annotation.Nullable;
+import androidx.test.uiautomator.Direction;
 import androidx.test.uiautomator.UiDevice;
 
 import java.util.HashSet;
@@ -44,7 +45,7 @@ import static io.appium.uiautomator2.utils.StringHelpers.charSequenceToString;
 /**
  * This class contains static helper methods to work with {@link AccessibilityNodeInfo}
  */
-public class AccessibilityNodeInfoHelpers {
+public class AxNodeInfoHelpers {
     // https://github.com/appium/appium/issues/12892
     private final static int MAX_DEPTH = 70;
 
@@ -87,16 +88,85 @@ public class AccessibilityNodeInfoHelpers {
         return charSequenceToString(nodeInfo.getText(), replaceNull);
     }
 
+    private static Point getCenterPoint(Rect bounds) {
+        return new Point(bounds.centerX(), bounds.centerY());
+    }
+
+    private static Rect getBoundsForGestures(AccessibilityNodeInfo node) {
+        Rect bounds = getBounds(node);
+        bounds.left = bounds.left + 5;
+        bounds.top = bounds.top + 5;
+        bounds.right = bounds.right - 5;
+        bounds.bottom = bounds.bottom - 5;
+        return bounds;
+    }
+
     public static void click(AccessibilityNodeInfo node) {
         Rect bounds = getBounds(node);
-        CustomUiDevice.getInstance().getGestureController()
-                .click(new Point(bounds.centerX(), bounds.centerY()));
+        CustomUiDevice.getInstance().getGestureController().click(getCenterPoint(bounds));
     }
 
     public static void longClick(AccessibilityNodeInfo node) {
+        longClick(node, null);
+    }
+
+    public static void longClick(AccessibilityNodeInfo node, @Nullable Long durationMs) {
         Rect bounds = getBounds(node);
-        CustomUiDevice.getInstance().getGestureController()
-                .longClick(new Point(bounds.centerX(), bounds.centerY()));
+        CustomUiDevice.getInstance().getGestureController().longClick(getCenterPoint(bounds), durationMs);
+    }
+
+    public static void drag(AccessibilityNodeInfo node, Point end) {
+        drag(node, end, null);
+    }
+
+    public static void drag(AccessibilityNodeInfo node, Point end, @Nullable Integer speed) {
+        Rect bounds = getBounds(node);
+        CustomUiDevice.getInstance().getGestureController().drag(getCenterPoint(bounds), end, speed);
+    }
+
+    public static void pinchClose(AccessibilityNodeInfo node, float percent) {
+        pinchClose(node, percent, null);
+    }
+
+    public static void pinchClose(AccessibilityNodeInfo node, float percent, @Nullable Integer speed) {
+        Rect bounds = getBoundsForGestures(node);
+        CustomUiDevice.getInstance().getGestureController().pinchClose(bounds, percent, speed);
+    }
+
+    public static void pinchOpen(AccessibilityNodeInfo node, float percent) {
+        pinchOpen(node, percent, null);
+    }
+
+    public static void pinchOpen(AccessibilityNodeInfo node, float percent, @Nullable Integer speed) {
+        Rect bounds = getBoundsForGestures(node);
+        CustomUiDevice.getInstance().getGestureController().pinchOpen(bounds, percent, speed);
+    }
+
+    public static void swipe(AccessibilityNodeInfo node, Direction direction, float percent) {
+        swipe(node, direction, percent, null);
+    }
+
+    public static void swipe(AccessibilityNodeInfo node, Direction direction, float percent, @Nullable Integer speed) {
+        Rect bounds = getBoundsForGestures(node);
+        CustomUiDevice.getInstance().getGestureController().swipe(bounds, direction, percent, speed);
+    }
+
+    public static boolean scroll(AccessibilityNodeInfo node, Direction direction, float percent) {
+        return scroll(node, direction, percent, null);
+    }
+
+    public static boolean scroll(AccessibilityNodeInfo node, Direction direction, float percent, @Nullable Integer speed) {
+        Rect bounds = getBoundsForGestures(node);
+        return CustomUiDevice.getInstance().getGestureController().scroll(bounds, direction, percent, speed);
+    }
+
+    public static boolean fling(AccessibilityNodeInfo node, Direction direction) {
+        return fling(node, direction, null);
+    }
+
+    public static boolean fling(AccessibilityNodeInfo node, Direction direction, @Nullable Integer speed) {
+        Rect bounds = getBoundsForGestures(node);
+        return CustomUiDevice.getInstance().getGestureController().fling(bounds, direction, speed);
     }
 
     /**

--- a/app/src/main/java/io/appium/uiautomator2/core/InteractionController.java
+++ b/app/src/main/java/io/appium/uiautomator2/core/InteractionController.java
@@ -24,7 +24,7 @@ import io.appium.uiautomator2.model.settings.TrackScrollEvents;
 import io.appium.uiautomator2.utils.Logger;
 
 import static io.appium.uiautomator2.utils.ReflectionUtils.invoke;
-import static io.appium.uiautomator2.utils.ReflectionUtils.method;
+import static io.appium.uiautomator2.utils.ReflectionUtils.getMethod;
 
 public class InteractionController {
 
@@ -43,19 +43,19 @@ public class InteractionController {
     }
 
     public boolean sendKey(int keyCode, int metaState) throws UiAutomator2Exception {
-        return (Boolean) invoke(method(CLASS_INTERACTION_CONTROLLER, METHOD_SEND_KEY, int.class, int.class),
+        return (Boolean) invoke(getMethod(CLASS_INTERACTION_CONTROLLER, METHOD_SEND_KEY, int.class, int.class),
                 interactionController, keyCode, metaState);
     }
 
     public boolean injectEventSync(final InputEvent event, boolean shouldRegister) throws UiAutomator2Exception {
         if (!shouldRegister) {
-            return (Boolean) invoke(method(CLASS_INTERACTION_CONTROLLER,
+            return (Boolean) invoke(getMethod(CLASS_INTERACTION_CONTROLLER,
                     METHOD_INJECT_EVENT_SYNC, InputEvent.class), interactionController, event);
         }
         return EventRegister.runAndRegisterScrollEvents(new ReturningRunnable<Boolean>() {
             @Override
             public void run() {
-                Boolean result = (Boolean) invoke(method(CLASS_INTERACTION_CONTROLLER,
+                Boolean result = (Boolean) invoke(getMethod(CLASS_INTERACTION_CONTROLLER,
                         METHOD_INJECT_EVENT_SYNC, InputEvent.class), interactionController, event);
                 setResult(result);
             }
@@ -77,7 +77,7 @@ public class InteractionController {
     }
 
     private boolean doTouchDown(final int x, final int y) {
-        return (Boolean) invoke(method(CLASS_INTERACTION_CONTROLLER,
+        return (Boolean) invoke(getMethod(CLASS_INTERACTION_CONTROLLER,
                 METHOD_TOUCH_DOWN, int.class, int.class), interactionController, x, y);
     }
 
@@ -93,7 +93,7 @@ public class InteractionController {
     }
 
     private boolean doTouchUp(final int x, final int y) {
-        return (Boolean) invoke(method(CLASS_INTERACTION_CONTROLLER, METHOD_TOUCH_UP,
+        return (Boolean) invoke(getMethod(CLASS_INTERACTION_CONTROLLER, METHOD_TOUCH_UP,
                 int.class, int.class), interactionController, x, y);
     }
 
@@ -109,7 +109,7 @@ public class InteractionController {
     }
 
     private boolean doTouchMove(final int x, final int y) {
-        return (Boolean) invoke(method(CLASS_INTERACTION_CONTROLLER,
+        return (Boolean) invoke(getMethod(CLASS_INTERACTION_CONTROLLER,
                 METHOD_TOUCH_MOVE, int.class, int.class), interactionController, x, y);
     }
 
@@ -125,13 +125,13 @@ public class InteractionController {
     }
 
     private boolean doPerformMultiPointerGesture(final PointerCoords[][] pcs) {
-        return (Boolean) invoke(method(CLASS_INTERACTION_CONTROLLER,
+        return (Boolean) invoke(getMethod(CLASS_INTERACTION_CONTROLLER,
                 METHOD_PERFORM_MULTI_POINTER_GESTURE, PointerCoords[][].class),
                 interactionController, (Object) pcs);
     }
 
     public boolean clickNoSync(int x, int y) {
-        return (Boolean) invoke(method(CLASS_INTERACTION_CONTROLLER,
+        return (Boolean) invoke(getMethod(CLASS_INTERACTION_CONTROLLER,
                 METHOD_CLICK_NO_SYNC, int.class, int.class), interactionController, x, y);
     }
 

--- a/app/src/main/java/io/appium/uiautomator2/core/UiAutomatorBridge.java
+++ b/app/src/main/java/io/appium/uiautomator2/core/UiAutomatorBridge.java
@@ -25,7 +25,7 @@ import io.appium.uiautomator2.common.exceptions.UiAutomator2Exception;
 import io.appium.uiautomator2.utils.Device;
 
 import static io.appium.uiautomator2.utils.ReflectionUtils.invoke;
-import static io.appium.uiautomator2.utils.ReflectionUtils.method;
+import static io.appium.uiautomator2.utils.ReflectionUtils.getMethod;
 
 public class UiAutomatorBridge {
     private static UiAutomatorBridge INSTANCE = null;
@@ -40,20 +40,20 @@ public class UiAutomatorBridge {
     }
 
     public InteractionController getInteractionController() throws UiAutomator2Exception {
-        return new InteractionController(invoke(method(UiDevice.class, "getInteractionController"),
+        return new InteractionController(invoke(getMethod(UiDevice.class, "getInteractionController"),
                 Device.getUiDevice()));
     }
 
     public AccessibilityNodeInfo getAccessibilityRootNode() throws UiAutomator2Exception {
-        Object queryController = invoke(method(UiDevice.class, "getQueryController"), Device.getUiDevice());
-        return (AccessibilityNodeInfo) invoke(method(queryController.getClass(), "getRootNode"), queryController);
+        Object queryController = invoke(getMethod(UiDevice.class, "getQueryController"), Device.getUiDevice());
+        return (AccessibilityNodeInfo) invoke(getMethod(queryController.getClass(), "getRootNode"), queryController);
     }
 
     public UiAutomation getUiAutomation() {
-        return (UiAutomation) invoke(method(UiDevice.class, "getUiAutomation"), Device.getUiDevice());
+        return (UiAutomation) invoke(getMethod(UiDevice.class, "getUiAutomation"), Device.getUiDevice());
     }
 
     public Display getDefaultDisplay() throws UiAutomator2Exception {
-        return (Display) invoke(method(UiDevice.class, "getDefaultDisplay"), Device.getUiDevice());
+        return (Display) invoke(getMethod(UiDevice.class, "getDefaultDisplay"), Device.getUiDevice());
     }
 }

--- a/app/src/main/java/io/appium/uiautomator2/handler/TouchLongClick.java
+++ b/app/src/main/java/io/appium/uiautomator2/handler/TouchLongClick.java
@@ -18,11 +18,8 @@ package io.appium.uiautomator2.handler;
 
 import android.os.SystemClock;
 
-import androidx.test.uiautomator.UiObjectNotFoundException;
-
 import io.appium.uiautomator2.common.exceptions.InvalidElementStateException;
 import io.appium.uiautomator2.core.InteractionController;
-import io.appium.uiautomator2.utils.Logger;
 
 public class TouchLongClick extends BaseTouchAction {
     private static final int DEFAULT_DURATION_MS = 2000;
@@ -42,7 +39,7 @@ public class TouchLongClick extends BaseTouchAction {
     }
 
     @Override
-    protected void executeEvent() throws UiObjectNotFoundException {
+    protected void executeEvent() {
         int duration = params.duration != null
                 ? (int) Math.round(params.duration)
                 : DEFAULT_DURATION_MS;
@@ -56,13 +53,6 @@ public class TouchLongClick extends BaseTouchAction {
             throw new InvalidElementStateException(
                     String.format("Cannot perform %s action at (%s, %s)", getName(), clickX, clickY));
         }
-
-        // if correctLongClick failed and we have an element
-        // then uiautomator's longClick is used as a fallback.
-        Logger.debug("Falling back to broken longClick");
-        if (!element.longClick()) {
-            throw new InvalidElementStateException(
-                    String.format("Cannot perform %s action at %s element", getName(), element.getBy()));
-        }
+        element.longClick();
     }
 }

--- a/app/src/main/java/io/appium/uiautomator2/handler/gestures/Drag.java
+++ b/app/src/main/java/io/appium/uiautomator2/handler/gestures/Drag.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.appium.uiautomator2.handler.gestures;
+
+import android.graphics.Point;
+import android.graphics.Rect;
+
+import io.appium.uiautomator2.common.exceptions.ElementNotFoundException;
+import io.appium.uiautomator2.handler.request.SafeRequestHandler;
+import io.appium.uiautomator2.http.AppiumResponse;
+import io.appium.uiautomator2.http.IHttpRequest;
+import io.appium.uiautomator2.model.AndroidElement;
+import io.appium.uiautomator2.model.AppiumUIA2Driver;
+import io.appium.uiautomator2.model.Session;
+import io.appium.uiautomator2.model.api.gestures.DragModel;
+import io.appium.uiautomator2.model.internal.CustomUiDevice;
+
+import static io.appium.uiautomator2.utils.ModelUtils.toModel;
+
+public class Drag extends SafeRequestHandler {
+
+    public Drag(String mappedUri) {
+        super(mappedUri);
+    }
+
+    @Override
+    protected AppiumResponse safeHandle(IHttpRequest request) {
+        DragModel dragModel = toModel(request, DragModel.class);
+        final String elementId = dragModel.getUnifiedId();
+        if (elementId == null) {
+            if (dragModel.startX == null && dragModel.startY != null
+                    || dragModel.startX != null && dragModel.startY == null) {
+                throw new IllegalArgumentException("Both startX and startY coordinates must be set");
+            }
+            CustomUiDevice.getInstance().getGestureController().drag(
+                    dragModel.getNativeStartPoint(),
+                    dragModel.getNativeEndPoint(),
+                    dragModel.speed);
+        } else {
+            Session session = AppiumUIA2Driver.getInstance().getSessionOrThrow();
+            AndroidElement element = session.getKnownElements().getElementFromCache(elementId);
+            if (element == null) {
+                throw new ElementNotFoundException();
+            }
+            if (dragModel.startX == null && dragModel.startY == null) {
+                element.drag(dragModel.getEndPoint(), dragModel.speed);
+            } else if (dragModel.startX != null && dragModel.startY != null) {
+                Rect bounds = element.getBounds();
+                Point start = new Point(bounds.left + dragModel.startX.intValue(),
+                        bounds.top + dragModel.startY.intValue());
+                CustomUiDevice.getInstance().getGestureController().drag(start, dragModel.getNativeEndPoint(),
+                        dragModel.speed);
+            } else {
+                throw new IllegalArgumentException("Both startX and startY coordinates must be set");
+            }
+        }
+
+        return new AppiumResponse(getSessionId(request));
+    }
+}

--- a/app/src/main/java/io/appium/uiautomator2/handler/gestures/Drag.java
+++ b/app/src/main/java/io/appium/uiautomator2/handler/gestures/Drag.java
@@ -40,16 +40,10 @@ public class Drag extends SafeRequestHandler {
     @Override
     protected AppiumResponse safeHandle(IHttpRequest request) {
         DragModel dragModel = toModel(request, DragModel.class);
-        final String elementId = dragModel.getUnifiedId();
+        final String elementId = dragModel.origin == null ? null : dragModel.origin.getUnifiedId();
         if (elementId == null) {
-            if (dragModel.startX == null && dragModel.startY != null
-                    || dragModel.startX != null && dragModel.startY == null) {
-                throw new IllegalArgumentException("Both startX and startY coordinates must be set");
-            }
             CustomUiDevice.getInstance().getGestureController().drag(
-                    dragModel.getNativeStartPoint(),
-                    dragModel.getNativeEndPoint(),
-                    dragModel.speed);
+                    dragModel.getNativeStartPoint(), dragModel.getNativeEndPoint(), dragModel.speed);
         } else {
             Session session = AppiumUIA2Driver.getInstance().getSessionOrThrow();
             AndroidElement element = session.getKnownElements().getElementFromCache(elementId);

--- a/app/src/main/java/io/appium/uiautomator2/handler/gestures/Drag.java
+++ b/app/src/main/java/io/appium/uiautomator2/handler/gestures/Drag.java
@@ -42,24 +42,26 @@ public class Drag extends SafeRequestHandler {
         DragModel dragModel = toModel(request, DragModel.class);
         final String elementId = dragModel.origin == null ? null : dragModel.origin.getUnifiedId();
         if (elementId == null) {
+            if (dragModel.start == null) {
+                throw new IllegalArgumentException("The starting point coordinates must be provided if " +
+                        "element is not set");
+            }
             CustomUiDevice.getInstance().getGestureController().drag(
-                    dragModel.getNativeStartPoint(), dragModel.getNativeEndPoint(), dragModel.speed);
+                    dragModel.start.toNativePoint(), dragModel.end.toNativePoint(), dragModel.speed);
         } else {
             Session session = AppiumUIA2Driver.getInstance().getSessionOrThrow();
             AndroidElement element = session.getKnownElements().getElementFromCache(elementId);
             if (element == null) {
                 throw new ElementNotFoundException();
             }
-            if (dragModel.startX == null && dragModel.startY == null) {
-                element.drag(dragModel.getEndPoint(), dragModel.speed);
-            } else if (dragModel.startX != null && dragModel.startY != null) {
-                Rect bounds = element.getBounds();
-                Point start = new Point(bounds.left + dragModel.startX.intValue(),
-                        bounds.top + dragModel.startY.intValue());
-                CustomUiDevice.getInstance().getGestureController().drag(start, dragModel.getNativeEndPoint(),
-                        dragModel.speed);
+            if (dragModel.start == null) {
+                element.drag(dragModel.end.toPoint(), dragModel.speed);
             } else {
-                throw new IllegalArgumentException("Both startX and startY coordinates must be set");
+                Rect bounds = element.getBounds();
+                Point start = new Point(bounds.left + dragModel.start.x.intValue(),
+                        bounds.top + dragModel.start.y.intValue());
+                CustomUiDevice.getInstance().getGestureController().drag(start, dragModel.end.toNativePoint(),
+                        dragModel.speed);
             }
         }
 

--- a/app/src/main/java/io/appium/uiautomator2/handler/gestures/Fling.java
+++ b/app/src/main/java/io/appium/uiautomator2/handler/gestures/Fling.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.appium.uiautomator2.handler.gestures;
+
+import io.appium.uiautomator2.common.exceptions.ElementNotFoundException;
+import io.appium.uiautomator2.handler.request.SafeRequestHandler;
+import io.appium.uiautomator2.http.AppiumResponse;
+import io.appium.uiautomator2.http.IHttpRequest;
+import io.appium.uiautomator2.model.AndroidElement;
+import io.appium.uiautomator2.model.AppiumUIA2Driver;
+import io.appium.uiautomator2.model.Session;
+import io.appium.uiautomator2.model.api.gestures.FlingModel;
+import io.appium.uiautomator2.model.internal.CustomUiDevice;
+
+import static io.appium.uiautomator2.utils.ModelUtils.toModel;
+
+public class Fling extends SafeRequestHandler {
+
+    public Fling(String mappedUri) {
+        super(mappedUri);
+    }
+
+    @Override
+    protected AppiumResponse safeHandle(IHttpRequest request) {
+        FlingModel flingModel = toModel(request, FlingModel.class);
+        final String elementId = flingModel.getUnifiedId();
+        final boolean result;
+        if (elementId == null) {
+            result = CustomUiDevice.getInstance().getGestureController()
+                    .fling(flingModel.getArea(), flingModel.getDirection(), flingModel.speed);
+        } else {
+            Session session = AppiumUIA2Driver.getInstance().getSessionOrThrow();
+            AndroidElement element = session.getKnownElements().getElementFromCache(elementId);
+            if (element == null) {
+                throw new ElementNotFoundException();
+            }
+            result = element.fling(flingModel.getDirection(), flingModel.speed);
+        }
+
+        return new AppiumResponse(getSessionId(request), result);
+    }
+}

--- a/app/src/main/java/io/appium/uiautomator2/handler/gestures/Fling.java
+++ b/app/src/main/java/io/appium/uiautomator2/handler/gestures/Fling.java
@@ -37,7 +37,7 @@ public class Fling extends SafeRequestHandler {
     @Override
     protected AppiumResponse safeHandle(IHttpRequest request) {
         FlingModel flingModel = toModel(request, FlingModel.class);
-        final String elementId = flingModel.getUnifiedId();
+        final String elementId = flingModel.origin == null ? null : flingModel.origin.getUnifiedId();
         final boolean result;
         if (elementId == null) {
             result = CustomUiDevice.getInstance().getGestureController()

--- a/app/src/main/java/io/appium/uiautomator2/handler/gestures/Fling.java
+++ b/app/src/main/java/io/appium/uiautomator2/handler/gestures/Fling.java
@@ -40,8 +40,12 @@ public class Fling extends SafeRequestHandler {
         final String elementId = flingModel.origin == null ? null : flingModel.origin.getUnifiedId();
         final boolean result;
         if (elementId == null) {
+            if (flingModel.area == null) {
+                throw new IllegalArgumentException("The fling area coordinates must be provided if " +
+                        "element is not set");
+            }
             result = CustomUiDevice.getInstance().getGestureController()
-                    .fling(flingModel.getArea(), flingModel.getDirection(), flingModel.speed);
+                    .fling(flingModel.area.toNativeRect(), flingModel.getDirection(), flingModel.speed);
         } else {
             Session session = AppiumUIA2Driver.getInstance().getSessionOrThrow();
             AndroidElement element = session.getKnownElements().getElementFromCache(elementId);

--- a/app/src/main/java/io/appium/uiautomator2/handler/gestures/LongClick.java
+++ b/app/src/main/java/io/appium/uiautomator2/handler/gestures/LongClick.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.appium.uiautomator2.handler.gestures;
+
+import android.graphics.Point;
+import android.graphics.Rect;
+
+import io.appium.uiautomator2.common.exceptions.ElementNotFoundException;
+import io.appium.uiautomator2.handler.request.SafeRequestHandler;
+import io.appium.uiautomator2.http.AppiumResponse;
+import io.appium.uiautomator2.http.IHttpRequest;
+import io.appium.uiautomator2.model.AndroidElement;
+import io.appium.uiautomator2.model.AppiumUIA2Driver;
+import io.appium.uiautomator2.model.Session;
+import io.appium.uiautomator2.model.api.gestures.LongClickModel;
+import io.appium.uiautomator2.model.internal.CustomUiDevice;
+
+import static io.appium.uiautomator2.utils.ModelUtils.toModel;
+
+public class LongClick extends SafeRequestHandler {
+
+    public LongClick(String mappedUri) {
+        super(mappedUri);
+    }
+
+    @Override
+    protected AppiumResponse safeHandle(IHttpRequest request) {
+        LongClickModel longClickModel = toModel(request, LongClickModel.class);
+        final String elementId = longClickModel.getUnifiedId();
+        if (elementId == null) {
+            if (longClickModel.x == null && longClickModel.y != null
+                    || longClickModel.x != null && longClickModel.y == null) {
+                throw new IllegalArgumentException("Both x and y coordinates must be set");
+            }
+            CustomUiDevice.getInstance().getGestureController().longClick(
+                    longClickModel.toNativePoint(),
+                    longClickModel.duration == null ? null : longClickModel.duration.longValue()
+            );
+        } else {
+            Session session = AppiumUIA2Driver.getInstance().getSessionOrThrow();
+            AndroidElement element = session.getKnownElements().getElementFromCache(elementId);
+            if (element == null) {
+                throw new ElementNotFoundException();
+            }
+            if (longClickModel.x == null && longClickModel.y == null) {
+                if (longClickModel.duration == null) {
+                    element.longClick();
+                } else {
+                    element.longClick(longClickModel.duration.longValue());
+                }
+            } else if (longClickModel.x != null && longClickModel.y != null) {
+                Rect bounds = element.getBounds();
+                CustomUiDevice.getInstance().getGestureController().longClick(
+                        new Point(bounds.left + longClickModel.x.intValue(), bounds.top + longClickModel.y.intValue()),
+                        longClickModel.duration == null ? null : longClickModel.duration.longValue()
+                );
+            } else {
+                throw new IllegalArgumentException("Both x and y coordinates must be set");
+            }
+        }
+
+        return new AppiumResponse(getSessionId(request));
+    }
+}

--- a/app/src/main/java/io/appium/uiautomator2/handler/gestures/LongClick.java
+++ b/app/src/main/java/io/appium/uiautomator2/handler/gestures/LongClick.java
@@ -42,12 +42,12 @@ public class LongClick extends SafeRequestHandler {
         LongClickModel longClickModel = toModel(request, LongClickModel.class);
         final String elementId = longClickModel.origin == null ? null : longClickModel.origin.getUnifiedId();
         if (elementId == null) {
-            if (longClickModel.x == null && longClickModel.y != null
-                    || longClickModel.x != null && longClickModel.y == null) {
-                throw new IllegalArgumentException("Both x and y coordinates must be set");
+            if (longClickModel.offset == null) {
+                throw new IllegalArgumentException("Long click offset coordinates must be provided " +
+                        "if element is not set");
             }
             CustomUiDevice.getInstance().getGestureController().longClick(
-                    longClickModel.toNativePoint(),
+                    longClickModel.offset.toNativePoint(),
                     longClickModel.duration == null ? null : longClickModel.duration.longValue()
             );
         } else {
@@ -56,20 +56,19 @@ public class LongClick extends SafeRequestHandler {
             if (element == null) {
                 throw new ElementNotFoundException();
             }
-            if (longClickModel.x == null && longClickModel.y == null) {
+            if (longClickModel.offset == null) {
                 if (longClickModel.duration == null) {
                     element.longClick();
                 } else {
                     element.longClick(longClickModel.duration.longValue());
                 }
-            } else if (longClickModel.x != null && longClickModel.y != null) {
+            } else {
                 Rect bounds = element.getBounds();
-                CustomUiDevice.getInstance().getGestureController().longClick(
-                        new Point(bounds.left + longClickModel.x.intValue(), bounds.top + longClickModel.y.intValue()),
+                Point location = new Point(bounds.left + longClickModel.offset.x.intValue(),
+                        bounds.top + longClickModel.offset.y.intValue());
+                CustomUiDevice.getInstance().getGestureController().longClick(location,
                         longClickModel.duration == null ? null : longClickModel.duration.longValue()
                 );
-            } else {
-                throw new IllegalArgumentException("Both x and y coordinates must be set");
             }
         }
 

--- a/app/src/main/java/io/appium/uiautomator2/handler/gestures/LongClick.java
+++ b/app/src/main/java/io/appium/uiautomator2/handler/gestures/LongClick.java
@@ -40,7 +40,7 @@ public class LongClick extends SafeRequestHandler {
     @Override
     protected AppiumResponse safeHandle(IHttpRequest request) {
         LongClickModel longClickModel = toModel(request, LongClickModel.class);
-        final String elementId = longClickModel.getUnifiedId();
+        final String elementId = longClickModel.origin == null ? null : longClickModel.origin.getUnifiedId();
         if (elementId == null) {
             if (longClickModel.x == null && longClickModel.y != null
                     || longClickModel.x != null && longClickModel.y == null) {

--- a/app/src/main/java/io/appium/uiautomator2/handler/gestures/PinchClose.java
+++ b/app/src/main/java/io/appium/uiautomator2/handler/gestures/PinchClose.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.appium.uiautomator2.handler.gestures;
+
+import io.appium.uiautomator2.common.exceptions.ElementNotFoundException;
+import io.appium.uiautomator2.handler.request.SafeRequestHandler;
+import io.appium.uiautomator2.http.AppiumResponse;
+import io.appium.uiautomator2.http.IHttpRequest;
+import io.appium.uiautomator2.model.AndroidElement;
+import io.appium.uiautomator2.model.AppiumUIA2Driver;
+import io.appium.uiautomator2.model.Session;
+import io.appium.uiautomator2.model.api.gestures.PinchModel;
+import io.appium.uiautomator2.model.internal.CustomUiDevice;
+
+import static io.appium.uiautomator2.utils.ModelUtils.toModel;
+
+public class PinchClose extends SafeRequestHandler {
+
+    public PinchClose(String mappedUri) {
+        super(mappedUri);
+    }
+
+    @Override
+    protected AppiumResponse safeHandle(IHttpRequest request) {
+        PinchModel pinchModel = toModel(request, PinchModel.class);
+        final String elementId = pinchModel.getUnifiedId();
+        if (elementId == null) {
+            CustomUiDevice.getInstance().getGestureController()
+                    .pinchClose(pinchModel.getArea(), pinchModel.percent, pinchModel.speed);
+        } else {
+            Session session = AppiumUIA2Driver.getInstance().getSessionOrThrow();
+            AndroidElement element = session.getKnownElements().getElementFromCache(elementId);
+            if (element == null) {
+                throw new ElementNotFoundException();
+            }
+            element.pinchClose(pinchModel.percent, pinchModel.speed);
+        }
+
+        return new AppiumResponse(getSessionId(request));
+    }
+}

--- a/app/src/main/java/io/appium/uiautomator2/handler/gestures/PinchClose.java
+++ b/app/src/main/java/io/appium/uiautomator2/handler/gestures/PinchClose.java
@@ -39,8 +39,12 @@ public class PinchClose extends SafeRequestHandler {
         PinchModel pinchModel = toModel(request, PinchModel.class);
         final String elementId = pinchModel.origin == null ? null : pinchModel.origin.getUnifiedId();
         if (elementId == null) {
+            if (pinchModel.area == null) {
+                throw new IllegalArgumentException("The pinch area coordinates must be provided if " +
+                        "element is not set");
+            }
             CustomUiDevice.getInstance().getGestureController()
-                    .pinchClose(pinchModel.getArea(), pinchModel.percent, pinchModel.speed);
+                    .pinchClose(pinchModel.area.toNativeRect(), pinchModel.percent, pinchModel.speed);
         } else {
             Session session = AppiumUIA2Driver.getInstance().getSessionOrThrow();
             AndroidElement element = session.getKnownElements().getElementFromCache(elementId);

--- a/app/src/main/java/io/appium/uiautomator2/handler/gestures/PinchClose.java
+++ b/app/src/main/java/io/appium/uiautomator2/handler/gestures/PinchClose.java
@@ -37,7 +37,7 @@ public class PinchClose extends SafeRequestHandler {
     @Override
     protected AppiumResponse safeHandle(IHttpRequest request) {
         PinchModel pinchModel = toModel(request, PinchModel.class);
-        final String elementId = pinchModel.getUnifiedId();
+        final String elementId = pinchModel.origin == null ? null : pinchModel.origin.getUnifiedId();
         if (elementId == null) {
             CustomUiDevice.getInstance().getGestureController()
                     .pinchClose(pinchModel.getArea(), pinchModel.percent, pinchModel.speed);

--- a/app/src/main/java/io/appium/uiautomator2/handler/gestures/PinchOpen.java
+++ b/app/src/main/java/io/appium/uiautomator2/handler/gestures/PinchOpen.java
@@ -39,8 +39,12 @@ public class PinchOpen extends SafeRequestHandler {
         PinchModel pinchModel = toModel(request, PinchModel.class);
         final String elementId = pinchModel.origin == null ? null : pinchModel.origin.getUnifiedId();
         if (elementId == null) {
+            if (pinchModel.area == null) {
+                throw new IllegalArgumentException("The pinch area coordinates must be provided if " +
+                        "element is not set");
+            }
             CustomUiDevice.getInstance().getGestureController()
-                    .pinchOpen(pinchModel.getArea(), pinchModel.percent, pinchModel.speed);
+                    .pinchOpen(pinchModel.area.toNativeRect(), pinchModel.percent, pinchModel.speed);
         } else {
             Session session = AppiumUIA2Driver.getInstance().getSessionOrThrow();
             AndroidElement element = session.getKnownElements().getElementFromCache(elementId);

--- a/app/src/main/java/io/appium/uiautomator2/handler/gestures/PinchOpen.java
+++ b/app/src/main/java/io/appium/uiautomator2/handler/gestures/PinchOpen.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.appium.uiautomator2.handler.gestures;
+
+import io.appium.uiautomator2.common.exceptions.ElementNotFoundException;
+import io.appium.uiautomator2.handler.request.SafeRequestHandler;
+import io.appium.uiautomator2.http.AppiumResponse;
+import io.appium.uiautomator2.http.IHttpRequest;
+import io.appium.uiautomator2.model.AndroidElement;
+import io.appium.uiautomator2.model.AppiumUIA2Driver;
+import io.appium.uiautomator2.model.Session;
+import io.appium.uiautomator2.model.api.gestures.PinchModel;
+import io.appium.uiautomator2.model.internal.CustomUiDevice;
+
+import static io.appium.uiautomator2.utils.ModelUtils.toModel;
+
+public class PinchOpen extends SafeRequestHandler {
+
+    public PinchOpen(String mappedUri) {
+        super(mappedUri);
+    }
+
+    @Override
+    protected AppiumResponse safeHandle(IHttpRequest request) {
+        PinchModel pinchModel = toModel(request, PinchModel.class);
+        final String elementId = pinchModel.getUnifiedId();
+        if (elementId == null) {
+            CustomUiDevice.getInstance().getGestureController()
+                    .pinchOpen(pinchModel.getArea(), pinchModel.percent, pinchModel.speed);
+        } else {
+            Session session = AppiumUIA2Driver.getInstance().getSessionOrThrow();
+            AndroidElement element = session.getKnownElements().getElementFromCache(elementId);
+            if (element == null) {
+                throw new ElementNotFoundException();
+            }
+            element.pinchOpen(pinchModel.percent, pinchModel.speed);
+        }
+
+        return new AppiumResponse(getSessionId(request));
+    }
+}

--- a/app/src/main/java/io/appium/uiautomator2/handler/gestures/PinchOpen.java
+++ b/app/src/main/java/io/appium/uiautomator2/handler/gestures/PinchOpen.java
@@ -37,7 +37,7 @@ public class PinchOpen extends SafeRequestHandler {
     @Override
     protected AppiumResponse safeHandle(IHttpRequest request) {
         PinchModel pinchModel = toModel(request, PinchModel.class);
-        final String elementId = pinchModel.getUnifiedId();
+        final String elementId = pinchModel.origin == null ? null : pinchModel.origin.getUnifiedId();
         if (elementId == null) {
             CustomUiDevice.getInstance().getGestureController()
                     .pinchOpen(pinchModel.getArea(), pinchModel.percent, pinchModel.speed);

--- a/app/src/main/java/io/appium/uiautomator2/handler/gestures/Scroll.java
+++ b/app/src/main/java/io/appium/uiautomator2/handler/gestures/Scroll.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.appium.uiautomator2.handler.gestures;
+
+import io.appium.uiautomator2.common.exceptions.ElementNotFoundException;
+import io.appium.uiautomator2.handler.request.SafeRequestHandler;
+import io.appium.uiautomator2.http.AppiumResponse;
+import io.appium.uiautomator2.http.IHttpRequest;
+import io.appium.uiautomator2.model.AndroidElement;
+import io.appium.uiautomator2.model.AppiumUIA2Driver;
+import io.appium.uiautomator2.model.Session;
+import io.appium.uiautomator2.model.api.gestures.ScrollModel;
+import io.appium.uiautomator2.model.internal.CustomUiDevice;
+
+import static io.appium.uiautomator2.utils.ModelUtils.toModel;
+
+public class Scroll extends SafeRequestHandler {
+
+    public Scroll(String mappedUri) {
+        super(mappedUri);
+    }
+
+    @Override
+    protected AppiumResponse safeHandle(IHttpRequest request) {
+        ScrollModel scrollModel = toModel(request, ScrollModel.class);
+        final String elementId = scrollModel.getUnifiedId();
+        final boolean result;
+        if (elementId == null) {
+            result = CustomUiDevice.getInstance().getGestureController()
+                    .scroll(scrollModel.getArea(), scrollModel.getDirection(), scrollModel.percent, scrollModel.speed);
+
+        } else {
+            Session session = AppiumUIA2Driver.getInstance().getSessionOrThrow();
+            AndroidElement element = session.getKnownElements().getElementFromCache(elementId);
+            if (element == null) {
+                throw new ElementNotFoundException();
+            }
+            result = element.scroll(scrollModel.getDirection(), scrollModel.percent, scrollModel.speed);
+        }
+
+        return new AppiumResponse(getSessionId(request), result);
+    }
+}

--- a/app/src/main/java/io/appium/uiautomator2/handler/gestures/Scroll.java
+++ b/app/src/main/java/io/appium/uiautomator2/handler/gestures/Scroll.java
@@ -37,7 +37,7 @@ public class Scroll extends SafeRequestHandler {
     @Override
     protected AppiumResponse safeHandle(IHttpRequest request) {
         ScrollModel scrollModel = toModel(request, ScrollModel.class);
-        final String elementId = scrollModel.getUnifiedId();
+        final String elementId = scrollModel.origin == null ? null : scrollModel.origin.getUnifiedId();
         final boolean result;
         if (elementId == null) {
             result = CustomUiDevice.getInstance().getGestureController()

--- a/app/src/main/java/io/appium/uiautomator2/handler/gestures/Scroll.java
+++ b/app/src/main/java/io/appium/uiautomator2/handler/gestures/Scroll.java
@@ -40,9 +40,12 @@ public class Scroll extends SafeRequestHandler {
         final String elementId = scrollModel.origin == null ? null : scrollModel.origin.getUnifiedId();
         final boolean result;
         if (elementId == null) {
+            if (scrollModel.area == null) {
+                throw new IllegalArgumentException("The scroll area coordinates must be provided if " +
+                        "element is not set");
+            }
             result = CustomUiDevice.getInstance().getGestureController()
-                    .scroll(scrollModel.getArea(), scrollModel.getDirection(), scrollModel.percent, scrollModel.speed);
-
+                    .scroll(scrollModel.area.toNativeRect(), scrollModel.getDirection(), scrollModel.percent, scrollModel.speed);
         } else {
             Session session = AppiumUIA2Driver.getInstance().getSessionOrThrow();
             AndroidElement element = session.getKnownElements().getElementFromCache(elementId);

--- a/app/src/main/java/io/appium/uiautomator2/handler/gestures/Swipe.java
+++ b/app/src/main/java/io/appium/uiautomator2/handler/gestures/Swipe.java
@@ -39,8 +39,12 @@ public class Swipe extends SafeRequestHandler {
         SwipeModel swipeModel = toModel(request, SwipeModel.class);
         final String elementId = swipeModel.origin == null ? null : swipeModel.origin.getUnifiedId();
         if (elementId == null) {
+            if (swipeModel.area == null) {
+                throw new IllegalArgumentException("The swipe area coordinates must be provided if " +
+                        "element is not set");
+            }
             CustomUiDevice.getInstance().getGestureController()
-                    .swipe(swipeModel.getArea(), swipeModel.getDirection(), swipeModel.percent, swipeModel.speed);
+                    .swipe(swipeModel.area.toNativeRect(), swipeModel.getDirection(), swipeModel.percent, swipeModel.speed);
         } else {
             Session session = AppiumUIA2Driver.getInstance().getSessionOrThrow();
             AndroidElement element = session.getKnownElements().getElementFromCache(elementId);

--- a/app/src/main/java/io/appium/uiautomator2/handler/gestures/Swipe.java
+++ b/app/src/main/java/io/appium/uiautomator2/handler/gestures/Swipe.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.appium.uiautomator2.handler.gestures;
+
+import io.appium.uiautomator2.common.exceptions.ElementNotFoundException;
+import io.appium.uiautomator2.handler.request.SafeRequestHandler;
+import io.appium.uiautomator2.http.AppiumResponse;
+import io.appium.uiautomator2.http.IHttpRequest;
+import io.appium.uiautomator2.model.AndroidElement;
+import io.appium.uiautomator2.model.AppiumUIA2Driver;
+import io.appium.uiautomator2.model.Session;
+import io.appium.uiautomator2.model.api.gestures.SwipeModel;
+import io.appium.uiautomator2.model.internal.CustomUiDevice;
+
+import static io.appium.uiautomator2.utils.ModelUtils.toModel;
+
+public class Swipe extends SafeRequestHandler {
+
+    public Swipe(String mappedUri) {
+        super(mappedUri);
+    }
+
+    @Override
+    protected AppiumResponse safeHandle(IHttpRequest request) {
+        SwipeModel swipeModel = toModel(request, SwipeModel.class);
+        final String elementId = swipeModel.getUnifiedId();
+        if (elementId == null) {
+            CustomUiDevice.getInstance().getGestureController()
+                    .swipe(swipeModel.getArea(), swipeModel.getDirection(), swipeModel.percent, swipeModel.speed);
+        } else {
+            Session session = AppiumUIA2Driver.getInstance().getSessionOrThrow();
+            AndroidElement element = session.getKnownElements().getElementFromCache(elementId);
+            if (element == null) {
+                throw new ElementNotFoundException();
+            }
+            element.swipe(swipeModel.getDirection(), swipeModel.percent, swipeModel.speed);
+        }
+
+        return new AppiumResponse(getSessionId(request));
+    }
+}

--- a/app/src/main/java/io/appium/uiautomator2/handler/gestures/Swipe.java
+++ b/app/src/main/java/io/appium/uiautomator2/handler/gestures/Swipe.java
@@ -37,7 +37,7 @@ public class Swipe extends SafeRequestHandler {
     @Override
     protected AppiumResponse safeHandle(IHttpRequest request) {
         SwipeModel swipeModel = toModel(request, SwipeModel.class);
-        final String elementId = swipeModel.getUnifiedId();
+        final String elementId = swipeModel.origin == null ? null : swipeModel.origin.getUnifiedId();
         if (elementId == null) {
             CustomUiDevice.getInstance().getGestureController()
                     .swipe(swipeModel.getArea(), swipeModel.getDirection(), swipeModel.percent, swipeModel.speed);

--- a/app/src/main/java/io/appium/uiautomator2/model/AndroidElement.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/AndroidElement.java
@@ -35,7 +35,7 @@ public interface AndroidElement {
 
     void click();
 
-    boolean longClick() throws UiObjectNotFoundException;
+    void longClick();
 
     String getText();
 

--- a/app/src/main/java/io/appium/uiautomator2/model/AndroidElement.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/AndroidElement.java
@@ -19,6 +19,7 @@ package io.appium.uiautomator2.model;
 import android.graphics.Rect;
 
 import androidx.annotation.Nullable;
+import androidx.test.uiautomator.Direction;
 import androidx.test.uiautomator.UiObjectNotFoundException;
 
 import java.util.List;
@@ -32,10 +33,6 @@ public interface AndroidElement {
     boolean isSingleMatch();
 
     void clear() throws UiObjectNotFoundException;
-
-    void click();
-
-    void longClick();
 
     String getText();
 
@@ -63,9 +60,117 @@ public interface AndroidElement {
 
     Point getAbsolutePosition(final Point offset) throws UiObjectNotFoundException;
 
-    boolean dragTo(final int destX, final int destY, final int steps) throws UiObjectNotFoundException;
-
-    boolean dragTo(final Object destObj, final int steps) throws UiObjectNotFoundException;
-
     Object toModel() throws UiObjectNotFoundException;
+
+    //region Gestures
+    /** Clicks on this object. */
+    void click();
+
+    /** Performs a long click on this object. */
+    void longClick();
+
+    /** Performs a click on this object that lasts for {@code durationMs} milliseconds. */
+    void longClick(long durationMs);
+
+    /**
+     * Drags this object to the specified location.
+     *
+     * @param dest The end point that this object should be dragged to.
+     */
+    void drag(Point dest);
+
+    /**
+     * Drags this object to the specified location.
+     *
+     * @param dest The end point that this object should be dragged to.
+     * @param speed The speed at which to perform this gesture in pixels per second.
+     */
+    void drag(Point dest, @Nullable Integer speed);
+
+    /**
+     * Performs a pinch close gesture on this object.
+     *
+     * @param percent The size of the pinch as a percentage of this object's size.
+     */
+    void pinchClose(float percent);
+
+    /**
+     * Performs a pinch close gesture on this object.
+     *
+     * @param percent The size of the pinch as a percentage of this object's size.
+     * @param speed The speed at which to perform this gesture in pixels per second.
+     */
+    void pinchClose(float percent, @Nullable Integer speed);
+
+    /**
+     * Performs a pinch open gesture on this object.
+     *
+     * @param percent The size of the pinch as a percentage of this object's size.
+     */
+    void pinchOpen(float percent);
+
+    /**
+     * Performs a pinch open gesture on this object.
+     *
+     * @param percent The size of the pinch as a percentage of this object's size.
+     * @param speed The speed at which to perform this gesture in pixels per second.
+     */
+    void pinchOpen(float percent, @Nullable Integer speed);
+
+    /**
+     * Performs a swipe gesture on this object.
+     *
+     * @param direction The direction in which to swipe.
+     * @param percent The length of the swipe as a percentage of this object's size.
+     */
+    void swipe(Direction direction, float percent);
+
+    /**
+     * Performs a swipe gesture on this object.
+     *
+     * @param direction The direction in which to swipe.
+     * @param percent The length of the swipe as a percentage of this object's size.
+     * @param speed The speed at which to perform this gesture in pixels per second.
+     */
+    void swipe(Direction direction, float percent, @Nullable Integer speed);
+
+    /**
+     * Performs a scroll gesture on this object.
+     *
+     * @param direction The direction in which to scroll.
+     * @param percent The distance to scroll as a percentage of this object's visible size.
+     * @return Whether the object can still scroll in the given direction.
+     */
+    boolean scroll(Direction direction, float percent);
+
+    /**
+     * Performs a scroll gesture on this object.
+     *
+     * @param direction The direction in which to scroll.
+     * @param percent The distance to scroll as a percentage of this object's visible size.
+     * @param speed The speed at which to perform this gesture in pixels per second.
+     * @return Whether the object can still scroll in the given direction.
+     */
+    boolean scroll(Direction direction, float percent, @Nullable Integer speed);
+
+    /**
+     * Performs a fling gesture on this object.
+     *
+     * @param direction The direction in which to fling.
+     * @return Whether the object can still scroll in the given direction.
+     */
+    boolean fling(Direction direction);
+
+    /**
+     * Performs a fling gesture on this object.
+     *
+     * @param direction The direction in which to fling.
+     * @param speed The speed at which to perform this gesture in pixels per second.
+     * @return Whether the object can still scroll in the given direction.
+     */
+    boolean fling(Direction direction, @Nullable Integer speed);
+    // legacy
+    boolean dragTo(final int destX, final int destY, final int steps) throws UiObjectNotFoundException;
+    boolean dragTo(final Object destObj, final int steps) throws UiObjectNotFoundException;
+    //endregion Gestures
 }

--- a/app/src/main/java/io/appium/uiautomator2/model/Point.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/Point.java
@@ -59,4 +59,8 @@ public class Point {
     public String toString() {
         return "[x=" + x + ", y=" + y + "]";
     }
+
+    public android.graphics.Point toNativePoint() {
+        return new android.graphics.Point(x.intValue(), y.intValue());
+    }
 }

--- a/app/src/main/java/io/appium/uiautomator2/model/UiElementSnapshot.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/UiElementSnapshot.java
@@ -27,7 +27,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
-import io.appium.uiautomator2.core.AxNodeInfoHelpers;
+import io.appium.uiautomator2.core.AxNodeInfoHelper;
 import io.appium.uiautomator2.utils.Attribute;
 import io.appium.uiautomator2.utils.Logger;
 
@@ -65,8 +65,8 @@ public class UiElementSnapshot extends UiElement<AccessibilityNodeInfo, UiElemen
         setAttribute(attributes, Attribute.INDEX, index);
         setAttribute(attributes, Attribute.PACKAGE, charSequenceToNullableString(node.getPackageName()));
         setAttribute(attributes, Attribute.CLASS, charSequenceToNullableString(node.getClassName()));
-        setAttribute(attributes, Attribute.TEXT, AxNodeInfoHelpers.getText(node, true));
-        setAttribute(attributes, Attribute.ORIGINAL_TEXT, AxNodeInfoHelpers.getText(node, false));
+        setAttribute(attributes, Attribute.TEXT, AxNodeInfoHelper.getText(node, true));
+        setAttribute(attributes, Attribute.ORIGINAL_TEXT, AxNodeInfoHelper.getText(node, false));
         setAttribute(attributes, Attribute.CONTENT_DESC, charSequenceToNullableString(node.getContentDescription()));
         setAttribute(attributes, Attribute.RESOURCE_ID, node.getViewIdResourceName());
         setAttribute(attributes, Attribute.CHECKABLE, node.isCheckable());
@@ -78,13 +78,13 @@ public class UiElementSnapshot extends UiElement<AccessibilityNodeInfo, UiElemen
         setAttribute(attributes, Attribute.LONG_CLICKABLE, node.isLongClickable());
         setAttribute(attributes, Attribute.PASSWORD, node.isPassword());
         setAttribute(attributes, Attribute.SCROLLABLE, node.isScrollable());
-        Range<Integer> selectionRange = AxNodeInfoHelpers.getSelectionRange(node);
+        Range<Integer> selectionRange = AxNodeInfoHelper.getSelectionRange(node);
         if (selectionRange != null) {
             attributes.put(Attribute.SELECTION_START, selectionRange.getLower());
             attributes.put(Attribute.SELECTION_END, selectionRange.getUpper());
         }
         setAttribute(attributes, Attribute.SELECTED, node.isSelected());
-        setAttribute(attributes, Attribute.BOUNDS, AxNodeInfoHelpers.getBounds(node).toShortString());
+        setAttribute(attributes, Attribute.BOUNDS, AxNodeInfoHelper.getBounds(node).toShortString());
         setAttribute(attributes, Attribute.DISPLAYED, node.isVisibleToUser());
         // Skip CONTENT_SIZE as it is quite expensive to compute it for each element
         this.attributes = Collections.unmodifiableMap(attributes);

--- a/app/src/main/java/io/appium/uiautomator2/model/UiElementSnapshot.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/UiElementSnapshot.java
@@ -27,7 +27,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
-import io.appium.uiautomator2.core.AccessibilityNodeInfoHelpers;
+import io.appium.uiautomator2.core.AxNodeInfoHelpers;
 import io.appium.uiautomator2.utils.Attribute;
 import io.appium.uiautomator2.utils.Logger;
 
@@ -65,8 +65,8 @@ public class UiElementSnapshot extends UiElement<AccessibilityNodeInfo, UiElemen
         setAttribute(attributes, Attribute.INDEX, index);
         setAttribute(attributes, Attribute.PACKAGE, charSequenceToNullableString(node.getPackageName()));
         setAttribute(attributes, Attribute.CLASS, charSequenceToNullableString(node.getClassName()));
-        setAttribute(attributes, Attribute.TEXT, AccessibilityNodeInfoHelpers.getText(node, true));
-        setAttribute(attributes, Attribute.ORIGINAL_TEXT, AccessibilityNodeInfoHelpers.getText(node, false));
+        setAttribute(attributes, Attribute.TEXT, AxNodeInfoHelpers.getText(node, true));
+        setAttribute(attributes, Attribute.ORIGINAL_TEXT, AxNodeInfoHelpers.getText(node, false));
         setAttribute(attributes, Attribute.CONTENT_DESC, charSequenceToNullableString(node.getContentDescription()));
         setAttribute(attributes, Attribute.RESOURCE_ID, node.getViewIdResourceName());
         setAttribute(attributes, Attribute.CHECKABLE, node.isCheckable());
@@ -78,13 +78,13 @@ public class UiElementSnapshot extends UiElement<AccessibilityNodeInfo, UiElemen
         setAttribute(attributes, Attribute.LONG_CLICKABLE, node.isLongClickable());
         setAttribute(attributes, Attribute.PASSWORD, node.isPassword());
         setAttribute(attributes, Attribute.SCROLLABLE, node.isScrollable());
-        Range<Integer> selectionRange = AccessibilityNodeInfoHelpers.getSelectionRange(node);
+        Range<Integer> selectionRange = AxNodeInfoHelpers.getSelectionRange(node);
         if (selectionRange != null) {
             attributes.put(Attribute.SELECTION_START, selectionRange.getLower());
             attributes.put(Attribute.SELECTION_END, selectionRange.getUpper());
         }
         setAttribute(attributes, Attribute.SELECTED, node.isSelected());
-        setAttribute(attributes, Attribute.BOUNDS, AccessibilityNodeInfoHelpers.getBounds(node).toShortString());
+        setAttribute(attributes, Attribute.BOUNDS, AxNodeInfoHelpers.getBounds(node).toShortString());
         setAttribute(attributes, Attribute.DISPLAYED, node.isVisibleToUser());
         // Skip CONTENT_SIZE as it is quite expensive to compute it for each element
         this.attributes = Collections.unmodifiableMap(attributes);

--- a/app/src/main/java/io/appium/uiautomator2/model/UiObject2Element.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/UiObject2Element.java
@@ -22,6 +22,7 @@ import android.view.accessibility.AccessibilityNodeInfo;
 
 import androidx.annotation.Nullable;
 import androidx.test.uiautomator.BySelector;
+import androidx.test.uiautomator.Direction;
 import androidx.test.uiautomator.UiObject;
 import androidx.test.uiautomator.UiObject2;
 import androidx.test.uiautomator.UiObjectNotFoundException;
@@ -30,7 +31,7 @@ import androidx.test.uiautomator.UiSelector;
 import java.util.List;
 import java.util.UUID;
 
-import io.appium.uiautomator2.core.AccessibilityNodeInfoHelpers;
+import io.appium.uiautomator2.core.AxNodeInfoHelpers;
 import io.appium.uiautomator2.model.internal.CustomUiDevice;
 import io.appium.uiautomator2.utils.Attribute;
 import io.appium.uiautomator2.utils.ElementHelpers;
@@ -61,12 +62,77 @@ public class UiObject2Element extends BaseElement {
 
     @Override
     public void click() {
-        AccessibilityNodeInfoHelpers.click(toAxNodeInfo(element));
+        AxNodeInfoHelpers.click(toAxNodeInfo(element));
     }
 
     @Override
     public void longClick() {
-        AccessibilityNodeInfoHelpers.longClick(toAxNodeInfo(element));
+        AxNodeInfoHelpers.longClick(toAxNodeInfo(element));
+    }
+
+    @Override
+    public void longClick(long durationMs) {
+        AxNodeInfoHelpers.longClick(toAxNodeInfo(element), durationMs);
+    }
+
+    @Override
+    public void drag(Point dest) {
+        AxNodeInfoHelpers.drag(toAxNodeInfo(element), dest.toNativePoint());
+    }
+
+    @Override
+    public void drag(Point dest, @Nullable Integer speed) {
+        AxNodeInfoHelpers.drag(toAxNodeInfo(element), dest.toNativePoint(), speed);
+    }
+
+    @Override
+    public void pinchClose(float percent) {
+        AxNodeInfoHelpers.pinchClose(toAxNodeInfo(element), percent);
+    }
+
+    @Override
+    public void pinchClose(float percent, @Nullable Integer speed) {
+        AxNodeInfoHelpers.pinchClose(toAxNodeInfo(element), percent, speed);
+    }
+
+    @Override
+    public void pinchOpen(float percent) {
+        AxNodeInfoHelpers.pinchOpen(toAxNodeInfo(element), percent);
+    }
+
+    @Override
+    public void pinchOpen(float percent, @Nullable Integer speed) {
+        AxNodeInfoHelpers.pinchOpen(toAxNodeInfo(element), percent, speed);
+    }
+
+    @Override
+    public void swipe(Direction direction, float percent) {
+        AxNodeInfoHelpers.swipe(toAxNodeInfo(element), direction, percent);
+    }
+
+    @Override
+    public void swipe(Direction direction, float percent, @Nullable Integer speed) {
+        AxNodeInfoHelpers.swipe(toAxNodeInfo(element), direction, percent, speed);
+    }
+
+    @Override
+    public boolean scroll(Direction direction, float percent) {
+        return AxNodeInfoHelpers.scroll(toAxNodeInfo(element), direction, percent);
+    }
+
+    @Override
+    public boolean scroll(Direction direction, float percent, @Nullable Integer speed) {
+        return AxNodeInfoHelpers.scroll(toAxNodeInfo(element), direction, percent, speed);
+    }
+
+    @Override
+    public boolean fling(Direction direction) {
+        return AxNodeInfoHelpers.fling(toAxNodeInfo(element), direction);
+    }
+
+    @Override
+    public boolean fling(Direction direction, @Nullable Integer speed) {
+        return AxNodeInfoHelpers.fling(toAxNodeInfo(element), direction, speed);
     }
 
     @Override
@@ -133,20 +199,20 @@ public class UiObject2Element extends BaseElement {
                 result = element.isSelected();
                 break;
             case DISPLAYED:
-                result = AccessibilityNodeInfoHelpers.isVisible(toAxNodeInfo(element));
+                result = AxNodeInfoHelpers.isVisible(toAxNodeInfo(element));
                 break;
             case PASSWORD:
-                result = AccessibilityNodeInfoHelpers.isPassword(toAxNodeInfo(element));
+                result = AxNodeInfoHelpers.isPassword(toAxNodeInfo(element));
                 break;
             case BOUNDS:
                 result = getBounds().toShortString();
                 break;
             case PACKAGE:
-                result = AccessibilityNodeInfoHelpers.getPackageName(toAxNodeInfo(element));
+                result = AxNodeInfoHelpers.getPackageName(toAxNodeInfo(element));
                 break;
             case SELECTION_END:
             case SELECTION_START:
-                Range<Integer> selectionRange = AccessibilityNodeInfoHelpers.getSelectionRange(toAxNodeInfo(element));
+                Range<Integer> selectionRange = AxNodeInfoHelpers.getSelectionRange(toAxNodeInfo(element));
                 result = selectionRange == null
                         ? null
                         : (dstAttribute == Attribute.SELECTION_END ? selectionRange.getUpper() : selectionRange.getLower());
@@ -202,7 +268,7 @@ public class UiObject2Element extends BaseElement {
 
     @Override
     public Rect getBounds() {
-        return AccessibilityNodeInfoHelpers.getBounds(toAxNodeInfo(element));
+        return AxNodeInfoHelpers.getBounds(toAxNodeInfo(element));
     }
 
     @Nullable

--- a/app/src/main/java/io/appium/uiautomator2/model/UiObject2Element.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/UiObject2Element.java
@@ -65,9 +65,8 @@ public class UiObject2Element extends BaseElement {
     }
 
     @Override
-    public boolean longClick() {
-        element.longClick();
-        return true;
+    public void longClick() {
+        AccessibilityNodeInfoHelpers.longClick(toAxNodeInfo(element));
     }
 
     @Override

--- a/app/src/main/java/io/appium/uiautomator2/model/UiObject2Element.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/UiObject2Element.java
@@ -31,7 +31,7 @@ import androidx.test.uiautomator.UiSelector;
 import java.util.List;
 import java.util.UUID;
 
-import io.appium.uiautomator2.core.AxNodeInfoHelpers;
+import io.appium.uiautomator2.core.AxNodeInfoHelper;
 import io.appium.uiautomator2.model.internal.CustomUiDevice;
 import io.appium.uiautomator2.utils.Attribute;
 import io.appium.uiautomator2.utils.ElementHelpers;
@@ -62,77 +62,77 @@ public class UiObject2Element extends BaseElement {
 
     @Override
     public void click() {
-        AxNodeInfoHelpers.click(toAxNodeInfo(element));
+        AxNodeInfoHelper.click(toAxNodeInfo(element));
     }
 
     @Override
     public void longClick() {
-        AxNodeInfoHelpers.longClick(toAxNodeInfo(element));
+        AxNodeInfoHelper.longClick(toAxNodeInfo(element));
     }
 
     @Override
     public void longClick(long durationMs) {
-        AxNodeInfoHelpers.longClick(toAxNodeInfo(element), durationMs);
+        AxNodeInfoHelper.longClick(toAxNodeInfo(element), durationMs);
     }
 
     @Override
     public void drag(Point dest) {
-        AxNodeInfoHelpers.drag(toAxNodeInfo(element), dest.toNativePoint());
+        AxNodeInfoHelper.drag(toAxNodeInfo(element), dest.toNativePoint());
     }
 
     @Override
     public void drag(Point dest, @Nullable Integer speed) {
-        AxNodeInfoHelpers.drag(toAxNodeInfo(element), dest.toNativePoint(), speed);
+        AxNodeInfoHelper.drag(toAxNodeInfo(element), dest.toNativePoint(), speed);
     }
 
     @Override
     public void pinchClose(float percent) {
-        AxNodeInfoHelpers.pinchClose(toAxNodeInfo(element), percent);
+        AxNodeInfoHelper.pinchClose(toAxNodeInfo(element), percent);
     }
 
     @Override
     public void pinchClose(float percent, @Nullable Integer speed) {
-        AxNodeInfoHelpers.pinchClose(toAxNodeInfo(element), percent, speed);
+        AxNodeInfoHelper.pinchClose(toAxNodeInfo(element), percent, speed);
     }
 
     @Override
     public void pinchOpen(float percent) {
-        AxNodeInfoHelpers.pinchOpen(toAxNodeInfo(element), percent);
+        AxNodeInfoHelper.pinchOpen(toAxNodeInfo(element), percent);
     }
 
     @Override
     public void pinchOpen(float percent, @Nullable Integer speed) {
-        AxNodeInfoHelpers.pinchOpen(toAxNodeInfo(element), percent, speed);
+        AxNodeInfoHelper.pinchOpen(toAxNodeInfo(element), percent, speed);
     }
 
     @Override
     public void swipe(Direction direction, float percent) {
-        AxNodeInfoHelpers.swipe(toAxNodeInfo(element), direction, percent);
+        AxNodeInfoHelper.swipe(toAxNodeInfo(element), direction, percent);
     }
 
     @Override
     public void swipe(Direction direction, float percent, @Nullable Integer speed) {
-        AxNodeInfoHelpers.swipe(toAxNodeInfo(element), direction, percent, speed);
+        AxNodeInfoHelper.swipe(toAxNodeInfo(element), direction, percent, speed);
     }
 
     @Override
     public boolean scroll(Direction direction, float percent) {
-        return AxNodeInfoHelpers.scroll(toAxNodeInfo(element), direction, percent);
+        return AxNodeInfoHelper.scroll(toAxNodeInfo(element), direction, percent);
     }
 
     @Override
     public boolean scroll(Direction direction, float percent, @Nullable Integer speed) {
-        return AxNodeInfoHelpers.scroll(toAxNodeInfo(element), direction, percent, speed);
+        return AxNodeInfoHelper.scroll(toAxNodeInfo(element), direction, percent, speed);
     }
 
     @Override
     public boolean fling(Direction direction) {
-        return AxNodeInfoHelpers.fling(toAxNodeInfo(element), direction);
+        return AxNodeInfoHelper.fling(toAxNodeInfo(element), direction);
     }
 
     @Override
     public boolean fling(Direction direction, @Nullable Integer speed) {
-        return AxNodeInfoHelpers.fling(toAxNodeInfo(element), direction, speed);
+        return AxNodeInfoHelper.fling(toAxNodeInfo(element), direction, speed);
     }
 
     @Override
@@ -199,20 +199,20 @@ public class UiObject2Element extends BaseElement {
                 result = element.isSelected();
                 break;
             case DISPLAYED:
-                result = AxNodeInfoHelpers.isVisible(toAxNodeInfo(element));
+                result = AxNodeInfoHelper.isVisible(toAxNodeInfo(element));
                 break;
             case PASSWORD:
-                result = AxNodeInfoHelpers.isPassword(toAxNodeInfo(element));
+                result = AxNodeInfoHelper.isPassword(toAxNodeInfo(element));
                 break;
             case BOUNDS:
                 result = getBounds().toShortString();
                 break;
             case PACKAGE:
-                result = AxNodeInfoHelpers.getPackageName(toAxNodeInfo(element));
+                result = AxNodeInfoHelper.getPackageName(toAxNodeInfo(element));
                 break;
             case SELECTION_END:
             case SELECTION_START:
-                Range<Integer> selectionRange = AxNodeInfoHelpers.getSelectionRange(toAxNodeInfo(element));
+                Range<Integer> selectionRange = AxNodeInfoHelper.getSelectionRange(toAxNodeInfo(element));
                 result = selectionRange == null
                         ? null
                         : (dstAttribute == Attribute.SELECTION_END ? selectionRange.getUpper() : selectionRange.getLower());
@@ -268,7 +268,7 @@ public class UiObject2Element extends BaseElement {
 
     @Override
     public Rect getBounds() {
-        return AxNodeInfoHelpers.getBounds(toAxNodeInfo(element));
+        return AxNodeInfoHelper.getBounds(toAxNodeInfo(element));
     }
 
     @Nullable

--- a/app/src/main/java/io/appium/uiautomator2/model/UiObjectElement.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/UiObjectElement.java
@@ -34,7 +34,7 @@ import java.util.List;
 import java.util.regex.Pattern;
 
 import io.appium.uiautomator2.common.exceptions.ElementNotFoundException;
-import io.appium.uiautomator2.core.AxNodeInfoHelpers;
+import io.appium.uiautomator2.core.AxNodeInfoHelper;
 import io.appium.uiautomator2.model.internal.CustomUiDevice;
 import io.appium.uiautomator2.utils.Attribute;
 import io.appium.uiautomator2.utils.Device;
@@ -68,77 +68,77 @@ public class UiObjectElement extends BaseElement {
 
     @Override
     public void click() {
-        AxNodeInfoHelpers.click(toAxNodeInfo(element));
+        AxNodeInfoHelper.click(toAxNodeInfo(element));
     }
 
     @Override
     public void longClick() {
-        AxNodeInfoHelpers.longClick(toAxNodeInfo(element));
+        AxNodeInfoHelper.longClick(toAxNodeInfo(element));
     }
 
     @Override
     public void longClick(long durationMs) {
-        AxNodeInfoHelpers.longClick(toAxNodeInfo(element), durationMs);
+        AxNodeInfoHelper.longClick(toAxNodeInfo(element), durationMs);
     }
 
     @Override
     public void drag(Point dest) {
-        AxNodeInfoHelpers.drag(toAxNodeInfo(element), dest.toNativePoint());
+        AxNodeInfoHelper.drag(toAxNodeInfo(element), dest.toNativePoint());
     }
 
     @Override
     public void drag(Point dest, @Nullable Integer speed) {
-        AxNodeInfoHelpers.drag(toAxNodeInfo(element), dest.toNativePoint(), speed);
+        AxNodeInfoHelper.drag(toAxNodeInfo(element), dest.toNativePoint(), speed);
     }
 
     @Override
     public void pinchClose(float percent) {
-        AxNodeInfoHelpers.pinchClose(toAxNodeInfo(element), percent);
+        AxNodeInfoHelper.pinchClose(toAxNodeInfo(element), percent);
     }
 
     @Override
     public void pinchClose(float percent, @Nullable Integer speed) {
-        AxNodeInfoHelpers.pinchClose(toAxNodeInfo(element), percent, speed);
+        AxNodeInfoHelper.pinchClose(toAxNodeInfo(element), percent, speed);
     }
 
     @Override
     public void pinchOpen(float percent) {
-        AxNodeInfoHelpers.pinchOpen(toAxNodeInfo(element), percent);
+        AxNodeInfoHelper.pinchOpen(toAxNodeInfo(element), percent);
     }
 
     @Override
     public void pinchOpen(float percent, @Nullable Integer speed) {
-        AxNodeInfoHelpers.pinchOpen(toAxNodeInfo(element), percent, speed);
+        AxNodeInfoHelper.pinchOpen(toAxNodeInfo(element), percent, speed);
     }
 
     @Override
     public void swipe(Direction direction, float percent) {
-        AxNodeInfoHelpers.swipe(toAxNodeInfo(element), direction, percent);
+        AxNodeInfoHelper.swipe(toAxNodeInfo(element), direction, percent);
     }
 
     @Override
     public void swipe(Direction direction, float percent, @Nullable Integer speed) {
-        AxNodeInfoHelpers.swipe(toAxNodeInfo(element), direction, percent, speed);
+        AxNodeInfoHelper.swipe(toAxNodeInfo(element), direction, percent, speed);
     }
 
     @Override
     public boolean scroll(Direction direction, float percent) {
-        return AxNodeInfoHelpers.scroll(toAxNodeInfo(element), direction, percent);
+        return AxNodeInfoHelper.scroll(toAxNodeInfo(element), direction, percent);
     }
 
     @Override
     public boolean scroll(Direction direction, float percent, @Nullable Integer speed) {
-        return AxNodeInfoHelpers.scroll(toAxNodeInfo(element), direction, percent, speed);
+        return AxNodeInfoHelper.scroll(toAxNodeInfo(element), direction, percent, speed);
     }
 
     @Override
     public boolean fling(Direction direction) {
-        return AxNodeInfoHelpers.fling(toAxNodeInfo(element), direction);
+        return AxNodeInfoHelper.fling(toAxNodeInfo(element), direction);
     }
 
     @Override
     public boolean fling(Direction direction, @Nullable Integer speed) {
-        return AxNodeInfoHelpers.fling(toAxNodeInfo(element), direction, speed);
+        return AxNodeInfoHelper.fling(toAxNodeInfo(element), direction, speed);
     }
 
     @Override
@@ -205,21 +205,21 @@ public class UiObjectElement extends BaseElement {
                 result = element.isSelected();
                 break;
             case DISPLAYED:
-                result = element.exists() && AxNodeInfoHelpers.isVisible(toAxNodeInfo(element));
+                result = element.exists() && AxNodeInfoHelper.isVisible(toAxNodeInfo(element));
                 break;
             case PASSWORD:
-                result = AxNodeInfoHelpers.isPassword(toAxNodeInfo(element));
+                result = AxNodeInfoHelper.isPassword(toAxNodeInfo(element));
                 break;
             case BOUNDS:
                 result = getBounds().toShortString();
                 break;
             case PACKAGE: {
-                result = AxNodeInfoHelpers.getPackageName(toAxNodeInfo(element));
+                result = AxNodeInfoHelper.getPackageName(toAxNodeInfo(element));
                 break;
             }
             case SELECTION_END:
             case SELECTION_START:
-                Range<Integer> selectionRange = AxNodeInfoHelpers.getSelectionRange(toAxNodeInfo(element));
+                Range<Integer> selectionRange = AxNodeInfoHelper.getSelectionRange(toAxNodeInfo(element));
                 result = selectionRange == null ? null
                         : (dstAttribute == Attribute.SELECTION_END ? selectionRange.getUpper() : selectionRange.getLower());
                 break;
@@ -274,7 +274,7 @@ public class UiObjectElement extends BaseElement {
 
     @Override
     public Rect getBounds() {
-        return AxNodeInfoHelpers.getBounds(toAxNodeInfo(element));
+        return AxNodeInfoHelper.getBounds(toAxNodeInfo(element));
     }
 
     @Nullable

--- a/app/src/main/java/io/appium/uiautomator2/model/UiObjectElement.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/UiObjectElement.java
@@ -71,8 +71,8 @@ public class UiObjectElement extends BaseElement {
     }
 
     @Override
-    public boolean longClick() throws UiObjectNotFoundException {
-        return element.longClick();
+    public void longClick() {
+        AccessibilityNodeInfoHelpers.longClick(toAxNodeInfo(element));
     }
 
     @Override

--- a/app/src/main/java/io/appium/uiautomator2/model/UiObjectElement.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/UiObjectElement.java
@@ -45,7 +45,7 @@ import io.appium.uiautomator2.utils.PositionHelper;
 import static io.appium.uiautomator2.core.AxNodeInfoExtractor.toAxNodeInfo;
 import static io.appium.uiautomator2.utils.ElementHelpers.generateNoAttributeException;
 import static io.appium.uiautomator2.utils.ReflectionUtils.invoke;
-import static io.appium.uiautomator2.utils.ReflectionUtils.method;
+import static io.appium.uiautomator2.utils.ReflectionUtils.getMethod;
 import static io.appium.uiautomator2.utils.StringHelpers.isBlank;
 
 public class UiObjectElement extends BaseElement {
@@ -404,7 +404,7 @@ public class UiObjectElement extends BaseElement {
              * The returned string matches exactly what is displayed in the
              * UiAutomater inspector.
              */
-            AccessibilityNodeInfo node = (AccessibilityNodeInfo) invoke(method(element.getClass(), "findAccessibilityNodeInfo", long.class),
+            AccessibilityNodeInfo node = (AccessibilityNodeInfo) invoke(getMethod(element.getClass(), "findAccessibilityNodeInfo", long.class),
                     element, Configurator.getInstance().getWaitForSelectorTimeout());
 
             if (node == null) {

--- a/app/src/main/java/io/appium/uiautomator2/model/UiObjectElement.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/UiObjectElement.java
@@ -23,6 +23,7 @@ import android.view.accessibility.AccessibilityNodeInfo;
 import androidx.annotation.Nullable;
 import androidx.test.uiautomator.BySelector;
 import androidx.test.uiautomator.Configurator;
+import androidx.test.uiautomator.Direction;
 import androidx.test.uiautomator.UiObject;
 import androidx.test.uiautomator.UiObject2;
 import androidx.test.uiautomator.UiObjectNotFoundException;
@@ -33,7 +34,7 @@ import java.util.List;
 import java.util.regex.Pattern;
 
 import io.appium.uiautomator2.common.exceptions.ElementNotFoundException;
-import io.appium.uiautomator2.core.AccessibilityNodeInfoHelpers;
+import io.appium.uiautomator2.core.AxNodeInfoHelpers;
 import io.appium.uiautomator2.model.internal.CustomUiDevice;
 import io.appium.uiautomator2.utils.Attribute;
 import io.appium.uiautomator2.utils.Device;
@@ -67,12 +68,77 @@ public class UiObjectElement extends BaseElement {
 
     @Override
     public void click() {
-        AccessibilityNodeInfoHelpers.click(toAxNodeInfo(element));
+        AxNodeInfoHelpers.click(toAxNodeInfo(element));
     }
 
     @Override
     public void longClick() {
-        AccessibilityNodeInfoHelpers.longClick(toAxNodeInfo(element));
+        AxNodeInfoHelpers.longClick(toAxNodeInfo(element));
+    }
+
+    @Override
+    public void longClick(long durationMs) {
+        AxNodeInfoHelpers.longClick(toAxNodeInfo(element), durationMs);
+    }
+
+    @Override
+    public void drag(Point dest) {
+        AxNodeInfoHelpers.drag(toAxNodeInfo(element), dest.toNativePoint());
+    }
+
+    @Override
+    public void drag(Point dest, @Nullable Integer speed) {
+        AxNodeInfoHelpers.drag(toAxNodeInfo(element), dest.toNativePoint(), speed);
+    }
+
+    @Override
+    public void pinchClose(float percent) {
+        AxNodeInfoHelpers.pinchClose(toAxNodeInfo(element), percent);
+    }
+
+    @Override
+    public void pinchClose(float percent, @Nullable Integer speed) {
+        AxNodeInfoHelpers.pinchClose(toAxNodeInfo(element), percent, speed);
+    }
+
+    @Override
+    public void pinchOpen(float percent) {
+        AxNodeInfoHelpers.pinchOpen(toAxNodeInfo(element), percent);
+    }
+
+    @Override
+    public void pinchOpen(float percent, @Nullable Integer speed) {
+        AxNodeInfoHelpers.pinchOpen(toAxNodeInfo(element), percent, speed);
+    }
+
+    @Override
+    public void swipe(Direction direction, float percent) {
+        AxNodeInfoHelpers.swipe(toAxNodeInfo(element), direction, percent);
+    }
+
+    @Override
+    public void swipe(Direction direction, float percent, @Nullable Integer speed) {
+        AxNodeInfoHelpers.swipe(toAxNodeInfo(element), direction, percent, speed);
+    }
+
+    @Override
+    public boolean scroll(Direction direction, float percent) {
+        return AxNodeInfoHelpers.scroll(toAxNodeInfo(element), direction, percent);
+    }
+
+    @Override
+    public boolean scroll(Direction direction, float percent, @Nullable Integer speed) {
+        return AxNodeInfoHelpers.scroll(toAxNodeInfo(element), direction, percent, speed);
+    }
+
+    @Override
+    public boolean fling(Direction direction) {
+        return AxNodeInfoHelpers.fling(toAxNodeInfo(element), direction);
+    }
+
+    @Override
+    public boolean fling(Direction direction, @Nullable Integer speed) {
+        return AxNodeInfoHelpers.fling(toAxNodeInfo(element), direction, speed);
     }
 
     @Override
@@ -139,21 +205,21 @@ public class UiObjectElement extends BaseElement {
                 result = element.isSelected();
                 break;
             case DISPLAYED:
-                result = element.exists() && AccessibilityNodeInfoHelpers.isVisible(toAxNodeInfo(element));
+                result = element.exists() && AxNodeInfoHelpers.isVisible(toAxNodeInfo(element));
                 break;
             case PASSWORD:
-                result = AccessibilityNodeInfoHelpers.isPassword(toAxNodeInfo(element));
+                result = AxNodeInfoHelpers.isPassword(toAxNodeInfo(element));
                 break;
             case BOUNDS:
                 result = getBounds().toShortString();
                 break;
             case PACKAGE: {
-                result = AccessibilityNodeInfoHelpers.getPackageName(toAxNodeInfo(element));
+                result = AxNodeInfoHelpers.getPackageName(toAxNodeInfo(element));
                 break;
             }
             case SELECTION_END:
             case SELECTION_START:
-                Range<Integer> selectionRange = AccessibilityNodeInfoHelpers.getSelectionRange(toAxNodeInfo(element));
+                Range<Integer> selectionRange = AxNodeInfoHelpers.getSelectionRange(toAxNodeInfo(element));
                 result = selectionRange == null ? null
                         : (dstAttribute == Attribute.SELECTION_END ? selectionRange.getUpper() : selectionRange.getLower());
                 break;
@@ -208,7 +274,7 @@ public class UiObjectElement extends BaseElement {
 
     @Override
     public Rect getBounds() {
-        return AccessibilityNodeInfoHelpers.getBounds(toAxNodeInfo(element));
+        return AxNodeInfoHelpers.getBounds(toAxNodeInfo(element));
     }
 
     @Nullable

--- a/app/src/main/java/io/appium/uiautomator2/model/api/gestures/DragModel.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/api/gestures/DragModel.java
@@ -3,9 +3,11 @@ package io.appium.uiautomator2.model.api.gestures;
 import android.graphics.Point;
 
 import io.appium.uiautomator2.model.RequiredField;
+import io.appium.uiautomator2.model.api.BaseModel;
 import io.appium.uiautomator2.model.api.ElementModel;
 
-public class DragModel extends ElementModel {
+public class DragModel extends BaseModel {
+    public ElementModel origin;
     public Double startX;
     public Double startY;
     @RequiredField
@@ -17,6 +19,9 @@ public class DragModel extends ElementModel {
     public DragModel() {}
 
     public Point getNativeStartPoint() {
+        if (startX == null || startY == null) {
+            throw new IllegalArgumentException("Both startX and startY coordinates must be set");
+        }
         return new Point(startX.intValue(), startY.intValue());
     }
 

--- a/app/src/main/java/io/appium/uiautomator2/model/api/gestures/DragModel.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/api/gestures/DragModel.java
@@ -10,6 +10,4 @@ public class DragModel extends BaseModel {
     @RequiredField
     public PointModel end;
     public Integer speed;
-
-    public DragModel() {}
 }

--- a/app/src/main/java/io/appium/uiautomator2/model/api/gestures/DragModel.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/api/gestures/DragModel.java
@@ -1,0 +1,30 @@
+package io.appium.uiautomator2.model.api.gestures;
+
+import android.graphics.Point;
+
+import io.appium.uiautomator2.model.RequiredField;
+import io.appium.uiautomator2.model.api.ElementModel;
+
+public class DragModel extends ElementModel {
+    public Double startX;
+    public Double startY;
+    @RequiredField
+    public Double endX;
+    @RequiredField
+    public Double endY;
+    public Integer speed;
+
+    public DragModel() {}
+
+    public Point getNativeStartPoint() {
+        return new Point(startX.intValue(), startY.intValue());
+    }
+
+    public Point getNativeEndPoint() {
+        return new Point(endX.intValue(), endY.intValue());
+    }
+
+    public io.appium.uiautomator2.model.Point getEndPoint() {
+        return new io.appium.uiautomator2.model.Point(endX, endY);
+    }
+}

--- a/app/src/main/java/io/appium/uiautomator2/model/api/gestures/DragModel.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/api/gestures/DragModel.java
@@ -1,35 +1,15 @@
 package io.appium.uiautomator2.model.api.gestures;
 
-import android.graphics.Point;
-
 import io.appium.uiautomator2.model.RequiredField;
 import io.appium.uiautomator2.model.api.BaseModel;
 import io.appium.uiautomator2.model.api.ElementModel;
 
 public class DragModel extends BaseModel {
     public ElementModel origin;
-    public Double startX;
-    public Double startY;
+    public PointModel start;
     @RequiredField
-    public Double endX;
-    @RequiredField
-    public Double endY;
+    public PointModel end;
     public Integer speed;
 
     public DragModel() {}
-
-    public Point getNativeStartPoint() {
-        if (startX == null || startY == null) {
-            throw new IllegalArgumentException("Both startX and startY coordinates must be set");
-        }
-        return new Point(startX.intValue(), startY.intValue());
-    }
-
-    public Point getNativeEndPoint() {
-        return new Point(endX.intValue(), endY.intValue());
-    }
-
-    public io.appium.uiautomator2.model.Point getEndPoint() {
-        return new io.appium.uiautomator2.model.Point(endX, endY);
-    }
 }

--- a/app/src/main/java/io/appium/uiautomator2/model/api/gestures/FlingModel.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/api/gestures/FlingModel.java
@@ -1,7 +1,5 @@
 package io.appium.uiautomator2.model.api.gestures;
 
-import android.graphics.Rect;
-
 import androidx.test.uiautomator.Direction;
 
 import java.util.Arrays;
@@ -12,29 +10,12 @@ import io.appium.uiautomator2.model.api.ElementModel;
 
 public class FlingModel extends BaseModel {
     public ElementModel origin;
-    public Double startX;
-    public Double startY;
-    public Double width;
-    public Double height;
+    public RectModel area;
     @RequiredField
     public String direction;
     public Integer speed;
 
     public FlingModel() {}
-
-    public Rect getArea() {
-        if (startX == null || startY == null) {
-            throw new IllegalArgumentException("Both startX and startY coordinates of the fling area must be set");
-        }
-        if (width == null || height == null) {
-            throw new IllegalArgumentException("Both width and height of the fling area must be set");
-        }
-        if (width <= 0 || height <= 0) {
-            throw new IllegalArgumentException("Both width and height of the fling area must be greater than zero");
-        }
-        return new Rect(startX.intValue(), startY.intValue(),
-                startX.intValue() + width.intValue(), startY.intValue() + height.intValue());
-    }
 
     public Direction getDirection() {
         try {

--- a/app/src/main/java/io/appium/uiautomator2/model/api/gestures/FlingModel.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/api/gestures/FlingModel.java
@@ -1,0 +1,45 @@
+package io.appium.uiautomator2.model.api.gestures;
+
+import android.graphics.Rect;
+
+import androidx.test.uiautomator.Direction;
+
+import java.util.Arrays;
+
+import io.appium.uiautomator2.model.RequiredField;
+import io.appium.uiautomator2.model.api.ElementModel;
+
+public class FlingModel extends ElementModel {
+    public Double startX;
+    public Double startY;
+    public Double width;
+    public Double height;
+    @RequiredField
+    public String direction;
+    public Integer speed;
+
+    public FlingModel() {}
+
+    public Rect getArea() {
+        if (startX == null || startY == null) {
+            throw new IllegalArgumentException("Both startX and startY coordinates of the fling area must be set");
+        }
+        if (width == null || height == null) {
+            throw new IllegalArgumentException("Both width and height of the fling area must be set");
+        }
+        if (width <= 0 || height <= 0) {
+            throw new IllegalArgumentException("Both width and height of the fling area must be greater than zero");
+        }
+        return new Rect(startX.intValue(), startY.intValue(),
+                startX.intValue() + width.intValue(), startY.intValue() + height.intValue());
+    }
+
+    public Direction getDirection() {
+        try {
+            return Direction.valueOf(direction.toUpperCase());
+        } catch (IllegalArgumentException | NullPointerException e) {
+            throw new IllegalArgumentException(
+                    String.format("Fling direction must be one of %s", Arrays.toString(Direction.values())));
+        }
+    }
+}

--- a/app/src/main/java/io/appium/uiautomator2/model/api/gestures/FlingModel.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/api/gestures/FlingModel.java
@@ -15,8 +15,6 @@ public class FlingModel extends BaseModel {
     public String direction;
     public Integer speed;
 
-    public FlingModel() {}
-
     public Direction getDirection() {
         try {
             return Direction.valueOf(direction.toUpperCase());

--- a/app/src/main/java/io/appium/uiautomator2/model/api/gestures/FlingModel.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/api/gestures/FlingModel.java
@@ -7,9 +7,11 @@ import androidx.test.uiautomator.Direction;
 import java.util.Arrays;
 
 import io.appium.uiautomator2.model.RequiredField;
+import io.appium.uiautomator2.model.api.BaseModel;
 import io.appium.uiautomator2.model.api.ElementModel;
 
-public class FlingModel extends ElementModel {
+public class FlingModel extends BaseModel {
+    public ElementModel origin;
     public Double startX;
     public Double startY;
     public Double width;

--- a/app/src/main/java/io/appium/uiautomator2/model/api/gestures/LongClickModel.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/api/gestures/LongClickModel.java
@@ -2,9 +2,11 @@ package io.appium.uiautomator2.model.api.gestures;
 
 import android.graphics.Point;
 
+import io.appium.uiautomator2.model.api.BaseModel;
 import io.appium.uiautomator2.model.api.ElementModel;
 
-public class LongClickModel extends ElementModel {
+public class LongClickModel extends BaseModel {
+    public ElementModel origin;
     public Double x;
     public Double y;
     public Double duration;

--- a/app/src/main/java/io/appium/uiautomator2/model/api/gestures/LongClickModel.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/api/gestures/LongClickModel.java
@@ -1,19 +1,12 @@
 package io.appium.uiautomator2.model.api.gestures;
 
-import android.graphics.Point;
-
 import io.appium.uiautomator2.model.api.BaseModel;
 import io.appium.uiautomator2.model.api.ElementModel;
 
 public class LongClickModel extends BaseModel {
     public ElementModel origin;
-    public Double x;
-    public Double y;
+    public PointModel offset;
     public Double duration;
 
     public LongClickModel() {}
-
-    public Point toNativePoint() {
-        return new Point(x.intValue(), y.intValue());
-    }
 }

--- a/app/src/main/java/io/appium/uiautomator2/model/api/gestures/LongClickModel.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/api/gestures/LongClickModel.java
@@ -7,6 +7,4 @@ public class LongClickModel extends BaseModel {
     public ElementModel origin;
     public PointModel offset;
     public Double duration;
-
-    public LongClickModel() {}
 }

--- a/app/src/main/java/io/appium/uiautomator2/model/api/gestures/LongClickModel.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/api/gestures/LongClickModel.java
@@ -1,0 +1,17 @@
+package io.appium.uiautomator2.model.api.gestures;
+
+import android.graphics.Point;
+
+import io.appium.uiautomator2.model.api.ElementModel;
+
+public class LongClickModel extends ElementModel {
+    public Double x;
+    public Double y;
+    public Double duration;
+
+    public LongClickModel() {}
+
+    public Point toNativePoint() {
+        return new Point(x.intValue(), y.intValue());
+    }
+}

--- a/app/src/main/java/io/appium/uiautomator2/model/api/gestures/PinchModel.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/api/gestures/PinchModel.java
@@ -1,34 +1,15 @@
 package io.appium.uiautomator2.model.api.gestures;
 
-import android.graphics.Rect;
-
 import io.appium.uiautomator2.model.RequiredField;
 import io.appium.uiautomator2.model.api.BaseModel;
 import io.appium.uiautomator2.model.api.ElementModel;
 
 public class PinchModel extends BaseModel {
     public ElementModel origin;
-    public Double startX;
-    public Double startY;
-    public Double width;
-    public Double height;
+    public RectModel area;
     @RequiredField
     public Float percent;
     public Integer speed;
 
     public PinchModel() {}
-
-    public Rect getArea() {
-        if (startX == null || startY == null) {
-            throw new IllegalArgumentException("Both startX and startY coordinates of the pinch area must be set");
-        }
-        if (width == null || height == null) {
-            throw new IllegalArgumentException("Both width and height of the pinch area must be set");
-        }
-        if (width <= 0 || height <= 0) {
-            throw new IllegalArgumentException("Both width and height of the swipe area must be greater than zero");
-        }
-        return new Rect(startX.intValue(), startY.intValue(),
-                startX.intValue() + width.intValue(), startY.intValue() + height.intValue());
-    }
 }

--- a/app/src/main/java/io/appium/uiautomator2/model/api/gestures/PinchModel.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/api/gestures/PinchModel.java
@@ -3,9 +3,11 @@ package io.appium.uiautomator2.model.api.gestures;
 import android.graphics.Rect;
 
 import io.appium.uiautomator2.model.RequiredField;
+import io.appium.uiautomator2.model.api.BaseModel;
 import io.appium.uiautomator2.model.api.ElementModel;
 
-public class PinchModel extends ElementModel {
+public class PinchModel extends BaseModel {
+    public ElementModel origin;
     public Double startX;
     public Double startY;
     public Double width;

--- a/app/src/main/java/io/appium/uiautomator2/model/api/gestures/PinchModel.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/api/gestures/PinchModel.java
@@ -1,0 +1,32 @@
+package io.appium.uiautomator2.model.api.gestures;
+
+import android.graphics.Rect;
+
+import io.appium.uiautomator2.model.RequiredField;
+import io.appium.uiautomator2.model.api.ElementModel;
+
+public class PinchModel extends ElementModel {
+    public Double startX;
+    public Double startY;
+    public Double width;
+    public Double height;
+    @RequiredField
+    public Float percent;
+    public Integer speed;
+
+    public PinchModel() {}
+
+    public Rect getArea() {
+        if (startX == null || startY == null) {
+            throw new IllegalArgumentException("Both startX and startY coordinates of the pinch area must be set");
+        }
+        if (width == null || height == null) {
+            throw new IllegalArgumentException("Both width and height of the pinch area must be set");
+        }
+        if (width <= 0 || height <= 0) {
+            throw new IllegalArgumentException("Both width and height of the swipe area must be greater than zero");
+        }
+        return new Rect(startX.intValue(), startY.intValue(),
+                startX.intValue() + width.intValue(), startY.intValue() + height.intValue());
+    }
+}

--- a/app/src/main/java/io/appium/uiautomator2/model/api/gestures/PinchModel.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/api/gestures/PinchModel.java
@@ -10,6 +10,4 @@ public class PinchModel extends BaseModel {
     @RequiredField
     public Float percent;
     public Integer speed;
-
-    public PinchModel() {}
 }

--- a/app/src/main/java/io/appium/uiautomator2/model/api/gestures/PointModel.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/api/gestures/PointModel.java
@@ -1,0 +1,24 @@
+package io.appium.uiautomator2.model.api.gestures;
+
+import android.graphics.Point;
+
+import io.appium.uiautomator2.model.RequiredField;
+import io.appium.uiautomator2.model.api.BaseModel;
+import io.appium.uiautomator2.model.api.ElementModel;
+
+public class PointModel extends BaseModel {
+    @RequiredField
+    public Double x;
+    @RequiredField
+    public Double y;
+
+    public PointModel() {}
+
+    public Point toNativePoint() {
+        return new Point(x.intValue(), y.intValue());
+    }
+
+    public io.appium.uiautomator2.model.Point toPoint() {
+        return new io.appium.uiautomator2.model.Point(x, y);
+    }
+}

--- a/app/src/main/java/io/appium/uiautomator2/model/api/gestures/PointModel.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/api/gestures/PointModel.java
@@ -4,15 +4,12 @@ import android.graphics.Point;
 
 import io.appium.uiautomator2.model.RequiredField;
 import io.appium.uiautomator2.model.api.BaseModel;
-import io.appium.uiautomator2.model.api.ElementModel;
 
 public class PointModel extends BaseModel {
     @RequiredField
     public Double x;
     @RequiredField
     public Double y;
-
-    public PointModel() {}
 
     public Point toNativePoint() {
         return new Point(x.intValue(), y.intValue());

--- a/app/src/main/java/io/appium/uiautomator2/model/api/gestures/RectModel.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/api/gestures/RectModel.java
@@ -15,8 +15,6 @@ public class RectModel extends BaseModel {
     @RequiredField
     public Double height;
 
-    public RectModel() {}
-
     public Rect toNativeRect() {
         if (width < 0) {
             throw new IllegalArgumentException("Rectangle width must not be negative");

--- a/app/src/main/java/io/appium/uiautomator2/model/api/gestures/RectModel.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/api/gestures/RectModel.java
@@ -1,0 +1,30 @@
+package io.appium.uiautomator2.model.api.gestures;
+
+import android.graphics.Rect;
+
+import io.appium.uiautomator2.model.RequiredField;
+import io.appium.uiautomator2.model.api.BaseModel;
+
+public class RectModel extends BaseModel {
+    @RequiredField
+    public Double top;
+    @RequiredField
+    public Double left;
+    @RequiredField
+    public Double width;
+    @RequiredField
+    public Double height;
+
+    public RectModel() {}
+
+    public Rect toNativeRect() {
+        if (width < 0) {
+            throw new IllegalArgumentException("Rectangle width must not be negative");
+        }
+        if (height < 0) {
+            throw new IllegalArgumentException("Rectangle height must not be negative");
+        }
+        return new Rect(left.intValue(), top.intValue(),
+                left.intValue() + width.intValue(), top.intValue() + height.intValue());
+    }
+}

--- a/app/src/main/java/io/appium/uiautomator2/model/api/gestures/ScrollModel.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/api/gestures/ScrollModel.java
@@ -17,8 +17,6 @@ public class ScrollModel extends BaseModel {
     public Float percent;
     public Integer speed;
 
-    public ScrollModel() {}
-
     public Direction getDirection() {
         try {
             return Direction.valueOf(direction.toUpperCase());

--- a/app/src/main/java/io/appium/uiautomator2/model/api/gestures/ScrollModel.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/api/gestures/ScrollModel.java
@@ -1,0 +1,47 @@
+package io.appium.uiautomator2.model.api.gestures;
+
+import android.graphics.Rect;
+
+import androidx.test.uiautomator.Direction;
+
+import java.util.Arrays;
+
+import io.appium.uiautomator2.model.RequiredField;
+import io.appium.uiautomator2.model.api.ElementModel;
+
+public class ScrollModel extends ElementModel {
+    public Double startX;
+    public Double startY;
+    public Double width;
+    public Double height;
+    @RequiredField
+    public String direction;
+    @RequiredField
+    public Float percent;
+    public Integer speed;
+
+    public ScrollModel() {}
+
+    public Rect getArea() {
+        if (startX == null || startY == null) {
+            throw new IllegalArgumentException("Both startX and startY coordinates of the scroll area must be set");
+        }
+        if (width == null || height == null) {
+            throw new IllegalArgumentException("Both width and height of the scroll area must be set");
+        }
+        if (width <= 0 || height <= 0) {
+            throw new IllegalArgumentException("Both width and height of the scroll area must be greater than zero");
+        }
+        return new Rect(startX.intValue(), startY.intValue(),
+                startX.intValue() + width.intValue(), startY.intValue() + height.intValue());
+    }
+
+    public Direction getDirection() {
+        try {
+            return Direction.valueOf(direction.toUpperCase());
+        } catch (IllegalArgumentException | NullPointerException e) {
+            throw new IllegalArgumentException(
+                    String.format("Scroll direction must be one of %s", Arrays.toString(Direction.values())));
+        }
+    }
+}

--- a/app/src/main/java/io/appium/uiautomator2/model/api/gestures/ScrollModel.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/api/gestures/ScrollModel.java
@@ -1,7 +1,5 @@
 package io.appium.uiautomator2.model.api.gestures;
 
-import android.graphics.Rect;
-
 import androidx.test.uiautomator.Direction;
 
 import java.util.Arrays;
@@ -12,10 +10,7 @@ import io.appium.uiautomator2.model.api.ElementModel;
 
 public class ScrollModel extends BaseModel {
     public ElementModel origin;
-    public Double startX;
-    public Double startY;
-    public Double width;
-    public Double height;
+    public RectModel area;
     @RequiredField
     public String direction;
     @RequiredField
@@ -23,20 +18,6 @@ public class ScrollModel extends BaseModel {
     public Integer speed;
 
     public ScrollModel() {}
-
-    public Rect getArea() {
-        if (startX == null || startY == null) {
-            throw new IllegalArgumentException("Both startX and startY coordinates of the scroll area must be set");
-        }
-        if (width == null || height == null) {
-            throw new IllegalArgumentException("Both width and height of the scroll area must be set");
-        }
-        if (width <= 0 || height <= 0) {
-            throw new IllegalArgumentException("Both width and height of the scroll area must be greater than zero");
-        }
-        return new Rect(startX.intValue(), startY.intValue(),
-                startX.intValue() + width.intValue(), startY.intValue() + height.intValue());
-    }
 
     public Direction getDirection() {
         try {

--- a/app/src/main/java/io/appium/uiautomator2/model/api/gestures/ScrollModel.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/api/gestures/ScrollModel.java
@@ -7,9 +7,11 @@ import androidx.test.uiautomator.Direction;
 import java.util.Arrays;
 
 import io.appium.uiautomator2.model.RequiredField;
+import io.appium.uiautomator2.model.api.BaseModel;
 import io.appium.uiautomator2.model.api.ElementModel;
 
-public class ScrollModel extends ElementModel {
+public class ScrollModel extends BaseModel {
+    public ElementModel origin;
     public Double startX;
     public Double startY;
     public Double width;

--- a/app/src/main/java/io/appium/uiautomator2/model/api/gestures/SwipeModel.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/api/gestures/SwipeModel.java
@@ -17,8 +17,6 @@ public class SwipeModel extends BaseModel {
     public Float percent;
     public Integer speed;
 
-    public SwipeModel() {}
-
     public Direction getDirection() {
         try {
             return Direction.valueOf(direction.toUpperCase());

--- a/app/src/main/java/io/appium/uiautomator2/model/api/gestures/SwipeModel.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/api/gestures/SwipeModel.java
@@ -1,0 +1,47 @@
+package io.appium.uiautomator2.model.api.gestures;
+
+import android.graphics.Rect;
+
+import androidx.test.uiautomator.Direction;
+
+import java.util.Arrays;
+
+import io.appium.uiautomator2.model.RequiredField;
+import io.appium.uiautomator2.model.api.ElementModel;
+
+public class SwipeModel extends ElementModel {
+    public Double startX;
+    public Double startY;
+    public Double width;
+    public Double height;
+    @RequiredField
+    public String direction;
+    @RequiredField
+    public Float percent;
+    public Integer speed;
+
+    public SwipeModel() {}
+
+    public Rect getArea() {
+        if (startX == null || startY == null) {
+            throw new IllegalArgumentException("Both startX and startY coordinates of the swipe area must be set");
+        }
+        if (width == null || height == null) {
+            throw new IllegalArgumentException("Both width and height of the swipe area must be set");
+        }
+        if (width <= 0 || height <= 0) {
+            throw new IllegalArgumentException("Both width and height of the swipe area must be greater than zero");
+        }
+        return new Rect(startX.intValue(), startY.intValue(),
+                startX.intValue() + width.intValue(), startY.intValue() + height.intValue());
+    }
+
+    public Direction getDirection() {
+        try {
+            return Direction.valueOf(direction.toUpperCase());
+        } catch (IllegalArgumentException | NullPointerException e) {
+            throw new IllegalArgumentException(
+                    String.format("Swipe direction must be one of %s", Arrays.toString(Direction.values())));
+        }
+    }
+}

--- a/app/src/main/java/io/appium/uiautomator2/model/api/gestures/SwipeModel.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/api/gestures/SwipeModel.java
@@ -1,7 +1,5 @@
 package io.appium.uiautomator2.model.api.gestures;
 
-import android.graphics.Rect;
-
 import androidx.test.uiautomator.Direction;
 
 import java.util.Arrays;
@@ -12,10 +10,7 @@ import io.appium.uiautomator2.model.api.ElementModel;
 
 public class SwipeModel extends BaseModel {
     public ElementModel origin;
-    public Double startX;
-    public Double startY;
-    public Double width;
-    public Double height;
+    public RectModel area;
     @RequiredField
     public String direction;
     @RequiredField
@@ -23,20 +18,6 @@ public class SwipeModel extends BaseModel {
     public Integer speed;
 
     public SwipeModel() {}
-
-    public Rect getArea() {
-        if (startX == null || startY == null) {
-            throw new IllegalArgumentException("Both startX and startY coordinates of the swipe area must be set");
-        }
-        if (width == null || height == null) {
-            throw new IllegalArgumentException("Both width and height of the swipe area must be set");
-        }
-        if (width <= 0 || height <= 0) {
-            throw new IllegalArgumentException("Both width and height of the swipe area must be greater than zero");
-        }
-        return new Rect(startX.intValue(), startY.intValue(),
-                startX.intValue() + width.intValue(), startY.intValue() + height.intValue());
-    }
 
     public Direction getDirection() {
         try {

--- a/app/src/main/java/io/appium/uiautomator2/model/api/gestures/SwipeModel.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/api/gestures/SwipeModel.java
@@ -7,9 +7,11 @@ import androidx.test.uiautomator.Direction;
 import java.util.Arrays;
 
 import io.appium.uiautomator2.model.RequiredField;
+import io.appium.uiautomator2.model.api.BaseModel;
 import io.appium.uiautomator2.model.api.ElementModel;
 
-public class SwipeModel extends ElementModel {
+public class SwipeModel extends BaseModel {
+    public ElementModel origin;
     public Double startX;
     public Double startY;
     public Double width;

--- a/app/src/main/java/io/appium/uiautomator2/model/internal/CustomUiDevice.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/internal/CustomUiDevice.java
@@ -146,7 +146,8 @@ public class CustomUiDevice {
             if (dummyElement == null) {
                 throw new IllegalStateException("Cannot create dummy UiObject2 instance");
             }
-            gestureController = new GestureController(getField("mGestureController", dummyElement));
+            Gestures gestures = new Gestures(getField("mGestures", dummyElement));
+            gestureController = new GestureController(getField("mGestureController", dummyElement), gestures);
         }
         return gestureController;
     }

--- a/app/src/main/java/io/appium/uiautomator2/model/internal/CustomUiDevice.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/internal/CustomUiDevice.java
@@ -18,7 +18,6 @@ package io.appium.uiautomator2.model.internal;
 
 import android.app.Instrumentation;
 import android.os.SystemClock;
-import android.util.DisplayMetrics;
 import android.view.accessibility.AccessibilityNodeInfo;
 
 import androidx.annotation.Nullable;

--- a/app/src/main/java/io/appium/uiautomator2/model/internal/CustomUiDevice.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/internal/CustomUiDevice.java
@@ -18,6 +18,7 @@ package io.appium.uiautomator2.model.internal;
 
 import android.app.Instrumentation;
 import android.os.SystemClock;
+import android.util.DisplayMetrics;
 import android.view.accessibility.AccessibilityNodeInfo;
 
 import androidx.annotation.Nullable;

--- a/app/src/main/java/io/appium/uiautomator2/model/internal/CustomUiDevice.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/internal/CustomUiDevice.java
@@ -48,7 +48,7 @@ import static io.appium.uiautomator2.utils.Device.getUiDevice;
 import static io.appium.uiautomator2.utils.ReflectionUtils.getConstructor;
 import static io.appium.uiautomator2.utils.ReflectionUtils.getField;
 import static io.appium.uiautomator2.utils.ReflectionUtils.invoke;
-import static io.appium.uiautomator2.utils.ReflectionUtils.method;
+import static io.appium.uiautomator2.utils.ReflectionUtils.getMethod;
 
 public class CustomUiDevice {
     private static final int CHANGE_ORIENTATION_TIMEOUT_MS = 2000;
@@ -70,8 +70,8 @@ public class CustomUiDevice {
         this.mInstrumentation = (Instrumentation) getField(UiDevice.class, FIELD_M_INSTRUMENTATION, Device.getUiDevice());
         this.API_LEVEL_ACTUAL = getField(UiDevice.class, FIELD_API_LEVEL_ACTUAL, Device.getUiDevice());
         this.ByMatcherClass = ReflectionUtils.getClass("androidx.test.uiautomator.ByMatcher");
-        this.METHOD_FIND_MATCH = method(ByMatcherClass, "findMatch", UiDevice.class, BySelector.class, AccessibilityNodeInfo[].class);
-        this.METHOD_FIND_MATCHES = method(ByMatcherClass, "findMatches", UiDevice.class, BySelector.class, AccessibilityNodeInfo[].class);
+        this.METHOD_FIND_MATCH = getMethod(ByMatcherClass, "findMatch", UiDevice.class, BySelector.class, AccessibilityNodeInfo[].class);
+        this.METHOD_FIND_MATCHES = getMethod(ByMatcherClass, "findMatches", UiDevice.class, BySelector.class, AccessibilityNodeInfo[].class);
         this.uiObject2Constructor = getConstructor(UiObject2.class, UiDevice.class, BySelector.class, AccessibilityNodeInfo.class);
     }
 

--- a/app/src/main/java/io/appium/uiautomator2/model/internal/GestureController.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/internal/GestureController.java
@@ -134,15 +134,17 @@ public class GestureController {
 
         Direction swipeDirection = Direction.reverse(direction);
         int scrollSpeed = speed == null ? Gestures.getDefaultScrollSpeed() : checkSpeed(speed);
-        for (float swipePercent = percent; swipePercent > 0.0f; swipePercent -= 1.0f) {
+        float swipePercent = percent;
+        while (swipePercent > 0.0f) {
             float segment = Math.min(swipePercent, 1.0f);
-            PointerGesture swipe = gestures.swipe(area, swipeDirection, segment, scrollSpeed)
-                    .pause(250);
+            PointerGesture swipe = gestures.swipe(area, swipeDirection, segment, scrollSpeed).pause(250);
 
             // Perform the gesture and return early if we reached the end
             if (performGestureAndWait(Until.scrollFinished(direction), Gestures.getScrollTimeout(), swipe)) {
                 return false;
             }
+
+            swipePercent -= 1.0f;
         }
         // We never reached the end
         return true;

--- a/app/src/main/java/io/appium/uiautomator2/model/internal/GestureController.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/internal/GestureController.java
@@ -89,8 +89,11 @@ public class GestureController {
     }
 
     public void longClick(Point point, @Nullable Long durationMs) {
-        performGesture(new PointerGesture(point)
-                .pause(durationMs == null ? ViewConfiguration.getLongPressTimeout() : durationMs));
+        long duration = durationMs == null ? ViewConfiguration.getLongPressTimeout() : durationMs;
+        if (duration < 0) {
+            throw new IllegalArgumentException("Long click duration cannot be negative");
+        }
+        performGesture(new PointerGesture(point).pause(duration));
     }
 
     private static int checkSpeed(int speed) {

--- a/app/src/main/java/io/appium/uiautomator2/model/internal/Gestures.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/internal/Gestures.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.appium.uiautomator2.model.internal;
+
+import android.view.ViewConfiguration;
+
+import static io.appium.uiautomator2.utils.ReflectionUtils.getField;
+
+public class Gestures {
+    private final Object wrappedInstance;
+    private final ViewConfiguration viewConfiguration;
+
+    Gestures(Object wrappedInstance) {
+        this.wrappedInstance = wrappedInstance;
+        this.viewConfiguration = (ViewConfiguration) getField("mViewConfig", wrappedInstance);
+    }
+
+    public ViewConfiguration getViewConfiguration() {
+        return this.viewConfiguration;
+    }
+}

--- a/app/src/main/java/io/appium/uiautomator2/model/internal/Gestures.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/internal/Gestures.java
@@ -16,20 +16,95 @@
 
 package io.appium.uiautomator2.model.internal;
 
-import android.view.ViewConfiguration;
+import android.graphics.Point;
+import android.graphics.Rect;
+
+import androidx.test.platform.app.InstrumentationRegistry;
+import androidx.test.uiautomator.Direction;
+import androidx.test.uiautomator.UiObject2;
+
+import java.lang.reflect.Array;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.List;
 
 import static io.appium.uiautomator2.utils.ReflectionUtils.getField;
+import static io.appium.uiautomator2.utils.ReflectionUtils.invoke;
+import static io.appium.uiautomator2.utils.ReflectionUtils.method;
 
 public class Gestures {
     private final Object wrappedInstance;
-    private final ViewConfiguration viewConfiguration;
 
     Gestures(Object wrappedInstance) {
         this.wrappedInstance = wrappedInstance;
-        this.viewConfiguration = (ViewConfiguration) getField("mViewConfig", wrappedInstance);
     }
 
-    public ViewConfiguration getViewConfiguration() {
-        return this.viewConfiguration;
+    public PointerGesture drag(Point start, Point end, int speed) {
+        Method dragMethod = method(wrappedInstance.getClass(), "drag",
+                Point.class, Point.class, int.class);
+        return new PointerGesture(invoke(dragMethod, wrappedInstance, start, end, speed));
+    }
+
+    private static PointerGesture[] toGesturesArray(Object result) {
+        List<PointerGesture> list = new ArrayList<>();
+        for (int i = 0; i < Array.getLength(result); ++i) {
+            list.add(new PointerGesture(Array.get(result, i)));
+        }
+        return list.toArray(new PointerGesture[0]);
+    }
+
+    public PointerGesture[] pinchClose(Rect area, float percent, int speed) {
+        Method pinchCloseMethod = method(wrappedInstance.getClass(), "pinchClose",
+                Rect.class, float.class, int.class);
+        return toGesturesArray(invoke(pinchCloseMethod, wrappedInstance, area, percent, speed));
+    }
+
+    public PointerGesture[] pinchOpen(Rect area, float percent, int speed) {
+        Method pinchOpenMethod = method(wrappedInstance.getClass(), "pinchOpen",
+                Rect.class, float.class, int.class);
+        return toGesturesArray(invoke(pinchOpenMethod, wrappedInstance, area, percent, speed));
+    }
+
+    public PointerGesture swipe(Rect area, Direction direction, float percent, int speed) {
+        Method swipeRectMethod = method(wrappedInstance.getClass(), "swipeRect",
+                Rect.class, Direction.class, float.class, int.class);
+        return new PointerGesture(invoke(swipeRectMethod, wrappedInstance, area, direction, percent, speed));
+    }
+
+    public static float getDisplayDensity() {
+        return InstrumentationRegistry.getInstrumentation().getContext()
+                .getResources().getDisplayMetrics().density;
+    }
+
+    private static int getSpeedValue(String gestureName) {
+        return (int) getField(String.format("DEFAULT_%s_SPEED", gestureName.toUpperCase()), UiObject2.class);
+    }
+
+    public static int getDefaultDragSpeed() {
+        return (int) (getSpeedValue("drag") * getDisplayDensity());
+    }
+
+    public static int getDefaultSwipeSpeed() {
+        return (int) (getSpeedValue("swipe") * getDisplayDensity());
+    }
+
+    public static int getDefaultScrollSpeed() {
+        return (int) (getSpeedValue("scroll") * getDisplayDensity());
+    }
+
+    public static int getDefaultFlingSpeed() {
+        return (int) (getSpeedValue("fling") * getDisplayDensity());
+    }
+
+    public static int getDefaultPinchSpeed() {
+        return (int) (getSpeedValue("pinch") * getDisplayDensity());
+    }
+
+    public static long getScrollTimeout() {
+        return (long) getField("SCROLL_TIMEOUT", UiObject2.class);
+    }
+
+    public static long getFlingTimeout() {
+        return (long) getField("FLING_TIMEOUT", UiObject2.class);
     }
 }

--- a/app/src/main/java/io/appium/uiautomator2/model/internal/Gestures.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/internal/Gestures.java
@@ -24,14 +24,13 @@ import androidx.test.uiautomator.Direction;
 import androidx.test.uiautomator.UiObject2;
 
 import java.lang.reflect.Array;
-import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.List;
 
 import static io.appium.uiautomator2.utils.ReflectionUtils.getField;
 import static io.appium.uiautomator2.utils.ReflectionUtils.invoke;
-import static io.appium.uiautomator2.utils.ReflectionUtils.method;
+import static io.appium.uiautomator2.utils.ReflectionUtils.getMethod;
 
 public class Gestures {
     private final Object wrappedInstance;
@@ -41,7 +40,7 @@ public class Gestures {
     }
 
     public PointerGesture drag(Point start, Point end, int speed) {
-        Method dragMethod = method(wrappedInstance.getClass(), "drag",
+        Method dragMethod = getMethod(wrappedInstance.getClass(), "drag",
                 Point.class, Point.class, int.class);
         return new PointerGesture(invoke(dragMethod, wrappedInstance, start, end, speed));
     }
@@ -55,19 +54,19 @@ public class Gestures {
     }
 
     public PointerGesture[] pinchClose(Rect area, float percent, int speed) {
-        Method pinchCloseMethod = method(wrappedInstance.getClass(), "pinchClose",
+        Method pinchCloseMethod = getMethod(wrappedInstance.getClass(), "pinchClose",
                 Rect.class, float.class, int.class);
         return toGesturesArray(invoke(pinchCloseMethod, wrappedInstance, area, percent, speed));
     }
 
     public PointerGesture[] pinchOpen(Rect area, float percent, int speed) {
-        Method pinchOpenMethod = method(wrappedInstance.getClass(), "pinchOpen",
+        Method pinchOpenMethod = getMethod(wrappedInstance.getClass(), "pinchOpen",
                 Rect.class, float.class, int.class);
         return toGesturesArray(invoke(pinchOpenMethod, wrappedInstance, area, percent, speed));
     }
 
     public PointerGesture swipe(Rect area, Direction direction, float percent, int speed) {
-        Method swipeRectMethod = method(wrappedInstance.getClass(), "swipeRect",
+        Method swipeRectMethod = getMethod(wrappedInstance.getClass(), "swipeRect",
                 Rect.class, Direction.class, float.class, int.class);
         return new PointerGesture(invoke(swipeRectMethod, wrappedInstance, area, direction, percent, speed));
     }
@@ -79,15 +78,7 @@ public class Gestures {
 
     private static int getSpeedValue(String gestureName) {
         String fieldName = String.format("DEFAULT_%s_SPEED", gestureName.toUpperCase());
-        try {
-            Field field = UiObject2.class.getDeclaredField(fieldName);
-            field.setAccessible(true);
-            return field.getInt(null);
-        } catch (NoSuchFieldException | IllegalAccessException e) {
-            throw new IllegalStateException(
-                    String.format("Cannot retrieve %s field value of %s",
-                            fieldName, UiObject2.class.getCanonicalName()), e);
-        }
+        return (int) getField(UiObject2.class, fieldName, null);
     }
 
     public static int getDefaultDragSpeed() {
@@ -111,10 +102,10 @@ public class Gestures {
     }
 
     public static long getScrollTimeout() {
-        return (long) getField("SCROLL_TIMEOUT", UiObject2.class);
+        return (long) getField(UiObject2.class, "SCROLL_TIMEOUT", null);
     }
 
     public static long getFlingTimeout() {
-        return (long) getField("FLING_TIMEOUT", UiObject2.class);
+        return (long) getField(UiObject2.class,"FLING_TIMEOUT", null);
     }
 }

--- a/app/src/main/java/io/appium/uiautomator2/model/internal/Gestures.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/internal/Gestures.java
@@ -24,6 +24,7 @@ import androidx.test.uiautomator.Direction;
 import androidx.test.uiautomator.UiObject2;
 
 import java.lang.reflect.Array;
+import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.List;
@@ -77,7 +78,16 @@ public class Gestures {
     }
 
     private static int getSpeedValue(String gestureName) {
-        return (int) getField(String.format("DEFAULT_%s_SPEED", gestureName.toUpperCase()), UiObject2.class);
+        String fieldName = String.format("DEFAULT_%s_SPEED", gestureName.toUpperCase());
+        try {
+            Field field = UiObject2.class.getDeclaredField(fieldName);
+            field.setAccessible(true);
+            return field.getInt(null);
+        } catch (NoSuchFieldException | IllegalAccessException e) {
+            throw new IllegalStateException(
+                    String.format("Cannot retrieve %s field value of %s",
+                            fieldName, UiObject2.class.getCanonicalName()), e);
+        }
     }
 
     public static int getDefaultDragSpeed() {

--- a/app/src/main/java/io/appium/uiautomator2/model/internal/Gestures.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/internal/Gestures.java
@@ -102,10 +102,12 @@ public class Gestures {
     }
 
     public static long getScrollTimeout() {
-        return (long) getField(UiObject2.class, "SCROLL_TIMEOUT", null);
+        // UiObject2.SCROLL_TIMEOUT
+        return 1000L;
     }
 
     public static long getFlingTimeout() {
-        return (long) getField(UiObject2.class,"FLING_TIMEOUT", null);
+        // UiObject2.FLING_TIMEOUT
+        return 5000L;
     }
 }

--- a/app/src/main/java/io/appium/uiautomator2/model/internal/PointerGesture.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/internal/PointerGesture.java
@@ -49,11 +49,15 @@ public class PointerGesture {
         return pointerGestureConstructor;
     }
 
-    public PointerGesture(Point point) {
-        try {
-            this.wrappedInstance = getWrappedConstructor().newInstance(point);
-        } catch (IllegalAccessException | InstantiationException | InvocationTargetException e) {
-            throw new IllegalStateException(String.format("Cannot perform gesture at %s", point), e);
+    public PointerGesture(Object wrappedInstanceOrPoint) {
+        if (wrappedInstanceOrPoint instanceof Point) {
+            try {
+                this.wrappedInstance = getWrappedConstructor().newInstance((Point) wrappedInstanceOrPoint);
+            } catch (IllegalAccessException | InstantiationException | InvocationTargetException e) {
+                throw new IllegalStateException(String.format("Cannot perform gesture at %s", wrappedInstanceOrPoint), e);
+            }
+        } else {
+            this.wrappedInstance = wrappedInstanceOrPoint;
         }
     }
 

--- a/app/src/main/java/io/appium/uiautomator2/model/internal/PointerGesture.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/internal/PointerGesture.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.appium.uiautomator2.model.internal;
+
+import android.graphics.Point;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+import io.appium.uiautomator2.utils.ReflectionUtils;
+
+import static io.appium.uiautomator2.utils.ReflectionUtils.getConstructor;
+import static io.appium.uiautomator2.utils.ReflectionUtils.invoke;
+import static io.appium.uiautomator2.utils.ReflectionUtils.method;
+
+public class PointerGesture {
+    private static final String POINTER_GESTURE_CLASS = "androidx.test.uiautomator.PointerGesture";
+
+    private static Class<?> pointerGestureClass;
+    private static Constructor<?> pointerGestureConstructor;
+    private final Object wrappedInstance;
+
+    public synchronized static Class<?> getWrappedClass() {
+        if (pointerGestureClass == null) {
+            pointerGestureClass = ReflectionUtils.getClass(POINTER_GESTURE_CLASS);
+        }
+        return pointerGestureClass;
+    }
+
+    private static synchronized Constructor<?> getWrappedConstructor() {
+        if (pointerGestureConstructor == null) {
+            pointerGestureConstructor = getConstructor(getWrappedClass(), Point.class);
+        }
+        return pointerGestureConstructor;
+    }
+
+    public PointerGesture(Point point) {
+        try {
+            this.wrappedInstance = getWrappedConstructor().newInstance(point);
+        } catch (IllegalAccessException | InstantiationException | InvocationTargetException e) {
+            throw new IllegalStateException(String.format("Cannot perform gesture at %s", point), e);
+        }
+    }
+
+    public PointerGesture pause(long ms) {
+        Method pauseMethod = method(getWrappedClass(), "pause", long.class);
+        invoke(pauseMethod, wrappedInstance, ms);
+        return this;
+    }
+
+    public Object getWrappedInstance() {
+        return this.wrappedInstance;
+    }
+}

--- a/app/src/main/java/io/appium/uiautomator2/model/internal/PointerGesture.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/internal/PointerGesture.java
@@ -26,7 +26,7 @@ import io.appium.uiautomator2.utils.ReflectionUtils;
 
 import static io.appium.uiautomator2.utils.ReflectionUtils.getConstructor;
 import static io.appium.uiautomator2.utils.ReflectionUtils.invoke;
-import static io.appium.uiautomator2.utils.ReflectionUtils.method;
+import static io.appium.uiautomator2.utils.ReflectionUtils.getMethod;
 
 public class PointerGesture {
     private static final String POINTER_GESTURE_CLASS = "androidx.test.uiautomator.PointerGesture";
@@ -62,7 +62,7 @@ public class PointerGesture {
     }
 
     public PointerGesture pause(long ms) {
-        Method pauseMethod = method(getWrappedClass(), "pause", long.class);
+        Method pauseMethod = ReflectionUtils.getMethod(getWrappedClass(), "pause", long.class);
         invoke(pauseMethod, wrappedInstance, ms);
         return this;
     }

--- a/app/src/main/java/io/appium/uiautomator2/model/internal/PointerGesture.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/internal/PointerGesture.java
@@ -26,7 +26,6 @@ import io.appium.uiautomator2.utils.ReflectionUtils;
 
 import static io.appium.uiautomator2.utils.ReflectionUtils.getConstructor;
 import static io.appium.uiautomator2.utils.ReflectionUtils.invoke;
-import static io.appium.uiautomator2.utils.ReflectionUtils.getMethod;
 
 public class PointerGesture {
     private static final String POINTER_GESTURE_CLASS = "androidx.test.uiautomator.PointerGesture";

--- a/app/src/main/java/io/appium/uiautomator2/server/AppiumServlet.java
+++ b/app/src/main/java/io/appium/uiautomator2/server/AppiumServlet.java
@@ -145,6 +145,14 @@ public class AppiumServlet implements IHttpServlet {
         register(postHandler, new SetClipboard("/wd/hub/session/:sessionId/appium/device/set_clipboard"));
         register(postHandler, new AcceptAlert("/wd/hub/session/:sessionId/alert/accept"));
         register(postHandler, new DismissAlert("/wd/hub/session/:sessionId/alert/dismiss"));
+
+        register(postHandler, new io.appium.uiautomator2.handler.gestures.Drag("/wd/hub/session/:sessionId/appium/gestures/drag"));
+        register(postHandler, new io.appium.uiautomator2.handler.gestures.Fling("/wd/hub/session/:sessionId/appium/gestures/fling"));
+        register(postHandler, new io.appium.uiautomator2.handler.gestures.LongClick("/wd/hub/session/:sessionId/appium/gestures/long_click"));
+        register(postHandler, new io.appium.uiautomator2.handler.gestures.PinchClose("/wd/hub/session/:sessionId/appium/gestures/pinch_close"));
+        register(postHandler, new io.appium.uiautomator2.handler.gestures.PinchOpen("/wd/hub/session/:sessionId/appium/gestures/pinch_open"));
+        register(postHandler, new io.appium.uiautomator2.handler.gestures.Scroll("/wd/hub/session/:sessionId/appium/gestures/scroll"));
+        register(postHandler, new io.appium.uiautomator2.handler.gestures.Swipe("/wd/hub/session/:sessionId/appium/gestures/swipe"));
     }
 
     private void registerGetHandler() {

--- a/app/src/main/java/io/appium/uiautomator2/utils/ElementHelpers.java
+++ b/app/src/main/java/io/appium/uiautomator2/utils/ElementHelpers.java
@@ -46,7 +46,7 @@ import io.appium.uiautomator2.common.exceptions.ElementNotFoundException;
 import io.appium.uiautomator2.common.exceptions.NoSuchAttributeException;
 import io.appium.uiautomator2.common.exceptions.UiAutomator2Exception;
 import io.appium.uiautomator2.core.AxNodeInfoExtractor;
-import io.appium.uiautomator2.core.AccessibilityNodeInfoHelpers;
+import io.appium.uiautomator2.core.AxNodeInfoHelpers;
 import io.appium.uiautomator2.core.EventRegister;
 import io.appium.uiautomator2.core.ReturningRunnable;
 import io.appium.uiautomator2.core.UiObjectChildGenerator;
@@ -139,7 +139,7 @@ public abstract class ElementHelpers {
          * if text length is greater than getMaxTextLength()
          */
         if (Build.VERSION.SDK_INT < 24) {
-            textToSend = AccessibilityNodeInfoHelpers.truncateTextToMaxLength(nodeInfo, textToSend);
+            textToSend = AxNodeInfoHelpers.truncateTextToMaxLength(nodeInfo, textToSend);
         }
 
         Logger.debug("Sending text to element: " + textToSend);
@@ -153,7 +153,7 @@ public abstract class ElementHelpers {
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.N) {
             throw new IllegalStateException("Setting progress is not supported on Android API below 24");
         }
-        AccessibilityNodeInfoHelpers.setProgressValue(nodeInfo, value);
+        AxNodeInfoHelpers.setProgressValue(nodeInfo, value);
     }
 
     public static AndroidElement findElement(final BySelector ui2BySelector) throws UiAutomator2Exception {
@@ -191,7 +191,7 @@ public abstract class ElementHelpers {
             }
         }
 
-        return AccessibilityNodeInfoHelpers.getText(AxNodeInfoExtractor.toAxNodeInfo(element), replaceNull);
+        return AxNodeInfoHelpers.getText(AxNodeInfoExtractor.toAxNodeInfo(element), replaceNull);
     }
 
     public static String getContentSize(AndroidElement element) throws UiObjectNotFoundException {

--- a/app/src/main/java/io/appium/uiautomator2/utils/ElementHelpers.java
+++ b/app/src/main/java/io/appium/uiautomator2/utils/ElementHelpers.java
@@ -46,7 +46,7 @@ import io.appium.uiautomator2.common.exceptions.ElementNotFoundException;
 import io.appium.uiautomator2.common.exceptions.NoSuchAttributeException;
 import io.appium.uiautomator2.common.exceptions.UiAutomator2Exception;
 import io.appium.uiautomator2.core.AxNodeInfoExtractor;
-import io.appium.uiautomator2.core.AxNodeInfoHelpers;
+import io.appium.uiautomator2.core.AxNodeInfoHelper;
 import io.appium.uiautomator2.core.EventRegister;
 import io.appium.uiautomator2.core.ReturningRunnable;
 import io.appium.uiautomator2.core.UiObjectChildGenerator;
@@ -139,7 +139,7 @@ public abstract class ElementHelpers {
          * if text length is greater than getMaxTextLength()
          */
         if (Build.VERSION.SDK_INT < 24) {
-            textToSend = AxNodeInfoHelpers.truncateTextToMaxLength(nodeInfo, textToSend);
+            textToSend = AxNodeInfoHelper.truncateTextToMaxLength(nodeInfo, textToSend);
         }
 
         Logger.debug("Sending text to element: " + textToSend);
@@ -153,7 +153,7 @@ public abstract class ElementHelpers {
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.N) {
             throw new IllegalStateException("Setting progress is not supported on Android API below 24");
         }
-        AxNodeInfoHelpers.setProgressValue(nodeInfo, value);
+        AxNodeInfoHelper.setProgressValue(nodeInfo, value);
     }
 
     public static AndroidElement findElement(final BySelector ui2BySelector) throws UiAutomator2Exception {
@@ -191,7 +191,7 @@ public abstract class ElementHelpers {
             }
         }
 
-        return AxNodeInfoHelpers.getText(AxNodeInfoExtractor.toAxNodeInfo(element), replaceNull);
+        return AxNodeInfoHelper.getText(AxNodeInfoExtractor.toAxNodeInfo(element), replaceNull);
     }
 
     public static String getContentSize(AndroidElement element) throws UiObjectNotFoundException {

--- a/app/src/main/java/io/appium/uiautomator2/utils/ElementHelpers.java
+++ b/app/src/main/java/io/appium/uiautomator2/utils/ElementHelpers.java
@@ -61,7 +61,7 @@ import static io.appium.uiautomator2.model.internal.CustomUiDevice.getInstance;
 import static io.appium.uiautomator2.utils.Device.getAndroidElement;
 import static io.appium.uiautomator2.utils.Device.getUiDevice;
 import static io.appium.uiautomator2.utils.ReflectionUtils.getField;
-import static io.appium.uiautomator2.utils.ReflectionUtils.method;
+import static io.appium.uiautomator2.utils.ReflectionUtils.getMethod;
 import static io.appium.uiautomator2.utils.StringHelpers.charSequenceToString;
 import static io.appium.uiautomator2.utils.StringHelpers.toNonNullString;
 
@@ -93,7 +93,7 @@ public abstract class ElementHelpers {
      */
     public static List<Object> dedupe(List<Object> elements) {
         try {
-            findAccessibilityNodeInfo = method(UiObject.class, "findAccessibilityNodeInfo", long.class);
+            findAccessibilityNodeInfo = getMethod(UiObject.class, "findAccessibilityNodeInfo", long.class);
         } catch (Exception e) {
             e.printStackTrace();
         }


### PR DESCRIPTION
After talking to @wswebcreation we've figured out there's a need for shortcuts for some basic Android gestures. Of course, they could be implemented via Actions interface, however this is a Jedi path and it is not easy at all to build such action chains even for experts. 
UiObject2 already implements a couple of such basic gestures, although we also allow to use UiObject1, which does not have them. This PR tries to unify the approach and to allow gesture shortcuts usage independently of the actual Ui-wrapper (caution: heavy reflection usage under the hood)