### PR TITLE
fix: Properly exclude attributes from snapshots to speed up xpath lookup

### DIFF
--- a/app/src/main/java/io/appium/uiautomator2/core/AccessibilityNodeInfoDumper.java
+++ b/app/src/main/java/io/appium/uiautomator2/core/AccessibilityNodeInfoDumper.java
@@ -202,6 +202,9 @@ public class AccessibilityNodeInfoDumper {
     }
 
     public NodeInfoList findNodes(String xpathSelector, boolean multiple) {
+        // TODO: Remove this before merge
+        Logger.info(String.format("Source XML: %s", dumpToXml()));
+
         try {
             XPATH.compile(xpathSelector, Filters.element());
         } catch (IllegalArgumentException e) {

--- a/app/src/main/java/io/appium/uiautomator2/core/AccessibilityNodeInfoDumper.java
+++ b/app/src/main/java/io/appium/uiautomator2/core/AccessibilityNodeInfoDumper.java
@@ -68,7 +68,7 @@ public class AccessibilityNodeInfoDumper {
     private static final String XML_ENCODING = "UTF-8";
     private static final XPathFactory XPATH = XPathFactory.instance();
     private static final SAXBuilder SAX_BUILDER = new SAXBuilder();
-    private final Semaphore RESOURCES_GUARD = new Semaphore(1);
+    private static final Semaphore RESOURCES_GUARD = new Semaphore(1);
 
     @Nullable
     private final AccessibilityNodeInfo root;

--- a/app/src/main/java/io/appium/uiautomator2/core/AccessibilityNodeInfoDumper.java
+++ b/app/src/main/java/io/appium/uiautomator2/core/AccessibilityNodeInfoDumper.java
@@ -67,7 +67,7 @@ public class AccessibilityNodeInfoDumper {
     private static final String XML_ENCODING = "UTF-8";
     private static final XPathFactory XPATH = XPathFactory.instance();
     private static final SAXBuilder SAX_BUILDER = new SAXBuilder();
-    private static final Semaphore RESOURCES_GUARD = new Semaphore(1);
+    private final Semaphore RESOURCES_GUARD = new Semaphore(1);
 
     @Nullable
     private final AccessibilityNodeInfo root;
@@ -206,8 +206,8 @@ public class AccessibilityNodeInfoDumper {
             final Document document = SAX_BUILDER.build(xmlStream);
             final XPathExpression<org.jdom2.Attribute> expr = XPATH
                     .compile(String.format("(%s)/@%s", xpathSelector, UI_ELEMENT_INDEX), Filters.attribute());
-            final long timeStarted = SystemClock.uptimeMillis();
             final NodeInfoList matchedNodes = new NodeInfoList();
+            final long timeStarted = SystemClock.uptimeMillis();
             for (org.jdom2.Attribute uiElementId : expr.evaluate(document)) {
                 UiElement<?, ?> uiElement = uiElementsMapping.get(uiElementId.getIntValue());
                 if (uiElement == null || uiElement.getNode() == null) {

--- a/app/src/main/java/io/appium/uiautomator2/core/AccessibilityNodeInfoDumper.java
+++ b/app/src/main/java/io/appium/uiautomator2/core/AccessibilityNodeInfoDumper.java
@@ -131,8 +131,7 @@ public class AccessibilityNodeInfoDumper {
         serializer.startTag(NAMESPACE, nodeName);
 
         for (Attribute attr : uiElement.attributeKeys()) {
-            if (!attr.isExposableToXml()
-                    || includedAttributes != null && !includedAttributes.contains(attr)) {
+            if (!attr.isExposableToXml()) {
                 continue;
             }
             Object value = uiElement.get(attr);
@@ -173,8 +172,8 @@ public class AccessibilityNodeInfoDumper {
             serializer.startDocument(XML_ENCODING, true);
             serializer.setFeature("http://xmlpull.org/v1/doc/features.html#indent-output", true);
             final UiElement<?, ?> xpathRoot = root == null
-                    ? UiElementSnapshot.take(getCachedWindowRoots(), NotificationListener.getInstance().getToastMessage())
-                    : UiElementSnapshot.take(root);
+                    ? UiElementSnapshot.take(getCachedWindowRoots(), NotificationListener.getInstance().getToastMessage(), includedAttributes)
+                    : UiElementSnapshot.take(root, includedAttributes);
             serializeUiElement(xpathRoot, 0);
             serializer.endDocument();
             Logger.debug(String.format("The source XML tree (%s bytes) has been fetched in %sms",

--- a/app/src/main/java/io/appium/uiautomator2/core/AccessibilityNodeInfoDumper.java
+++ b/app/src/main/java/io/appium/uiautomator2/core/AccessibilityNodeInfoDumper.java
@@ -203,7 +203,15 @@ public class AccessibilityNodeInfoDumper {
 
     public NodeInfoList findNodes(String xpathSelector, boolean multiple) {
         // TODO: Remove this before merge
-        Logger.info(String.format("Source XML: %s", dumpToXml()));
+        String xml;
+        try (InputStream xmlStream = toStream(true)) {
+            xml = IOUtils.toString(xmlStream, XML_ENCODING);
+        } catch (IOException e) {
+            throw new UiAutomator2Exception(e);
+        } finally {
+            uiElementsMapping.clear();
+        }
+        Logger.info(String.format("Source XML: %s", xml));
 
         try {
             XPATH.compile(xpathSelector, Filters.element());

--- a/app/src/main/java/io/appium/uiautomator2/model/NotificationListener.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/NotificationListener.java
@@ -101,7 +101,7 @@ public class NotificationListener implements OnAccessibilityEventListener {
     @NonNull
     public List<CharSequence> getToastMessage() {
         if (!toastMessage.isEmpty() && currentTimeMillis() - recentToastTimestamp > getToastClearTimeout()) {
-            Logger.debug("Clearing toast message: " + toastMessage);
+            Logger.info("Clearing toast message: " + toastMessage);
             toastMessage.clear();
         }
         return toastMessage;

--- a/app/src/main/java/io/appium/uiautomator2/model/UiElementSnapshot.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/UiElementSnapshot.java
@@ -165,7 +165,7 @@ public class UiElementSnapshot extends UiElement<AccessibilityNodeInfo, UiElemen
         node.setPackageName("com.android.settings");
         node.setVisibleToUser(true);
         setField("mSealed", true, node);
-        this.children.add(new UiElementSnapshot(node, this.children.size(), 0, includedAttributes));
+        this.children.add(new UiElementSnapshot(node, this.children.size(), 0, null));
     }
 
     private List<UiElementSnapshot> buildChildren(AccessibilityNodeInfo node) {

--- a/app/src/main/java/io/appium/uiautomator2/model/UiElementSnapshot.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/UiElementSnapshot.java
@@ -163,6 +163,7 @@ public class UiElementSnapshot extends UiElement<AccessibilityNodeInfo, UiElemen
         node.setText(tokenMSG);
         node.setClassName(Toast.class.getName());
         node.setPackageName("com.android.settings");
+        node.setVisibleToUser(true);
         setField("mSealed", true, node);
         this.children.add(new UiElementSnapshot(node, this.children.size(), 0, includedAttributes));
     }

--- a/app/src/main/java/io/appium/uiautomator2/model/UiElementSnapshot.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/UiElementSnapshot.java
@@ -136,12 +136,12 @@ public class UiElementSnapshot extends UiElement<AccessibilityNodeInfo, UiElemen
 
     public static UiElementSnapshot take(AccessibilityNodeInfo[] roots, List<CharSequence> toastMSGs,
                                          @Nullable Set<Attribute> includedAttributes) {
-        UiElementSnapshot root = new UiElementSnapshot(ROOT_NODE_NAME, roots, 0, includedAttributes);
+        UiElementSnapshot uiRoot = new UiElementSnapshot(ROOT_NODE_NAME, roots, 0, includedAttributes);
         for (CharSequence toastMSG : toastMSGs) {
-            Logger.debug(String.format("Adding toast message to root: %s", toastMSG));
-            root.addToastMsgToRoot(toastMSG);
+            Logger.info(String.format("Adding toast message to root: %s", toastMSG));
+            uiRoot.addToastMsg(toastMSG);
         }
-        return root;
+        return uiRoot;
     }
 
     public static UiElementSnapshot take(AccessibilityNodeInfo rootElement,
@@ -158,13 +158,13 @@ public class UiElementSnapshot extends UiElement<AccessibilityNodeInfo, UiElemen
         return new UiElementSnapshot(rootElement, index, includedAttributes).setDepth(depth);
     }
 
-    private void addToastMsgToRoot(CharSequence tokenMSG) {
+    private void addToastMsg(CharSequence tokenMSG) {
         AccessibilityNodeInfo node = AccessibilityNodeInfo.obtain();
         node.setText(tokenMSG);
         node.setClassName(Toast.class.getName());
         node.setPackageName("com.android.settings");
         setField("mSealed", true, node);
-        this.children.add(new UiElementSnapshot(node, this.children.size(), includedAttributes));
+        this.children.add(new UiElementSnapshot(node, this.children.size(), 0, includedAttributes));
     }
 
     private List<UiElementSnapshot> buildChildren(AccessibilityNodeInfo node) {

--- a/app/src/main/java/io/appium/uiautomator2/model/UiElementSnapshot.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/UiElementSnapshot.java
@@ -65,35 +65,7 @@ public class UiElementSnapshot extends UiElement<AccessibilityNodeInfo, UiElemen
             this.includedAttributes.add(Attribute.CLASS);
             this.includedAttributes.addAll(includedAttributes);
         }
-
-        Map<Attribute, Object> attributes = new LinkedHashMap<>();
-        // The same sequence will be used for node attributes in xml page source
-        setAttribute(attributes, Attribute.INDEX, index);
-        setAttribute(attributes, Attribute.PACKAGE, charSequenceToNullableString(node.getPackageName()));
-        setAttribute(attributes, Attribute.CLASS, charSequenceToNullableString(node.getClassName()));
-        setAttribute(attributes, Attribute.TEXT, AxNodeInfoHelper.getText(node, true));
-        setAttribute(attributes, Attribute.ORIGINAL_TEXT, AxNodeInfoHelper.getText(node, false));
-        setAttribute(attributes, Attribute.CONTENT_DESC, charSequenceToNullableString(node.getContentDescription()));
-        setAttribute(attributes, Attribute.RESOURCE_ID, node.getViewIdResourceName());
-        setAttribute(attributes, Attribute.CHECKABLE, node.isCheckable());
-        setAttribute(attributes, Attribute.CHECKED, node.isChecked());
-        setAttribute(attributes, Attribute.CLICKABLE, node.isClickable());
-        setAttribute(attributes, Attribute.ENABLED, node.isEnabled());
-        setAttribute(attributes, Attribute.FOCUSABLE, node.isFocusable());
-        setAttribute(attributes, Attribute.FOCUSED, node.isFocused());
-        setAttribute(attributes, Attribute.LONG_CLICKABLE, node.isLongClickable());
-        setAttribute(attributes, Attribute.PASSWORD, node.isPassword());
-        setAttribute(attributes, Attribute.SCROLLABLE, node.isScrollable());
-        Range<Integer> selectionRange = AxNodeInfoHelper.getSelectionRange(node);
-        if (selectionRange != null) {
-            attributes.put(Attribute.SELECTION_START, selectionRange.getLower());
-            attributes.put(Attribute.SELECTION_END, selectionRange.getUpper());
-        }
-        setAttribute(attributes, Attribute.SELECTED, node.isSelected());
-        setAttribute(attributes, Attribute.BOUNDS, AxNodeInfoHelper.getBounds(node).toShortString());
-        setAttribute(attributes, Attribute.DISPLAYED, node.isVisibleToUser());
-        // Skip CONTENT_SIZE as it is quite expensive to compute it for each element
-        this.attributes = Collections.unmodifiableMap(attributes);
+        this.attributes = collectAttributes(node, index);
         this.children = buildChildren(node);
     }
 
@@ -115,10 +87,91 @@ public class UiElementSnapshot extends UiElement<AccessibilityNodeInfo, UiElemen
         this.children = children;
     }
 
+    private boolean shouldIncludeAttribute(Attribute key) {
+        return includedAttributes.isEmpty() || includedAttributes.contains(key);
+    }
+
     private void setAttribute(Map<Attribute, Object> attribs, Attribute key, Object value) {
-        if (value != null && (includedAttributes.isEmpty() || includedAttributes.contains(key))) {
+        if (value != null) {
             attribs.put(key, value);
         }
+    }
+
+    private Map<Attribute, Object> collectAttributes(AccessibilityNodeInfo node, int index) {
+        Map<Attribute, Object> result = new LinkedHashMap<>();
+        // The same sequence will be used for node attributes in xml page source
+        if (shouldIncludeAttribute(Attribute.INDEX)) {
+            setAttribute(result, Attribute.INDEX, index);
+        }
+        if (shouldIncludeAttribute(Attribute.PACKAGE)) {
+            setAttribute(result, Attribute.PACKAGE, charSequenceToNullableString(node.getPackageName()));
+        }
+        if (shouldIncludeAttribute(Attribute.CLASS)) {
+            setAttribute(result, Attribute.CLASS, charSequenceToNullableString(node.getClassName()));
+        }
+        if (shouldIncludeAttribute(Attribute.TEXT)) {
+            setAttribute(result, Attribute.TEXT, AxNodeInfoHelper.getText(node, true));
+        }
+        if (shouldIncludeAttribute(Attribute.ORIGINAL_TEXT)) {
+            setAttribute(result, Attribute.ORIGINAL_TEXT, AxNodeInfoHelper.getText(node, false));
+        }
+        if (shouldIncludeAttribute(Attribute.CONTENT_DESC)) {
+            setAttribute(result, Attribute.CONTENT_DESC,
+                    charSequenceToNullableString(node.getContentDescription()));
+        }
+        if (shouldIncludeAttribute(Attribute.RESOURCE_ID)) {
+            setAttribute(result, Attribute.RESOURCE_ID, node.getViewIdResourceName());
+        }
+        if (shouldIncludeAttribute(Attribute.CHECKABLE)) {
+            setAttribute(result, Attribute.CHECKABLE, node.isCheckable());
+        }
+        if (shouldIncludeAttribute(Attribute.CHECKED)) {
+            setAttribute(result, Attribute.CHECKED, node.isChecked());
+        }
+        if (shouldIncludeAttribute(Attribute.CLICKABLE)) {
+            setAttribute(result, Attribute.CLICKABLE, node.isClickable());
+        }
+        if (shouldIncludeAttribute(Attribute.ENABLED)) {
+            setAttribute(result, Attribute.ENABLED, node.isEnabled());
+        }
+        if (shouldIncludeAttribute(Attribute.FOCUSABLE)) {
+            setAttribute(result, Attribute.FOCUSABLE, node.isFocusable());
+        }
+        if (shouldIncludeAttribute(Attribute.FOCUSED)) {
+            setAttribute(result, Attribute.FOCUSED, node.isFocused());
+        }
+        if (shouldIncludeAttribute(Attribute.LONG_CLICKABLE)) {
+            setAttribute(result, Attribute.LONG_CLICKABLE, node.isLongClickable());
+        }
+        if (shouldIncludeAttribute(Attribute.PASSWORD)) {
+            setAttribute(result, Attribute.PASSWORD, node.isPassword());
+        }
+        if (shouldIncludeAttribute(Attribute.SCROLLABLE)) {
+            setAttribute(result, Attribute.SCROLLABLE, node.isScrollable());
+        }
+        if (shouldIncludeAttribute(Attribute.SELECTION_START)
+                || shouldIncludeAttribute(Attribute.SELECTION_END)) {
+            Range<Integer> selectionRange = AxNodeInfoHelper.getSelectionRange(node);
+            if (selectionRange != null) {
+                if (shouldIncludeAttribute(Attribute.SELECTION_START)) {
+                    result.put(Attribute.SELECTION_START, selectionRange.getLower());
+                }
+                if (shouldIncludeAttribute(Attribute.SELECTION_END)) {
+                    result.put(Attribute.SELECTION_END, selectionRange.getUpper());
+                }
+            }
+        }
+        if (shouldIncludeAttribute(Attribute.SELECTED)) {
+            setAttribute(result, Attribute.SELECTED, node.isSelected());
+        }
+        if (shouldIncludeAttribute(Attribute.BOUNDS)) {
+            setAttribute(result, Attribute.BOUNDS, AxNodeInfoHelper.getBounds(node).toShortString());
+        }
+        if (shouldIncludeAttribute(Attribute.DISPLAYED)) {
+            setAttribute(result, Attribute.DISPLAYED, node.isVisibleToUser());
+        }
+        // Skip CONTENT_SIZE as it is quite expensive to compute it for each element
+        return Collections.unmodifiableMap(result);
     }
 
     private int getDepth() {

--- a/app/src/main/java/io/appium/uiautomator2/utils/ElementLocationHelpers.java
+++ b/app/src/main/java/io/appium/uiautomator2/utils/ElementLocationHelpers.java
@@ -22,6 +22,7 @@ import androidx.annotation.Nullable;
 import androidx.test.uiautomator.UiObjectNotFoundException;
 import androidx.test.uiautomator.UiSelector;
 
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -107,8 +108,21 @@ public class ElementLocationHelpers {
         // We are trying to be smart here and only include the actually queried
         // attributes into the source XML document. This allows to improve the performance a lot
         // while building this document.
-        return new AccessibilityNodeInfoDumper(root, extractQueriedAttributes(expression))
-                .findNodes(expression, multiple);
+        Set<Attribute> includedAttributes = extractQueriedAttributes(expression);
+        List<String> includedAttributeNames = new ArrayList<>();
+        if (includedAttributes == null) {
+            for (Attribute includedAttribute : Attribute.values()) {
+                if (includedAttribute.isExposableToXml()) {
+                    includedAttributeNames.add(includedAttribute.name());
+                }
+            }
+        } else {
+            for (Attribute includedAttribute : includedAttributes) {
+                includedAttributeNames.add(includedAttribute.name());
+            }
+        }
+        Logger.info(String.format("The following attributes will be included to the page source: %s", includedAttributeNames));
+        return new AccessibilityNodeInfoDumper(root, includedAttributes).findNodes(expression, multiple);
     }
 
     @Nullable

--- a/app/src/main/java/io/appium/uiautomator2/utils/ElementLocationHelpers.java
+++ b/app/src/main/java/io/appium/uiautomator2/utils/ElementLocationHelpers.java
@@ -22,7 +22,6 @@ import androidx.annotation.Nullable;
 import androidx.test.uiautomator.UiObjectNotFoundException;
 import androidx.test.uiautomator.UiSelector;
 
-import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -109,19 +108,8 @@ public class ElementLocationHelpers {
         // attributes into the source XML document. This allows to improve the performance a lot
         // while building this document.
         Set<Attribute> includedAttributes = extractQueriedAttributes(expression);
-        List<String> includedAttributeNames = new ArrayList<>();
-        if (includedAttributes == null) {
-            for (Attribute includedAttribute : Attribute.values()) {
-                if (includedAttribute.isExposableToXml()) {
-                    includedAttributeNames.add(includedAttribute.name());
-                }
-            }
-        } else {
-            for (Attribute includedAttribute : includedAttributes) {
-                includedAttributeNames.add(includedAttribute.name());
-            }
-        }
-        Logger.info(String.format("The following attributes will be included to the page source: %s", includedAttributeNames));
+        Logger.info(String.format("The following attributes will be included to the page source: %s",
+                includedAttributes == null ? "all" : includedAttributes));
         return new AccessibilityNodeInfoDumper(root, includedAttributes).findNodes(expression, multiple);
     }
 


### PR DESCRIPTION
Previously we were only excluding redundant attributes from the xml itself, which did not affect the performance much, but now we also exclude them from snapshots. And it does the job