### PR TITLE
refactor: Limit the maximum size of elements cache

### DIFF
--- a/app/src/main/java/io/appium/uiautomator2/common/exceptions/ElementNotFoundException.java
+++ b/app/src/main/java/io/appium/uiautomator2/common/exceptions/ElementNotFoundException.java
@@ -31,6 +31,10 @@ public class ElementNotFoundException extends UiAutomator2Exception {
         super(message, cause);
     }
 
+    public ElementNotFoundException(String message) {
+        super(message);
+    }
+
     @Override
     public String getError() {
         return "no such element";

--- a/app/src/main/java/io/appium/uiautomator2/handler/BaseTouchAction.java
+++ b/app/src/main/java/io/appium/uiautomator2/handler/BaseTouchAction.java
@@ -21,7 +21,6 @@ import android.graphics.Rect;
 import androidx.annotation.Nullable;
 import androidx.test.uiautomator.UiObjectNotFoundException;
 
-import io.appium.uiautomator2.common.exceptions.ElementNotFoundException;
 import io.appium.uiautomator2.core.InteractionController;
 import io.appium.uiautomator2.core.UiAutomatorBridge;
 import io.appium.uiautomator2.handler.request.SafeRequestHandler;
@@ -52,10 +51,7 @@ public abstract class BaseTouchAction extends SafeRequestHandler {
         final String elementId = params.getUnifiedId();
         if (elementId != null && params.x == null && params.y == null) {
             Session session = AppiumUIA2Driver.getInstance().getSessionOrThrow();
-            element = session.getKnownElements().getElementFromCache(elementId);
-            if (element == null) {
-                throw new ElementNotFoundException();
-            }
+            element = session.getElementsCache().getElementFromCache(elementId);
             final Rect bounds = element.getBounds();
             clickX = bounds.centerX();
             clickY = bounds.centerY();

--- a/app/src/main/java/io/appium/uiautomator2/handler/BaseTouchAction.java
+++ b/app/src/main/java/io/appium/uiautomator2/handler/BaseTouchAction.java
@@ -51,7 +51,7 @@ public abstract class BaseTouchAction extends SafeRequestHandler {
         final String elementId = params.getUnifiedId();
         if (elementId != null && params.x == null && params.y == null) {
             Session session = AppiumUIA2Driver.getInstance().getSessionOrThrow();
-            element = session.getElementsCache().getElementFromCache(elementId);
+            element = session.getElementsCache().get(elementId);
             final Rect bounds = element.getBounds();
             clickX = bounds.centerX();
             clickY = bounds.centerY();

--- a/app/src/main/java/io/appium/uiautomator2/handler/Clear.java
+++ b/app/src/main/java/io/appium/uiautomator2/handler/Clear.java
@@ -39,7 +39,7 @@ public class Clear extends SafeRequestHandler {
         String elementId = getElementId(request);
         if (elementId != null) {
             Session session = AppiumUIA2Driver.getInstance().getSessionOrThrow();
-            element = session.getElementsCache().getElementFromCache(elementId);
+            element = session.getElementsCache().get(elementId);
         } else {
             //perform action on focused element
             element = findElement(focused(true));

--- a/app/src/main/java/io/appium/uiautomator2/handler/Clear.java
+++ b/app/src/main/java/io/appium/uiautomator2/handler/Clear.java
@@ -18,8 +18,6 @@ package io.appium.uiautomator2.handler;
 
 import androidx.test.uiautomator.UiObjectNotFoundException;
 
-import java.util.NoSuchElementException;
-
 import io.appium.uiautomator2.handler.request.SafeRequestHandler;
 import io.appium.uiautomator2.http.AppiumResponse;
 import io.appium.uiautomator2.http.IHttpRequest;
@@ -41,10 +39,7 @@ public class Clear extends SafeRequestHandler {
         String elementId = getElementId(request);
         if (elementId != null) {
             Session session = AppiumUIA2Driver.getInstance().getSessionOrThrow();
-            element = session.getKnownElements().getElementFromCache(elementId);
-            if (element == null) {
-                throw new NoSuchElementException();
-            }
+            element = session.getElementsCache().getElementFromCache(elementId);
         } else {
             //perform action on focused element
             element = findElement(focused(true));

--- a/app/src/main/java/io/appium/uiautomator2/handler/Click.java
+++ b/app/src/main/java/io/appium/uiautomator2/handler/Click.java
@@ -16,8 +16,6 @@
 
 package io.appium.uiautomator2.handler;
 
-import java.util.NoSuchElementException;
-
 import io.appium.uiautomator2.handler.request.SafeRequestHandler;
 import io.appium.uiautomator2.http.AppiumResponse;
 import io.appium.uiautomator2.http.IHttpRequest;
@@ -35,11 +33,7 @@ public class Click extends SafeRequestHandler {
     @Override
     protected AppiumResponse safeHandle(IHttpRequest request) {
         Session session = AppiumUIA2Driver.getInstance().getSessionOrThrow();
-        AndroidElement element = session.getKnownElements()
-                .getElementFromCache(getElementId(request));
-        if (element == null) {
-            throw new NoSuchElementException();
-        }
+        AndroidElement element = session.getElementsCache().getElementFromCache(getElementId(request));
         element.click();
         Device.waitForIdle();
         return new AppiumResponse(getSessionId(request));

--- a/app/src/main/java/io/appium/uiautomator2/handler/Click.java
+++ b/app/src/main/java/io/appium/uiautomator2/handler/Click.java
@@ -33,7 +33,7 @@ public class Click extends SafeRequestHandler {
     @Override
     protected AppiumResponse safeHandle(IHttpRequest request) {
         Session session = AppiumUIA2Driver.getInstance().getSessionOrThrow();
-        AndroidElement element = session.getElementsCache().getElementFromCache(getElementId(request));
+        AndroidElement element = session.getElementsCache().get(getElementId(request));
         element.click();
         Device.waitForIdle();
         return new AppiumResponse(getSessionId(request));

--- a/app/src/main/java/io/appium/uiautomator2/handler/Drag.java
+++ b/app/src/main/java/io/appium/uiautomator2/handler/Drag.java
@@ -42,8 +42,8 @@ public class Drag extends SafeRequestHandler {
     protected AppiumResponse safeHandle(IHttpRequest request) throws UiObjectNotFoundException {
         DragModel model = toModel(request, DragModel.class);
         ElementsCache ke = AppiumUIA2Driver.getInstance().getSessionOrThrow().getElementsCache();
-        AndroidElement startElement = model.elementId == null ? null : ke.getElementFromCache(model.elementId);
-        AndroidElement endElement = model.destElId == null ? null : ke.getElementFromCache(model.destElId);
+        AndroidElement startElement = model.elementId == null ? null : ke.get(model.elementId);
+        AndroidElement endElement = model.destElId == null ? null : ke.get(model.destElId);
         Point start = (model.startX != null && model.startY != null) ? new Point(model.startX, model.startY) : null;
         Point end = (model.endX != null && model.endY != null) ? new Point(model.endX, model.endY) : null;
 

--- a/app/src/main/java/io/appium/uiautomator2/handler/Drag.java
+++ b/app/src/main/java/io/appium/uiautomator2/handler/Drag.java
@@ -18,14 +18,13 @@ package io.appium.uiautomator2.handler;
 
 import androidx.test.uiautomator.UiObjectNotFoundException;
 
-import io.appium.uiautomator2.common.exceptions.ElementNotFoundException;
 import io.appium.uiautomator2.common.exceptions.InvalidElementStateException;
 import io.appium.uiautomator2.handler.request.SafeRequestHandler;
 import io.appium.uiautomator2.http.AppiumResponse;
 import io.appium.uiautomator2.http.IHttpRequest;
 import io.appium.uiautomator2.model.AndroidElement;
 import io.appium.uiautomator2.model.AppiumUIA2Driver;
-import io.appium.uiautomator2.model.KnownElements;
+import io.appium.uiautomator2.model.ElementsCache;
 import io.appium.uiautomator2.model.Point;
 import io.appium.uiautomator2.model.api.DragModel;
 import io.appium.uiautomator2.utils.Logger;
@@ -42,15 +41,9 @@ public class Drag extends SafeRequestHandler {
     @Override
     protected AppiumResponse safeHandle(IHttpRequest request) throws UiObjectNotFoundException {
         DragModel model = toModel(request, DragModel.class);
-        KnownElements ke = AppiumUIA2Driver.getInstance().getSessionOrThrow().getKnownElements();
+        ElementsCache ke = AppiumUIA2Driver.getInstance().getSessionOrThrow().getElementsCache();
         AndroidElement startElement = model.elementId == null ? null : ke.getElementFromCache(model.elementId);
-        if (model.elementId != null && startElement == null) {
-            throw new ElementNotFoundException();
-        }
         AndroidElement endElement = model.destElId == null ? null : ke.getElementFromCache(model.destElId);
-        if (model.destElId != null && endElement == null) {
-            throw new ElementNotFoundException();
-        }
         Point start = (model.startX != null && model.startY != null) ? new Point(model.startX, model.startY) : null;
         Point end = (model.endX != null && model.endY != null) ? new Point(model.endX, model.endY) : null;
 

--- a/app/src/main/java/io/appium/uiautomator2/handler/FindElement.java
+++ b/app/src/main/java/io/appium/uiautomator2/handler/FindElement.java
@@ -105,7 +105,7 @@ public class FindElement extends SafeRequestHandler {
     @Nullable
     private Object findElement(By by, String contextId) throws UiAutomator2Exception, UiObjectNotFoundException {
         Session session = AppiumUIA2Driver.getInstance().getSessionOrThrow();
-        AndroidElement element = session.getElementsCache().getElementFromCache(contextId);
+        AndroidElement element = session.getElementsCache().get(contextId);
 
         if (by instanceof ById) {
             String locator = rewriteIdLocator((ById) by);

--- a/app/src/main/java/io/appium/uiautomator2/handler/FindElement.java
+++ b/app/src/main/java/io/appium/uiautomator2/handler/FindElement.java
@@ -76,7 +76,7 @@ public class FindElement extends SafeRequestHandler {
         String id = UUID.randomUUID().toString();
         AndroidElement androidElement = getAndroidElement(id, element, true, by, contextId);
         Session session = AppiumUIA2Driver.getInstance().getSessionOrThrow();
-        session.getKnownElements().add(androidElement);
+        session.getElementsCache().add(androidElement);
         return new AppiumResponse(getSessionId(request), androidElement.toModel());
     }
 
@@ -110,10 +110,7 @@ public class FindElement extends SafeRequestHandler {
     @Nullable
     private Object findElement(By by, String contextId) throws UiAutomator2Exception, UiObjectNotFoundException {
         Session session = AppiumUIA2Driver.getInstance().getSessionOrThrow();
-        AndroidElement element = session.getKnownElements().getElementFromCache(contextId);
-        if (element == null) {
-            throw new ElementNotFoundException();
-        }
+        AndroidElement element = session.getElementsCache().getElementFromCache(contextId);
 
         if (by instanceof ById) {
             String locator = rewriteIdLocator((ById) by);

--- a/app/src/main/java/io/appium/uiautomator2/handler/FindElement.java
+++ b/app/src/main/java/io/appium/uiautomator2/handler/FindElement.java
@@ -20,8 +20,6 @@ import androidx.annotation.Nullable;
 import androidx.test.uiautomator.UiObjectNotFoundException;
 import androidx.test.uiautomator.UiSelector;
 
-import java.util.UUID;
-
 import io.appium.uiautomator2.common.exceptions.ElementNotFoundException;
 import io.appium.uiautomator2.common.exceptions.UiAutomator2Exception;
 import io.appium.uiautomator2.common.exceptions.UiSelectorSyntaxException;
@@ -41,7 +39,6 @@ import io.appium.uiautomator2.utils.Logger;
 import io.appium.uiautomator2.utils.NodeInfoList;
 
 import static io.appium.uiautomator2.utils.AXWindowHelpers.refreshAccessibilityCache;
-import static io.appium.uiautomator2.utils.Device.getAndroidElement;
 import static io.appium.uiautomator2.utils.ElementLocationHelpers.getXPathNodeMatch;
 import static io.appium.uiautomator2.utils.ElementLocationHelpers.rewriteIdLocator;
 import static io.appium.uiautomator2.utils.ElementLocationHelpers.toSelector;
@@ -73,10 +70,8 @@ public class FindElement extends SafeRequestHandler {
             throw new ElementNotFoundException();
         }
 
-        String id = UUID.randomUUID().toString();
-        AndroidElement androidElement = getAndroidElement(id, element, true, by, contextId);
         Session session = AppiumUIA2Driver.getInstance().getSessionOrThrow();
-        session.getElementsCache().add(androidElement);
+        AndroidElement androidElement = session.getElementsCache().add(element, true, by, contextId);
         return new AppiumResponse(getSessionId(request), androidElement.toModel());
     }
 

--- a/app/src/main/java/io/appium/uiautomator2/handler/FindElements.java
+++ b/app/src/main/java/io/appium/uiautomator2/handler/FindElements.java
@@ -23,7 +23,6 @@ import androidx.test.uiautomator.UiSelector;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.UUID;
 import java.util.regex.Pattern;
 
 import io.appium.uiautomator2.common.exceptions.ElementNotFoundException;
@@ -45,7 +44,6 @@ import io.appium.uiautomator2.utils.Logger;
 import io.appium.uiautomator2.utils.NodeInfoList;
 
 import static io.appium.uiautomator2.utils.AXWindowHelpers.refreshAccessibilityCache;
-import static io.appium.uiautomator2.utils.Device.getAndroidElement;
 import static io.appium.uiautomator2.utils.Device.getUiDevice;
 import static io.appium.uiautomator2.utils.ElementLocationHelpers.getXPathNodeMatch;
 import static io.appium.uiautomator2.utils.ElementLocationHelpers.rewriteIdLocator;
@@ -83,9 +81,7 @@ public class FindElements extends SafeRequestHandler {
 
             Session session = AppiumUIA2Driver.getInstance().getSessionOrThrow();
             for (Object element : elements) {
-                String id = UUID.randomUUID().toString();
-                AndroidElement androidElement = getAndroidElement(id, element, false, by, contextId);
-                session.getElementsCache().add(androidElement);
+                AndroidElement androidElement = session.getElementsCache().add(element, false, by, contextId);
                 result.add(androidElement.toModel());
             }
             return new AppiumResponse(getSessionId(request), result);

--- a/app/src/main/java/io/appium/uiautomator2/handler/FindElements.java
+++ b/app/src/main/java/io/appium/uiautomator2/handler/FindElements.java
@@ -85,7 +85,7 @@ public class FindElements extends SafeRequestHandler {
             for (Object element : elements) {
                 String id = UUID.randomUUID().toString();
                 AndroidElement androidElement = getAndroidElement(id, element, false, by, contextId);
-                session.getKnownElements().add(androidElement);
+                session.getElementsCache().add(androidElement);
                 result.add(androidElement.toModel());
             }
             return new AppiumResponse(getSessionId(request), result);
@@ -123,10 +123,7 @@ public class FindElements extends SafeRequestHandler {
 
     private List<?> findElements(By by, String contextId) throws UiObjectNotFoundException {
         Session session = AppiumUIA2Driver.getInstance().getSessionOrThrow();
-        AndroidElement element = session.getKnownElements().getElementFromCache(contextId);
-        if (element == null) {
-            throw new ElementNotFoundException();
-        }
+        AndroidElement element = session.getElementsCache().getElementFromCache(contextId);
 
         if (by instanceof ById) {
             String locator = rewriteIdLocator((ById) by);
@@ -200,7 +197,12 @@ public class FindElements extends SafeRequestHandler {
         }
 
         UiObject lastFoundObj;
-        final AndroidElement baseEl = session.getKnownElements().getElementFromCache(key);
+        AndroidElement baseEl = null;
+        try {
+            baseEl = session.getElementsCache().getElementFromCache(key);
+        } catch (ElementNotFoundException e) {
+            // ignore
+        }
 
         UiSelector tmp;
         int counter = 0;

--- a/app/src/main/java/io/appium/uiautomator2/handler/FindElements.java
+++ b/app/src/main/java/io/appium/uiautomator2/handler/FindElements.java
@@ -119,7 +119,7 @@ public class FindElements extends SafeRequestHandler {
 
     private List<?> findElements(By by, String contextId) throws UiObjectNotFoundException {
         Session session = AppiumUIA2Driver.getInstance().getSessionOrThrow();
-        AndroidElement element = session.getElementsCache().getElementFromCache(contextId);
+        AndroidElement element = session.getElementsCache().get(contextId);
 
         if (by instanceof ById) {
             String locator = rewriteIdLocator((ById) by);
@@ -195,7 +195,7 @@ public class FindElements extends SafeRequestHandler {
         UiObject lastFoundObj;
         AndroidElement baseEl = null;
         try {
-            baseEl = session.getElementsCache().getElementFromCache(key);
+            baseEl = session.getElementsCache().get(key);
         } catch (ElementNotFoundException e) {
             // ignore
         }

--- a/app/src/main/java/io/appium/uiautomator2/handler/FirstVisibleView.java
+++ b/app/src/main/java/io/appium/uiautomator2/handler/FirstVisibleView.java
@@ -36,10 +36,7 @@ public class FirstVisibleView extends SafeRequestHandler {
         String elementId = getElementId(request);
         Session session = AppiumUIA2Driver.getInstance().getSessionOrThrow();
 
-        AndroidElement element = session.getKnownElements().getElementFromCache(elementId);
-        if (element == null) {
-            throw new ElementNotFoundException();
-        }
+        AndroidElement element = session.getElementsCache().getElementFromCache(elementId);
         Object firstObject = null;
         if (element.getUiObject() instanceof UiObject) {
             UiObject uiObject = (UiObject) element.getUiObject();
@@ -75,7 +72,7 @@ public class FirstVisibleView extends SafeRequestHandler {
 
         String id = UUID.randomUUID().toString();
         AndroidElement androidElement = getAndroidElement(id, firstObject, false);
-        session.getKnownElements().add(androidElement);
+        session.getElementsCache().add(androidElement);
         return new AppiumResponse(getSessionId(request), androidElement.toModel());
     }
 }

--- a/app/src/main/java/io/appium/uiautomator2/handler/FirstVisibleView.java
+++ b/app/src/main/java/io/appium/uiautomator2/handler/FirstVisibleView.java
@@ -6,7 +6,6 @@ import androidx.test.uiautomator.UiObjectNotFoundException;
 import androidx.test.uiautomator.UiSelector;
 
 import java.util.List;
-import java.util.UUID;
 
 import io.appium.uiautomator2.common.exceptions.ElementNotFoundException;
 import io.appium.uiautomator2.common.exceptions.UiAutomator2Exception;
@@ -18,8 +17,6 @@ import io.appium.uiautomator2.model.AndroidElement;
 import io.appium.uiautomator2.model.AppiumUIA2Driver;
 import io.appium.uiautomator2.model.Session;
 import io.appium.uiautomator2.utils.Logger;
-
-import static io.appium.uiautomator2.utils.Device.getAndroidElement;
 
 /**
  * This method return first visible element inside provided element
@@ -70,9 +67,7 @@ public class FirstVisibleView extends SafeRequestHandler {
             throw new ElementNotFoundException();
         }
 
-        String id = UUID.randomUUID().toString();
-        AndroidElement androidElement = getAndroidElement(id, firstObject, false);
-        session.getElementsCache().add(androidElement);
+        AndroidElement androidElement = session.getElementsCache().add(firstObject, true);
         return new AppiumResponse(getSessionId(request), androidElement.toModel());
     }
 }

--- a/app/src/main/java/io/appium/uiautomator2/handler/FirstVisibleView.java
+++ b/app/src/main/java/io/appium/uiautomator2/handler/FirstVisibleView.java
@@ -33,7 +33,7 @@ public class FirstVisibleView extends SafeRequestHandler {
         String elementId = getElementId(request);
         Session session = AppiumUIA2Driver.getInstance().getSessionOrThrow();
 
-        AndroidElement element = session.getElementsCache().getElementFromCache(elementId);
+        AndroidElement element = session.getElementsCache().get(elementId);
         Object firstObject = null;
         if (element.getUiObject() instanceof UiObject) {
             UiObject uiObject = (UiObject) element.getUiObject();

--- a/app/src/main/java/io/appium/uiautomator2/handler/Flick.java
+++ b/app/src/main/java/io/appium/uiautomator2/handler/Flick.java
@@ -50,7 +50,7 @@ public class Flick extends SafeRequestHandler {
         final String elementId = toModel(request, ElementModel.class).getUnifiedId();
         if (elementId != null) {
             Session session = AppiumUIA2Driver.getInstance().getSessionOrThrow();
-            AndroidElement element = session.getElementsCache().getElementFromCache(elementId);
+            AndroidElement element = session.getElementsCache().get(elementId);
             start = element.getAbsolutePosition(start);
             FlickByOffsetModel model = toModel(request, FlickByOffsetModel.class);
             if (model.speed == 0) {

--- a/app/src/main/java/io/appium/uiautomator2/handler/Flick.java
+++ b/app/src/main/java/io/appium/uiautomator2/handler/Flick.java
@@ -18,7 +18,6 @@ package io.appium.uiautomator2.handler;
 
 import androidx.test.uiautomator.UiObjectNotFoundException;
 
-import io.appium.uiautomator2.common.exceptions.ElementNotFoundException;
 import io.appium.uiautomator2.common.exceptions.InvalidElementStateException;
 import io.appium.uiautomator2.handler.request.SafeRequestHandler;
 import io.appium.uiautomator2.http.AppiumResponse;
@@ -51,10 +50,7 @@ public class Flick extends SafeRequestHandler {
         final String elementId = toModel(request, ElementModel.class).getUnifiedId();
         if (elementId != null) {
             Session session = AppiumUIA2Driver.getInstance().getSessionOrThrow();
-            AndroidElement element = session.getKnownElements().getElementFromCache(elementId);
-            if (element == null) {
-                throw new ElementNotFoundException();
-            }
+            AndroidElement element = session.getElementsCache().getElementFromCache(elementId);
             start = element.getAbsolutePosition(start);
             FlickByOffsetModel model = toModel(request, FlickByOffsetModel.class);
             if (model.speed == 0) {

--- a/app/src/main/java/io/appium/uiautomator2/handler/GetElementAttribute.java
+++ b/app/src/main/java/io/appium/uiautomator2/handler/GetElementAttribute.java
@@ -2,7 +2,6 @@ package io.appium.uiautomator2.handler;
 
 import androidx.test.uiautomator.UiObjectNotFoundException;
 
-import io.appium.uiautomator2.common.exceptions.ElementNotFoundException;
 import io.appium.uiautomator2.handler.request.SafeRequestHandler;
 import io.appium.uiautomator2.http.AppiumResponse;
 import io.appium.uiautomator2.http.IHttpRequest;
@@ -21,10 +20,7 @@ public class GetElementAttribute extends SafeRequestHandler {
         String id = getElementId(request);
         String attributeName = getNameAttribute(request);
         Session session = AppiumUIA2Driver.getInstance().getSessionOrThrow();
-        AndroidElement element = session.getKnownElements().getElementFromCache(id);
-        if (element == null) {
-            throw new ElementNotFoundException();
-        }
+        AndroidElement element = session.getElementsCache().getElementFromCache(id);
         String attribute = element.getAttribute(attributeName);
         return new AppiumResponse(getSessionId(request), attribute);
     }

--- a/app/src/main/java/io/appium/uiautomator2/handler/GetElementAttribute.java
+++ b/app/src/main/java/io/appium/uiautomator2/handler/GetElementAttribute.java
@@ -20,7 +20,7 @@ public class GetElementAttribute extends SafeRequestHandler {
         String id = getElementId(request);
         String attributeName = getNameAttribute(request);
         Session session = AppiumUIA2Driver.getInstance().getSessionOrThrow();
-        AndroidElement element = session.getElementsCache().getElementFromCache(id);
+        AndroidElement element = session.getElementsCache().get(id);
         String attribute = element.getAttribute(attributeName);
         return new AppiumResponse(getSessionId(request), attribute);
     }

--- a/app/src/main/java/io/appium/uiautomator2/handler/GetElementScreenshot.java
+++ b/app/src/main/java/io/appium/uiautomator2/handler/GetElementScreenshot.java
@@ -4,7 +4,6 @@ import android.graphics.Rect;
 
 import androidx.test.uiautomator.UiObjectNotFoundException;
 
-import io.appium.uiautomator2.common.exceptions.ElementNotFoundException;
 import io.appium.uiautomator2.handler.request.SafeRequestHandler;
 import io.appium.uiautomator2.http.AppiumResponse;
 import io.appium.uiautomator2.http.IHttpRequest;
@@ -23,10 +22,7 @@ public class GetElementScreenshot extends SafeRequestHandler {
     protected AppiumResponse safeHandle(IHttpRequest request) throws UiObjectNotFoundException {
         String id = getElementId(request);
         Session session = AppiumUIA2Driver.getInstance().getSessionOrThrow();
-        AndroidElement element = session.getKnownElements().getElementFromCache(id);
-        if (element == null) {
-            throw new ElementNotFoundException();
-        }
+        AndroidElement element = session.getElementsCache().getElementFromCache(id);
         final Rect elementRect = element.getBounds();
         final String result = ScreenshotHelper.takeScreenshot(elementRect);
         return new AppiumResponse(getSessionId(request), result);

--- a/app/src/main/java/io/appium/uiautomator2/handler/GetElementScreenshot.java
+++ b/app/src/main/java/io/appium/uiautomator2/handler/GetElementScreenshot.java
@@ -22,7 +22,7 @@ public class GetElementScreenshot extends SafeRequestHandler {
     protected AppiumResponse safeHandle(IHttpRequest request) throws UiObjectNotFoundException {
         String id = getElementId(request);
         Session session = AppiumUIA2Driver.getInstance().getSessionOrThrow();
-        AndroidElement element = session.getElementsCache().getElementFromCache(id);
+        AndroidElement element = session.getElementsCache().get(id);
         final Rect elementRect = element.getBounds();
         final String result = ScreenshotHelper.takeScreenshot(elementRect);
         return new AppiumResponse(getSessionId(request), result);

--- a/app/src/main/java/io/appium/uiautomator2/handler/GetName.java
+++ b/app/src/main/java/io/appium/uiautomator2/handler/GetName.java
@@ -38,7 +38,7 @@ public class GetName extends SafeRequestHandler {
     protected AppiumResponse safeHandle(IHttpRequest request) throws UiObjectNotFoundException {
         String id = getElementId(request);
         Session session = AppiumUIA2Driver.getInstance().getSessionOrThrow();
-        AndroidElement element = session.getElementsCache().getElementFromCache(id);
+        AndroidElement element = session.getElementsCache().get(id);
         return new AppiumResponse(getSessionId(request), element.getContentDesc());
     }
 }

--- a/app/src/main/java/io/appium/uiautomator2/handler/GetName.java
+++ b/app/src/main/java/io/appium/uiautomator2/handler/GetName.java
@@ -18,14 +18,12 @@ package io.appium.uiautomator2.handler;
 
 import androidx.test.uiautomator.UiObjectNotFoundException;
 
-import io.appium.uiautomator2.common.exceptions.ElementNotFoundException;
 import io.appium.uiautomator2.handler.request.SafeRequestHandler;
 import io.appium.uiautomator2.http.AppiumResponse;
 import io.appium.uiautomator2.http.IHttpRequest;
 import io.appium.uiautomator2.model.AndroidElement;
 import io.appium.uiautomator2.model.AppiumUIA2Driver;
 import io.appium.uiautomator2.model.Session;
-import io.appium.uiautomator2.utils.Logger;
 
 /**
  * This handler is used to get the size of elements that support it.
@@ -40,12 +38,7 @@ public class GetName extends SafeRequestHandler {
     protected AppiumResponse safeHandle(IHttpRequest request) throws UiObjectNotFoundException {
         String id = getElementId(request);
         Session session = AppiumUIA2Driver.getInstance().getSessionOrThrow();
-        AndroidElement element = session.getKnownElements().getElementFromCache(id);
-        if (element == null) {
-            throw new ElementNotFoundException();
-        }
-        String elementName = element.getContentDesc();
-        Logger.info("Element Name ", elementName);
-        return new AppiumResponse(getSessionId(request), elementName);
+        AndroidElement element = session.getElementsCache().getElementFromCache(id);
+        return new AppiumResponse(getSessionId(request), element.getContentDesc());
     }
 }

--- a/app/src/main/java/io/appium/uiautomator2/handler/GetRect.java
+++ b/app/src/main/java/io/appium/uiautomator2/handler/GetRect.java
@@ -37,7 +37,7 @@ public class GetRect extends SafeRequestHandler {
     protected AppiumResponse safeHandle(IHttpRequest request) {
         String id = getElementId(request);
         Session session = AppiumUIA2Driver.getInstance().getSessionOrThrow();
-        AndroidElement element = session.getElementsCache().getElementFromCache(id);
+        AndroidElement element = session.getElementsCache().get(id);
         return new AppiumResponse(getSessionId(request), new ElementRectModel(element.getBounds()));
     }
 }

--- a/app/src/main/java/io/appium/uiautomator2/handler/GetRect.java
+++ b/app/src/main/java/io/appium/uiautomator2/handler/GetRect.java
@@ -16,9 +16,6 @@
 
 package io.appium.uiautomator2.handler;
 
-import androidx.test.uiautomator.UiObjectNotFoundException;
-
-import io.appium.uiautomator2.common.exceptions.ElementNotFoundException;
 import io.appium.uiautomator2.handler.request.SafeRequestHandler;
 import io.appium.uiautomator2.http.AppiumResponse;
 import io.appium.uiautomator2.http.IHttpRequest;
@@ -37,13 +34,10 @@ public class GetRect extends SafeRequestHandler {
     }
 
     @Override
-    protected AppiumResponse safeHandle(IHttpRequest request) throws UiObjectNotFoundException {
+    protected AppiumResponse safeHandle(IHttpRequest request) {
         String id = getElementId(request);
         Session session = AppiumUIA2Driver.getInstance().getSessionOrThrow();
-        AndroidElement element = session.getKnownElements().getElementFromCache(id);
-        if (element == null) {
-            throw new ElementNotFoundException();
-        }
+        AndroidElement element = session.getElementsCache().getElementFromCache(id);
         return new AppiumResponse(getSessionId(request), new ElementRectModel(element.getBounds()));
     }
 }

--- a/app/src/main/java/io/appium/uiautomator2/handler/GetSize.java
+++ b/app/src/main/java/io/appium/uiautomator2/handler/GetSize.java
@@ -39,7 +39,7 @@ public class GetSize extends SafeRequestHandler {
     protected AppiumResponse safeHandle(IHttpRequest request) {
         String id = getElementId(request);
         Session session = AppiumUIA2Driver.getInstance().getSessionOrThrow();
-        AndroidElement element = session.getElementsCache().getElementFromCache(id);
+        AndroidElement element = session.getElementsCache().get(id);
         final Rect rect = element.getBounds();
         return new AppiumResponse(getSessionId(request), new SizeModel(
                 rect.width(),

--- a/app/src/main/java/io/appium/uiautomator2/handler/GetSize.java
+++ b/app/src/main/java/io/appium/uiautomator2/handler/GetSize.java
@@ -18,9 +18,6 @@ package io.appium.uiautomator2.handler;
 
 import android.graphics.Rect;
 
-import androidx.test.uiautomator.UiObjectNotFoundException;
-
-import io.appium.uiautomator2.common.exceptions.ElementNotFoundException;
 import io.appium.uiautomator2.handler.request.SafeRequestHandler;
 import io.appium.uiautomator2.http.AppiumResponse;
 import io.appium.uiautomator2.http.IHttpRequest;
@@ -39,13 +36,10 @@ public class GetSize extends SafeRequestHandler {
     }
 
     @Override
-    protected AppiumResponse safeHandle(IHttpRequest request) throws UiObjectNotFoundException {
+    protected AppiumResponse safeHandle(IHttpRequest request) {
         String id = getElementId(request);
         Session session = AppiumUIA2Driver.getInstance().getSessionOrThrow();
-        AndroidElement element = session.getKnownElements().getElementFromCache(id);
-        if (element == null) {
-            throw new ElementNotFoundException();
-        }
+        AndroidElement element = session.getElementsCache().getElementFromCache(id);
         final Rect rect = element.getBounds();
         return new AppiumResponse(getSessionId(request), new SizeModel(
                 rect.width(),

--- a/app/src/main/java/io/appium/uiautomator2/handler/GetText.java
+++ b/app/src/main/java/io/appium/uiautomator2/handler/GetText.java
@@ -17,7 +17,7 @@ public class GetText extends SafeRequestHandler {
     protected AppiumResponse safeHandle(IHttpRequest request) {
         String id = getElementId(request);
         Session session = AppiumUIA2Driver.getInstance().getSessionOrThrow();
-        AndroidElement element = session.getElementsCache().getElementFromCache(id);
+        AndroidElement element = session.getElementsCache().get(id);
         return new AppiumResponse(getSessionId(request), element.getText());
     }
 

--- a/app/src/main/java/io/appium/uiautomator2/handler/GetText.java
+++ b/app/src/main/java/io/appium/uiautomator2/handler/GetText.java
@@ -1,15 +1,11 @@
 package io.appium.uiautomator2.handler;
 
-import androidx.test.uiautomator.UiObjectNotFoundException;
-
-import io.appium.uiautomator2.common.exceptions.ElementNotFoundException;
 import io.appium.uiautomator2.handler.request.SafeRequestHandler;
 import io.appium.uiautomator2.http.AppiumResponse;
 import io.appium.uiautomator2.http.IHttpRequest;
 import io.appium.uiautomator2.model.AndroidElement;
 import io.appium.uiautomator2.model.AppiumUIA2Driver;
 import io.appium.uiautomator2.model.Session;
-import io.appium.uiautomator2.utils.Logger;
 
 public class GetText extends SafeRequestHandler {
 
@@ -18,16 +14,11 @@ public class GetText extends SafeRequestHandler {
     }
 
     @Override
-    protected AppiumResponse safeHandle(IHttpRequest request) throws UiObjectNotFoundException {
+    protected AppiumResponse safeHandle(IHttpRequest request) {
         String id = getElementId(request);
         Session session = AppiumUIA2Driver.getInstance().getSessionOrThrow();
-        AndroidElement element = session.getKnownElements().getElementFromCache(id);
-        if (element == null) {
-            throw new ElementNotFoundException();
-        }
-        String text = element.getText();
-        Logger.info("Get Text :" + text);
-        return new AppiumResponse(getSessionId(request), text);
+        AndroidElement element = session.getElementsCache().getElementFromCache(id);
+        return new AppiumResponse(getSessionId(request), element.getText());
     }
 
 }

--- a/app/src/main/java/io/appium/uiautomator2/handler/Location.java
+++ b/app/src/main/java/io/appium/uiautomator2/handler/Location.java
@@ -20,7 +20,7 @@ public class Location extends SafeRequestHandler {
     protected AppiumResponse safeHandle(IHttpRequest request) {
         Session session = AppiumUIA2Driver.getInstance().getSessionOrThrow();
         String id = getElementId(request);
-        AndroidElement element = session.getElementsCache().getElementFromCache(id);
+        AndroidElement element = session.getElementsCache().get(id);
         final Rect bounds = element.getBounds();
         Logger.info("Element found at location " + "(" + bounds.left + "," + bounds.top + ")");
         return new AppiumResponse(getSessionId(request), new LocationModel(bounds.left, bounds.top));

--- a/app/src/main/java/io/appium/uiautomator2/handler/Location.java
+++ b/app/src/main/java/io/appium/uiautomator2/handler/Location.java
@@ -2,9 +2,6 @@ package io.appium.uiautomator2.handler;
 
 import android.graphics.Rect;
 
-import androidx.test.uiautomator.UiObjectNotFoundException;
-
-import io.appium.uiautomator2.common.exceptions.ElementNotFoundException;
 import io.appium.uiautomator2.handler.request.SafeRequestHandler;
 import io.appium.uiautomator2.http.AppiumResponse;
 import io.appium.uiautomator2.http.IHttpRequest;
@@ -20,13 +17,10 @@ public class Location extends SafeRequestHandler {
     }
 
     @Override
-    protected AppiumResponse safeHandle(IHttpRequest request) throws UiObjectNotFoundException {
+    protected AppiumResponse safeHandle(IHttpRequest request) {
         Session session = AppiumUIA2Driver.getInstance().getSessionOrThrow();
         String id = getElementId(request);
-        AndroidElement element = session.getKnownElements().getElementFromCache(id);
-        if (element == null) {
-            throw new ElementNotFoundException();
-        }
+        AndroidElement element = session.getElementsCache().getElementFromCache(id);
         final Rect bounds = element.getBounds();
         Logger.info("Element found at location " + "(" + bounds.left + "," + bounds.top + ")");
         return new AppiumResponse(getSessionId(request), new LocationModel(bounds.left, bounds.top));

--- a/app/src/main/java/io/appium/uiautomator2/handler/ScrollTo.java
+++ b/app/src/main/java/io/appium/uiautomator2/handler/ScrollTo.java
@@ -32,7 +32,7 @@ import io.appium.uiautomator2.http.IHttpRequest;
 import io.appium.uiautomator2.model.AndroidElement;
 import io.appium.uiautomator2.model.AppiumUIA2Driver;
 import io.appium.uiautomator2.model.By;
-import io.appium.uiautomator2.model.KnownElements;
+import io.appium.uiautomator2.model.ElementsCache;
 import io.appium.uiautomator2.model.api.ScrollToModel;
 import io.appium.uiautomator2.model.internal.ElementsLookupStrategy;
 import io.appium.uiautomator2.utils.Logger;
@@ -73,11 +73,8 @@ public class ScrollTo extends SafeRequestHandler {
 
         UiScrollable origin = null;
         if (model.origin != null) {
-            KnownElements ke = AppiumUIA2Driver.getInstance().getSessionOrThrow().getKnownElements();
+            ElementsCache ke = AppiumUIA2Driver.getInstance().getSessionOrThrow().getElementsCache();
             AndroidElement element = ke.getElementFromCache(model.origin.getUnifiedId());
-            if (element == null) {
-                throw new ElementNotFoundException();
-            }
             if (!(element.getUiObject() instanceof UiObject)) {
                 throw new IllegalArgumentException("The given origin element must be a valid scrollable UiObject");
             }

--- a/app/src/main/java/io/appium/uiautomator2/handler/ScrollTo.java
+++ b/app/src/main/java/io/appium/uiautomator2/handler/ScrollTo.java
@@ -24,7 +24,6 @@ import androidx.test.uiautomator.UiSelector;
 import java.util.Arrays;
 import java.util.List;
 
-import io.appium.uiautomator2.common.exceptions.ElementNotFoundException;
 import io.appium.uiautomator2.common.exceptions.InvalidArgumentException;
 import io.appium.uiautomator2.handler.request.SafeRequestHandler;
 import io.appium.uiautomator2.http.AppiumResponse;
@@ -74,7 +73,7 @@ public class ScrollTo extends SafeRequestHandler {
         UiScrollable origin = null;
         if (model.origin != null) {
             ElementsCache ke = AppiumUIA2Driver.getInstance().getSessionOrThrow().getElementsCache();
-            AndroidElement element = ke.getElementFromCache(model.origin.getUnifiedId());
+            AndroidElement element = ke.get(model.origin.getUnifiedId());
             if (!(element.getUiObject() instanceof UiObject)) {
                 throw new IllegalArgumentException("The given origin element must be a valid scrollable UiObject");
             }

--- a/app/src/main/java/io/appium/uiautomator2/handler/ScrollToElement.java
+++ b/app/src/main/java/io/appium/uiautomator2/handler/ScrollToElement.java
@@ -40,8 +40,8 @@ public class ScrollToElement extends SafeRequestHandler {
     protected AppiumResponse safeHandle(IHttpRequest request) throws UiObjectNotFoundException {
         String[] elementIds = getElementIds(request);
         ElementsCache ke = AppiumUIA2Driver.getInstance().getSessionOrThrow().getElementsCache();
-        AndroidElement element = ke.getElementFromCache(elementIds[0]);
-        AndroidElement scrollToElement = ke.getElementFromCache(elementIds[1]);
+        AndroidElement element = ke.get(elementIds[0]);
+        AndroidElement scrollToElement = ke.get(elementIds[1]);
 
         // attempt to get UiObjects from the container and scroll to element
         // if we can't, we have to error out, since scrollIntoView only works with UiObjects

--- a/app/src/main/java/io/appium/uiautomator2/handler/ScrollToElement.java
+++ b/app/src/main/java/io/appium/uiautomator2/handler/ScrollToElement.java
@@ -20,14 +20,13 @@ import androidx.test.uiautomator.UiObject;
 import androidx.test.uiautomator.UiObjectNotFoundException;
 import androidx.test.uiautomator.UiSelector;
 
-import io.appium.uiautomator2.common.exceptions.ElementNotFoundException;
 import io.appium.uiautomator2.common.exceptions.InvalidArgumentException;
 import io.appium.uiautomator2.handler.request.SafeRequestHandler;
 import io.appium.uiautomator2.http.AppiumResponse;
 import io.appium.uiautomator2.http.IHttpRequest;
 import io.appium.uiautomator2.model.AndroidElement;
 import io.appium.uiautomator2.model.AppiumUIA2Driver;
-import io.appium.uiautomator2.model.KnownElements;
+import io.appium.uiautomator2.model.ElementsCache;
 
 import static java.util.Objects.requireNonNull;
 
@@ -40,15 +39,9 @@ public class ScrollToElement extends SafeRequestHandler {
     @Override
     protected AppiumResponse safeHandle(IHttpRequest request) throws UiObjectNotFoundException {
         String[] elementIds = getElementIds(request);
-        KnownElements ke = AppiumUIA2Driver.getInstance().getSessionOrThrow().getKnownElements();
+        ElementsCache ke = AppiumUIA2Driver.getInstance().getSessionOrThrow().getElementsCache();
         AndroidElement element = ke.getElementFromCache(elementIds[0]);
-        if (element == null) {
-            throw new ElementNotFoundException();
-        }
         AndroidElement scrollToElement = ke.getElementFromCache(elementIds[1]);
-        if (scrollToElement == null) {
-            throw new ElementNotFoundException();
-        }
 
         // attempt to get UiObjects from the container and scroll to element
         // if we can't, we have to error out, since scrollIntoView only works with UiObjects

--- a/app/src/main/java/io/appium/uiautomator2/handler/SendKeysToElement.java
+++ b/app/src/main/java/io/appium/uiautomator2/handler/SendKeysToElement.java
@@ -18,7 +18,6 @@ package io.appium.uiautomator2.handler;
 
 import androidx.test.uiautomator.UiObjectNotFoundException;
 
-import io.appium.uiautomator2.common.exceptions.ElementNotFoundException;
 import io.appium.uiautomator2.common.exceptions.InvalidElementStateException;
 import io.appium.uiautomator2.handler.request.SafeRequestHandler;
 import io.appium.uiautomator2.http.AppiumResponse;
@@ -102,10 +101,7 @@ public class SendKeysToElement extends SafeRequestHandler {
         AndroidElement element;
         if (elementId != null) {
             Session session = AppiumUIA2Driver.getInstance().getSessionOrThrow();
-            element = session.getKnownElements().getElementFromCache(elementId);
-            if (element == null) {
-                throw new ElementNotFoundException();
-            }
+            element = session.getElementsCache().getElementFromCache(elementId);
         } else {
             //perform action on focused element
             element = findElement(focused(true));

--- a/app/src/main/java/io/appium/uiautomator2/handler/SendKeysToElement.java
+++ b/app/src/main/java/io/appium/uiautomator2/handler/SendKeysToElement.java
@@ -101,7 +101,7 @@ public class SendKeysToElement extends SafeRequestHandler {
         AndroidElement element;
         if (elementId != null) {
             Session session = AppiumUIA2Driver.getInstance().getSessionOrThrow();
-            element = session.getElementsCache().getElementFromCache(elementId);
+            element = session.getElementsCache().get(elementId);
         } else {
             //perform action on focused element
             element = findElement(focused(true));

--- a/app/src/main/java/io/appium/uiautomator2/handler/Swipe.java
+++ b/app/src/main/java/io/appium/uiautomator2/handler/Swipe.java
@@ -18,7 +18,6 @@ package io.appium.uiautomator2.handler;
 
 import androidx.test.uiautomator.UiObjectNotFoundException;
 
-import io.appium.uiautomator2.common.exceptions.ElementNotFoundException;
 import io.appium.uiautomator2.common.exceptions.InvalidElementStateException;
 import io.appium.uiautomator2.core.EventRegister;
 import io.appium.uiautomator2.core.ReturningRunnable;
@@ -62,10 +61,7 @@ public class Swipe extends SafeRequestHandler {
         Point absEndPos;
         if (model.elementId != null) {
             Session session = AppiumUIA2Driver.getInstance().getSessionOrThrow();
-            AndroidElement element = session.getKnownElements().getElementFromCache(model.elementId);
-            if (element == null) {
-                throw new ElementNotFoundException();
-            }
+            AndroidElement element = session.getElementsCache().getElementFromCache(model.elementId);
             absStartPos = element.getAbsolutePosition(new Point(model.startX, model.startY));
             absEndPos = element.getAbsolutePosition(new Point(model.endX, model.endY));
             Logger.debug(String.format("Swiping the element %s from %s to %s in %s steps",

--- a/app/src/main/java/io/appium/uiautomator2/handler/Swipe.java
+++ b/app/src/main/java/io/appium/uiautomator2/handler/Swipe.java
@@ -61,7 +61,7 @@ public class Swipe extends SafeRequestHandler {
         Point absEndPos;
         if (model.elementId != null) {
             Session session = AppiumUIA2Driver.getInstance().getSessionOrThrow();
-            AndroidElement element = session.getElementsCache().getElementFromCache(model.elementId);
+            AndroidElement element = session.getElementsCache().get(model.elementId);
             absStartPos = element.getAbsolutePosition(new Point(model.startX, model.startY));
             absEndPos = element.getAbsolutePosition(new Point(model.endX, model.endY));
             Logger.debug(String.format("Swiping the element %s from %s to %s in %s steps",

--- a/app/src/main/java/io/appium/uiautomator2/handler/Tap.java
+++ b/app/src/main/java/io/appium/uiautomator2/handler/Tap.java
@@ -20,7 +20,6 @@ import android.graphics.Rect;
 
 import androidx.test.uiautomator.UiObjectNotFoundException;
 
-import io.appium.uiautomator2.common.exceptions.ElementNotFoundException;
 import io.appium.uiautomator2.common.exceptions.InvalidElementStateException;
 import io.appium.uiautomator2.handler.request.SafeRequestHandler;
 import io.appium.uiautomator2.http.AppiumResponse;
@@ -54,11 +53,7 @@ public class Tap extends SafeRequestHandler {
             tapLocation = PositionHelper.getDeviceAbsPos(new Point(model.x, model.y));
         } else {
             Session session = AppiumUIA2Driver.getInstance().getSessionOrThrow();
-            AndroidElement element = session.getKnownElements()
-                    .getElementFromCache(model.getUnifiedId());
-            if (element == null) {
-                throw new ElementNotFoundException();
-            }
+            AndroidElement element = session.getElementsCache().getElementFromCache(model.getUnifiedId());
             Rect bounds = element.getBounds();
             Point offset = (model.x != null && model.y != null)
                 ? new Point(model.x, model.y)

--- a/app/src/main/java/io/appium/uiautomator2/handler/Tap.java
+++ b/app/src/main/java/io/appium/uiautomator2/handler/Tap.java
@@ -53,7 +53,7 @@ public class Tap extends SafeRequestHandler {
             tapLocation = PositionHelper.getDeviceAbsPos(new Point(model.x, model.y));
         } else {
             Session session = AppiumUIA2Driver.getInstance().getSessionOrThrow();
-            AndroidElement element = session.getElementsCache().getElementFromCache(model.getUnifiedId());
+            AndroidElement element = session.getElementsCache().get(model.getUnifiedId());
             Rect bounds = element.getBounds();
             Point offset = (model.x != null && model.y != null)
                 ? new Point(model.x, model.y)

--- a/app/src/main/java/io/appium/uiautomator2/handler/gestures/Drag.java
+++ b/app/src/main/java/io/appium/uiautomator2/handler/gestures/Drag.java
@@ -49,7 +49,7 @@ public class Drag extends SafeRequestHandler {
                     dragModel.start.toNativePoint(), dragModel.end.toNativePoint(), dragModel.speed);
         } else {
             Session session = AppiumUIA2Driver.getInstance().getSessionOrThrow();
-            AndroidElement element = session.getElementsCache().getElementFromCache(elementId);
+            AndroidElement element = session.getElementsCache().get(elementId);
             if (dragModel.start == null) {
                 element.drag(dragModel.end.toPoint(), dragModel.speed);
             } else {

--- a/app/src/main/java/io/appium/uiautomator2/handler/gestures/Drag.java
+++ b/app/src/main/java/io/appium/uiautomator2/handler/gestures/Drag.java
@@ -19,7 +19,6 @@ package io.appium.uiautomator2.handler.gestures;
 import android.graphics.Point;
 import android.graphics.Rect;
 
-import io.appium.uiautomator2.common.exceptions.ElementNotFoundException;
 import io.appium.uiautomator2.handler.request.SafeRequestHandler;
 import io.appium.uiautomator2.http.AppiumResponse;
 import io.appium.uiautomator2.http.IHttpRequest;
@@ -50,10 +49,7 @@ public class Drag extends SafeRequestHandler {
                     dragModel.start.toNativePoint(), dragModel.end.toNativePoint(), dragModel.speed);
         } else {
             Session session = AppiumUIA2Driver.getInstance().getSessionOrThrow();
-            AndroidElement element = session.getKnownElements().getElementFromCache(elementId);
-            if (element == null) {
-                throw new ElementNotFoundException();
-            }
+            AndroidElement element = session.getElementsCache().getElementFromCache(elementId);
             if (dragModel.start == null) {
                 element.drag(dragModel.end.toPoint(), dragModel.speed);
             } else {

--- a/app/src/main/java/io/appium/uiautomator2/handler/gestures/Fling.java
+++ b/app/src/main/java/io/appium/uiautomator2/handler/gestures/Fling.java
@@ -16,7 +16,6 @@
 
 package io.appium.uiautomator2.handler.gestures;
 
-import io.appium.uiautomator2.common.exceptions.ElementNotFoundException;
 import io.appium.uiautomator2.handler.request.SafeRequestHandler;
 import io.appium.uiautomator2.http.AppiumResponse;
 import io.appium.uiautomator2.http.IHttpRequest;
@@ -48,10 +47,7 @@ public class Fling extends SafeRequestHandler {
                     .fling(flingModel.area.toNativeRect(), flingModel.getDirection(), flingModel.speed);
         } else {
             Session session = AppiumUIA2Driver.getInstance().getSessionOrThrow();
-            AndroidElement element = session.getKnownElements().getElementFromCache(elementId);
-            if (element == null) {
-                throw new ElementNotFoundException();
-            }
+            AndroidElement element = session.getElementsCache().getElementFromCache(elementId);
             result = element.fling(flingModel.getDirection(), flingModel.speed);
         }
 

--- a/app/src/main/java/io/appium/uiautomator2/handler/gestures/Fling.java
+++ b/app/src/main/java/io/appium/uiautomator2/handler/gestures/Fling.java
@@ -47,7 +47,7 @@ public class Fling extends SafeRequestHandler {
                     .fling(flingModel.area.toNativeRect(), flingModel.getDirection(), flingModel.speed);
         } else {
             Session session = AppiumUIA2Driver.getInstance().getSessionOrThrow();
-            AndroidElement element = session.getElementsCache().getElementFromCache(elementId);
+            AndroidElement element = session.getElementsCache().get(elementId);
             result = element.fling(flingModel.getDirection(), flingModel.speed);
         }
 

--- a/app/src/main/java/io/appium/uiautomator2/handler/gestures/LongClick.java
+++ b/app/src/main/java/io/appium/uiautomator2/handler/gestures/LongClick.java
@@ -19,7 +19,6 @@ package io.appium.uiautomator2.handler.gestures;
 import android.graphics.Point;
 import android.graphics.Rect;
 
-import io.appium.uiautomator2.common.exceptions.ElementNotFoundException;
 import io.appium.uiautomator2.handler.request.SafeRequestHandler;
 import io.appium.uiautomator2.http.AppiumResponse;
 import io.appium.uiautomator2.http.IHttpRequest;
@@ -52,10 +51,7 @@ public class LongClick extends SafeRequestHandler {
             );
         } else {
             Session session = AppiumUIA2Driver.getInstance().getSessionOrThrow();
-            AndroidElement element = session.getKnownElements().getElementFromCache(elementId);
-            if (element == null) {
-                throw new ElementNotFoundException();
-            }
+            AndroidElement element = session.getElementsCache().getElementFromCache(elementId);
             if (longClickModel.offset == null) {
                 if (longClickModel.duration == null) {
                     element.longClick();

--- a/app/src/main/java/io/appium/uiautomator2/handler/gestures/LongClick.java
+++ b/app/src/main/java/io/appium/uiautomator2/handler/gestures/LongClick.java
@@ -51,7 +51,7 @@ public class LongClick extends SafeRequestHandler {
             );
         } else {
             Session session = AppiumUIA2Driver.getInstance().getSessionOrThrow();
-            AndroidElement element = session.getElementsCache().getElementFromCache(elementId);
+            AndroidElement element = session.getElementsCache().get(elementId);
             if (longClickModel.offset == null) {
                 if (longClickModel.duration == null) {
                     element.longClick();

--- a/app/src/main/java/io/appium/uiautomator2/handler/gestures/PinchClose.java
+++ b/app/src/main/java/io/appium/uiautomator2/handler/gestures/PinchClose.java
@@ -46,7 +46,7 @@ public class PinchClose extends SafeRequestHandler {
                     .pinchClose(pinchModel.area.toNativeRect(), pinchModel.percent, pinchModel.speed);
         } else {
             Session session = AppiumUIA2Driver.getInstance().getSessionOrThrow();
-            AndroidElement element = session.getElementsCache().getElementFromCache(elementId);
+            AndroidElement element = session.getElementsCache().get(elementId);
             element.pinchClose(pinchModel.percent, pinchModel.speed);
         }
 

--- a/app/src/main/java/io/appium/uiautomator2/handler/gestures/PinchClose.java
+++ b/app/src/main/java/io/appium/uiautomator2/handler/gestures/PinchClose.java
@@ -16,7 +16,6 @@
 
 package io.appium.uiautomator2.handler.gestures;
 
-import io.appium.uiautomator2.common.exceptions.ElementNotFoundException;
 import io.appium.uiautomator2.handler.request.SafeRequestHandler;
 import io.appium.uiautomator2.http.AppiumResponse;
 import io.appium.uiautomator2.http.IHttpRequest;
@@ -47,10 +46,7 @@ public class PinchClose extends SafeRequestHandler {
                     .pinchClose(pinchModel.area.toNativeRect(), pinchModel.percent, pinchModel.speed);
         } else {
             Session session = AppiumUIA2Driver.getInstance().getSessionOrThrow();
-            AndroidElement element = session.getKnownElements().getElementFromCache(elementId);
-            if (element == null) {
-                throw new ElementNotFoundException();
-            }
+            AndroidElement element = session.getElementsCache().getElementFromCache(elementId);
             element.pinchClose(pinchModel.percent, pinchModel.speed);
         }
 

--- a/app/src/main/java/io/appium/uiautomator2/handler/gestures/PinchOpen.java
+++ b/app/src/main/java/io/appium/uiautomator2/handler/gestures/PinchOpen.java
@@ -46,7 +46,7 @@ public class PinchOpen extends SafeRequestHandler {
                     .pinchOpen(pinchModel.area.toNativeRect(), pinchModel.percent, pinchModel.speed);
         } else {
             Session session = AppiumUIA2Driver.getInstance().getSessionOrThrow();
-            AndroidElement element = session.getElementsCache().getElementFromCache(elementId);
+            AndroidElement element = session.getElementsCache().get(elementId);
             element.pinchOpen(pinchModel.percent, pinchModel.speed);
         }
 

--- a/app/src/main/java/io/appium/uiautomator2/handler/gestures/PinchOpen.java
+++ b/app/src/main/java/io/appium/uiautomator2/handler/gestures/PinchOpen.java
@@ -16,7 +16,6 @@
 
 package io.appium.uiautomator2.handler.gestures;
 
-import io.appium.uiautomator2.common.exceptions.ElementNotFoundException;
 import io.appium.uiautomator2.handler.request.SafeRequestHandler;
 import io.appium.uiautomator2.http.AppiumResponse;
 import io.appium.uiautomator2.http.IHttpRequest;
@@ -47,10 +46,7 @@ public class PinchOpen extends SafeRequestHandler {
                     .pinchOpen(pinchModel.area.toNativeRect(), pinchModel.percent, pinchModel.speed);
         } else {
             Session session = AppiumUIA2Driver.getInstance().getSessionOrThrow();
-            AndroidElement element = session.getKnownElements().getElementFromCache(elementId);
-            if (element == null) {
-                throw new ElementNotFoundException();
-            }
+            AndroidElement element = session.getElementsCache().getElementFromCache(elementId);
             element.pinchOpen(pinchModel.percent, pinchModel.speed);
         }
 

--- a/app/src/main/java/io/appium/uiautomator2/handler/gestures/Scroll.java
+++ b/app/src/main/java/io/appium/uiautomator2/handler/gestures/Scroll.java
@@ -16,7 +16,6 @@
 
 package io.appium.uiautomator2.handler.gestures;
 
-import io.appium.uiautomator2.common.exceptions.ElementNotFoundException;
 import io.appium.uiautomator2.handler.request.SafeRequestHandler;
 import io.appium.uiautomator2.http.AppiumResponse;
 import io.appium.uiautomator2.http.IHttpRequest;
@@ -48,10 +47,7 @@ public class Scroll extends SafeRequestHandler {
                     .scroll(scrollModel.area.toNativeRect(), scrollModel.getDirection(), scrollModel.percent, scrollModel.speed);
         } else {
             Session session = AppiumUIA2Driver.getInstance().getSessionOrThrow();
-            AndroidElement element = session.getKnownElements().getElementFromCache(elementId);
-            if (element == null) {
-                throw new ElementNotFoundException();
-            }
+            AndroidElement element = session.getElementsCache().getElementFromCache(elementId);
             result = element.scroll(scrollModel.getDirection(), scrollModel.percent, scrollModel.speed);
         }
 

--- a/app/src/main/java/io/appium/uiautomator2/handler/gestures/Scroll.java
+++ b/app/src/main/java/io/appium/uiautomator2/handler/gestures/Scroll.java
@@ -47,7 +47,7 @@ public class Scroll extends SafeRequestHandler {
                     .scroll(scrollModel.area.toNativeRect(), scrollModel.getDirection(), scrollModel.percent, scrollModel.speed);
         } else {
             Session session = AppiumUIA2Driver.getInstance().getSessionOrThrow();
-            AndroidElement element = session.getElementsCache().getElementFromCache(elementId);
+            AndroidElement element = session.getElementsCache().get(elementId);
             result = element.scroll(scrollModel.getDirection(), scrollModel.percent, scrollModel.speed);
         }
 

--- a/app/src/main/java/io/appium/uiautomator2/handler/gestures/Swipe.java
+++ b/app/src/main/java/io/appium/uiautomator2/handler/gestures/Swipe.java
@@ -46,7 +46,7 @@ public class Swipe extends SafeRequestHandler {
                     .swipe(swipeModel.area.toNativeRect(), swipeModel.getDirection(), swipeModel.percent, swipeModel.speed);
         } else {
             Session session = AppiumUIA2Driver.getInstance().getSessionOrThrow();
-            AndroidElement element = session.getElementsCache().getElementFromCache(elementId);
+            AndroidElement element = session.getElementsCache().get(elementId);
             element.swipe(swipeModel.getDirection(), swipeModel.percent, swipeModel.speed);
         }
 

--- a/app/src/main/java/io/appium/uiautomator2/handler/gestures/Swipe.java
+++ b/app/src/main/java/io/appium/uiautomator2/handler/gestures/Swipe.java
@@ -16,7 +16,6 @@
 
 package io.appium.uiautomator2.handler.gestures;
 
-import io.appium.uiautomator2.common.exceptions.ElementNotFoundException;
 import io.appium.uiautomator2.handler.request.SafeRequestHandler;
 import io.appium.uiautomator2.http.AppiumResponse;
 import io.appium.uiautomator2.http.IHttpRequest;
@@ -47,10 +46,7 @@ public class Swipe extends SafeRequestHandler {
                     .swipe(swipeModel.area.toNativeRect(), swipeModel.getDirection(), swipeModel.percent, swipeModel.speed);
         } else {
             Session session = AppiumUIA2Driver.getInstance().getSessionOrThrow();
-            AndroidElement element = session.getKnownElements().getElementFromCache(elementId);
-            if (element == null) {
-                throw new ElementNotFoundException();
-            }
+            AndroidElement element = session.getElementsCache().getElementFromCache(elementId);
             element.swipe(swipeModel.getDirection(), swipeModel.percent, swipeModel.speed);
         }
 

--- a/app/src/main/java/io/appium/uiautomator2/model/ElementsCache.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/ElementsCache.java
@@ -185,11 +185,13 @@ public class ElementsCache {
             }
 
             if (cache.size() >= maxSize) {
-                // Delete the chunk of older cache entries to maintain the overall size of the cache
+                int maxIndex = cache.size() * LOAD_FACTOR / 100;
+                Logger.info(String.format("The elements cache size reached its maximum value of %s. " +
+                        "Shrinking %s oldest elements from it", maxSize, maxIndex));
                 int index = 0;
                 Set<String> keysToRemove = new HashSet<>();
                 for (String key : cache.keySet()) {
-                    if (index > cache.size() * LOAD_FACTOR / 100) {
+                    if (index > maxIndex) {
                         break;
                     }
                     keysToRemove.add(key);

--- a/app/src/main/java/io/appium/uiautomator2/model/ElementsCache.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/ElementsCache.java
@@ -71,7 +71,7 @@ public class ElementsCache {
         }
     }
 
-    private void restoreCachedElement(AndroidElement element) {
+    private void restore(AndroidElement element) {
         final By by = element.getBy();
         if (by == null) {
             throw new StaleElementReferenceException(String.format(
@@ -87,7 +87,7 @@ public class ElementsCache {
         Logger.debug(String.format("Trying to restore the cached element '%s'", by));
         final AndroidElement searchRoot = element.getContextId() == null
                 ? null
-                : getElementFromCache(element.getContextId());
+                : get(element.getContextId());
         Object ui2Object = null;
         try {
             if (by instanceof By.ById) {
@@ -134,7 +134,7 @@ public class ElementsCache {
     }
 
     @NonNull
-    public AndroidElement getElementFromCache(@Nullable String id) {
+    public AndroidElement get(@Nullable String id) {
         if (id == null) {
             throw new IllegalArgumentException(
                     String.format("A valid element identifier must be provided. Got '%s' instead", id));
@@ -149,7 +149,7 @@ public class ElementsCache {
             try {
                 result.getName();
             } catch (Exception e) {
-                restoreCachedElement(result);
+                restore(result);
             }
         }
         result = cache.get(id);

--- a/app/src/main/java/io/appium/uiautomator2/model/ElementsCache.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/ElementsCache.java
@@ -129,6 +129,7 @@ public class ElementsCache {
         }
         AndroidElement restoredElement = toAndroidElement(ui2Object,
                 element.isSingleMatch(), element.getBy(), element.getContextId());
+        cache.remove(element.getId());
         assignAndroidElementId(restoredElement, element.getId());
         cache.put(restoredElement.getId(), restoredElement);
     }

--- a/app/src/main/java/io/appium/uiautomator2/model/ElementsCache.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/ElementsCache.java
@@ -24,6 +24,7 @@ import androidx.test.uiautomator.UiSelector;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Objects;
 import java.util.UUID;
 
 import io.appium.uiautomator2.common.exceptions.ElementNotFoundException;
@@ -171,6 +172,13 @@ public class ElementsCache {
     }
 
     public AndroidElement add(Object element, boolean isSingleMatch, @Nullable By by, @Nullable String contextId) {
+        AndroidElement androidElement = toAndroidElement(element, isSingleMatch, by, contextId);
+        for (Map.Entry<String, AndroidElement> entry : cache.entrySet()) {
+            if (Objects.equals(androidElement, entry.getValue())) {
+                return entry.getValue();
+            }
+        }
+
         if (cache.size() >= maxSize) {
             // Delete the chunk of older cache entries to maintain the overall size of the cache
             int index = 0;
@@ -183,7 +191,6 @@ public class ElementsCache {
             }
         }
 
-        AndroidElement androidElement = toAndroidElement(element, isSingleMatch, by, contextId);
         assignAndroidElementId(androidElement, UUID.randomUUID().toString());
         cache.put(androidElement.getId(), androidElement);
         return androidElement;

--- a/app/src/main/java/io/appium/uiautomator2/model/ElementsCache.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/ElementsCache.java
@@ -127,9 +127,9 @@ public class ElementsCache {
             throw new StaleElementReferenceException(String.format(
                     "The element '%s' does not exist in DOM anymore", by));
         }
+        cache.remove(element.getId());
         AndroidElement restoredElement = toAndroidElement(ui2Object,
                 element.isSingleMatch(), element.getBy(), element.getContextId());
-        cache.remove(element.getId());
         assignAndroidElementId(restoredElement, element.getId());
         cache.put(restoredElement.getId(), restoredElement);
     }

--- a/app/src/main/java/io/appium/uiautomator2/model/ElementsCache.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/ElementsCache.java
@@ -186,7 +186,7 @@ public class ElementsCache {
 
             if (cache.size() >= maxSize) {
                 int maxIndex = cache.size() * LOAD_FACTOR / 100;
-                Logger.info(String.format("The elements cache size reached its maximum value of %s. " +
+                Logger.info(String.format("The elements cache size has reached its maximum value of %s. " +
                         "Shrinking %s oldest elements from it", maxSize, maxIndex));
                 int index = 0;
                 Set<String> keysToRemove = new HashSet<>();

--- a/app/src/main/java/io/appium/uiautomator2/model/Session.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/Session.java
@@ -27,9 +27,11 @@ import static io.appium.uiautomator2.model.settings.Settings.SHOULD_USE_COMPACT_
 
 public class Session {
     public static final String NO_ID = "None";
+    public static final int MAX_CACHE_SIZE = 500;
+
     private final Map<String, Object> capabilities = new HashMap<>();
     private final String sessionId;
-    private final KnownElements knownElements = new KnownElements();
+    private final ElementsCache elementsCache = new ElementsCache(MAX_CACHE_SIZE);
     private AccessibilityScrollData lastScrollData;
 
     Session(String sessionId, Map<String, Object> capabilities) {
@@ -87,7 +89,7 @@ public class Session {
         lastScrollData = scrollData;
     }
 
-    public KnownElements getKnownElements() {
-        return this.knownElements;
+    public ElementsCache getElementsCache() {
+        return this.elementsCache;
     }
 }

--- a/app/src/main/java/io/appium/uiautomator2/model/UiObject2Element.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/UiObject2Element.java
@@ -29,7 +29,6 @@ import androidx.test.uiautomator.UiObjectNotFoundException;
 import androidx.test.uiautomator.UiSelector;
 
 import java.util.List;
-import java.util.UUID;
 
 import io.appium.uiautomator2.core.AxNodeInfoHelper;
 import io.appium.uiautomator2.model.internal.CustomUiDevice;
@@ -39,21 +38,17 @@ import io.appium.uiautomator2.utils.Logger;
 import io.appium.uiautomator2.utils.PositionHelper;
 
 import static io.appium.uiautomator2.core.AxNodeInfoExtractor.toAxNodeInfo;
-import static io.appium.uiautomator2.utils.Device.getAndroidElement;
 import static io.appium.uiautomator2.utils.ElementHelpers.generateNoAttributeException;
 import static io.appium.uiautomator2.utils.StringHelpers.isBlank;
 
 public class UiObject2Element extends BaseElement {
-
     private final UiObject2 element;
-    private final String id;
+    private String id;
     private final By by;
     private final String contextId;
     private final boolean isSingleMatch;
 
-    public UiObject2Element(String id, UiObject2 element, boolean isSingleMatch, By by,
-                            @Nullable String contextId) {
-        this.id = id;
+    public UiObject2Element(UiObject2 element, boolean isSingleMatch, By by, @Nullable String contextId) {
         this.element = element;
         this.by = by;
         this.contextId = contextId;
@@ -266,6 +261,10 @@ public class UiObject2Element extends BaseElement {
         return this.id;
     }
 
+    void setId(String id) {
+        this.id = id;
+    }
+
     @Override
     public Rect getBounds() {
         return AxNodeInfoHelper.getBounds(toAxNodeInfo(element));
@@ -306,8 +305,7 @@ public class UiObject2Element extends BaseElement {
             AccessibilityNodeInfo nodeInfo = toAxNodeInfo(element);
             UiSelector uiSelector = UiSelectorHelper.toUiSelector(nodeInfo);
             UiObject uiObject = (UiObject) CustomUiDevice.getInstance().findObject(uiSelector);
-            String id = UUID.randomUUID().toString();
-            AndroidElement androidElement = getAndroidElement(id, uiObject, true, by, getContextId());
+            UiObjectElement androidElement = new UiObjectElement(uiObject, true, by, getContextId());
             return androidElement.getChildren(selector, by);
         }
         return element.findObjects((BySelector) selector);

--- a/app/src/main/java/io/appium/uiautomator2/model/UiObject2Element.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/UiObject2Element.java
@@ -29,6 +29,7 @@ import androidx.test.uiautomator.UiObjectNotFoundException;
 import androidx.test.uiautomator.UiSelector;
 
 import java.util.List;
+import java.util.Objects;
 
 import io.appium.uiautomator2.core.AxNodeInfoHelper;
 import io.appium.uiautomator2.model.internal.CustomUiDevice;
@@ -351,5 +352,18 @@ public class UiObject2Element extends BaseElement {
         coords = PositionHelper.getDeviceAbsPos(coords);
         element.drag(new android.graphics.Point(coords.x.intValue(), coords.y.intValue()), steps);
         return true;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (!(other instanceof UiObject2Element)) {
+            return false;
+        }
+
+        UiObject2Element otherEl = (UiObject2Element)other;
+        return Objects.equals(this.element, otherEl.element)
+                && Objects.equals(by, otherEl.by)
+                && Objects.equals(contextId, otherEl.contextId)
+                && this.isSingleMatch == otherEl.isSingleMatch;
     }
 }

--- a/app/src/main/java/io/appium/uiautomator2/model/UiObject2Element.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/UiObject2Element.java
@@ -359,6 +359,9 @@ public class UiObject2Element extends BaseElement {
         if (!(other instanceof UiObject2Element)) {
             return false;
         }
+        if (this == other) {
+            return true;
+        }
 
         UiObject2Element otherEl = (UiObject2Element)other;
         return Objects.equals(this.element, otherEl.element)

--- a/app/src/main/java/io/appium/uiautomator2/model/UiObjectElement.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/UiObjectElement.java
@@ -52,14 +52,12 @@ public class UiObjectElement extends BaseElement {
 
     private static final Pattern endsWithInstancePattern = Pattern.compile(".*INSTANCE=\\d+]$");
     private final UiObject element;
-    private final String id;
+    private String id;
     private final By by;
     private final String contextId;
     private final boolean isSingleMatch;
 
-    public UiObjectElement(String id, UiObject element, boolean isSingleMatch, By by,
-                           @Nullable String contextId) {
-        this.id = id;
+    public UiObjectElement(UiObject element, boolean isSingleMatch, By by, @Nullable String contextId) {
         this.element = element;
         this.by = by;
         this.contextId = contextId;
@@ -270,6 +268,10 @@ public class UiObjectElement extends BaseElement {
     @Override
     public String getId() {
         return this.id;
+    }
+
+    void setId(String id) {
+        this.id = id;
     }
 
     @Override

--- a/app/src/main/java/io/appium/uiautomator2/model/UiObjectElement.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/UiObjectElement.java
@@ -31,6 +31,7 @@ import androidx.test.uiautomator.UiSelector;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.regex.Pattern;
 
 import io.appium.uiautomator2.common.exceptions.ElementNotFoundException;
@@ -441,5 +442,18 @@ public class UiObjectElement extends BaseElement {
 
         Logger.error("Destination should be either UiObject or UiObject2");
         return false;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (!(other instanceof UiObjectElement)) {
+            return false;
+        }
+
+        UiObjectElement otherEl = (UiObjectElement)other;
+        return Objects.equals(this.element, otherEl.element)
+                && Objects.equals(by, otherEl.by)
+                && Objects.equals(contextId, otherEl.contextId)
+                && this.isSingleMatch == otherEl.isSingleMatch;
     }
 }

--- a/app/src/main/java/io/appium/uiautomator2/model/UiObjectElement.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/UiObjectElement.java
@@ -449,6 +449,9 @@ public class UiObjectElement extends BaseElement {
         if (!(other instanceof UiObjectElement)) {
             return false;
         }
+        if (this == other) {
+            return true;
+        }
 
         UiObjectElement otherEl = (UiObjectElement)other;
         return Objects.equals(this.element, otherEl.element)

--- a/app/src/main/java/io/appium/uiautomator2/utils/Device.java
+++ b/app/src/main/java/io/appium/uiautomator2/utils/Device.java
@@ -19,46 +19,18 @@ package io.appium.uiautomator2.utils;
 import androidx.annotation.Nullable;
 import androidx.test.platform.app.InstrumentationRegistry;
 import androidx.test.uiautomator.UiDevice;
-import androidx.test.uiautomator.UiObject;
-import androidx.test.uiautomator.UiObject2;
 import androidx.test.uiautomator.UiObjectNotFoundException;
 import androidx.test.uiautomator.UiScrollable;
 import androidx.test.uiautomator.UiSelector;
 
 import java.util.Objects;
 
-import io.appium.uiautomator2.common.exceptions.UiAutomator2Exception;
-import io.appium.uiautomator2.model.AndroidElement;
-import io.appium.uiautomator2.model.By;
-import io.appium.uiautomator2.model.UiObject2Element;
-import io.appium.uiautomator2.model.UiObjectElement;
 import io.appium.uiautomator2.model.settings.Settings;
 import io.appium.uiautomator2.model.settings.WaitForIdleTimeout;
 
 public abstract class Device {
     public static UiDevice getUiDevice() {
         return UiDevice.getInstance(InstrumentationRegistry.getInstrumentation());
-    }
-
-    public static AndroidElement getAndroidElement(String id, Object element, boolean isSingleMatch,
-                                                   @Nullable By by, @Nullable String contextId) {
-        if (element instanceof UiObject2) {
-            return new UiObject2Element(id, (UiObject2) element, isSingleMatch, by, contextId);
-        } else if (element instanceof UiObject) {
-            return new UiObjectElement(id, (UiObject) element, isSingleMatch, by, contextId);
-        } else {
-            throw new UiAutomator2Exception("Unknown Element type: " + element.getClass().getName());
-        }
-    }
-
-    public static AndroidElement getAndroidElement(String id, Object element, boolean isSingleMatch,
-                                                   @Nullable By by) {
-        return getAndroidElement(id, element, isSingleMatch, by, null);
-    }
-
-    public static AndroidElement getAndroidElement(String id, Object element, boolean isSingleMatch)
-            throws UiAutomator2Exception {
-        return getAndroidElement(id, element, isSingleMatch, null, null);
     }
 
     public static void scrollToElement(@Nullable UiScrollable origin, UiSelector selector,

--- a/app/src/main/java/io/appium/uiautomator2/utils/ElementHelpers.java
+++ b/app/src/main/java/io/appium/uiautomator2/utils/ElementHelpers.java
@@ -40,7 +40,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
-import java.util.UUID;
 
 import io.appium.uiautomator2.common.exceptions.ElementNotFoundException;
 import io.appium.uiautomator2.common.exceptions.NoSuchAttributeException;
@@ -58,7 +57,6 @@ import io.appium.uiautomator2.model.UiObject2Element;
 
 import static android.view.accessibility.AccessibilityNodeInfo.AccessibilityAction.ACTION_SET_PROGRESS;
 import static io.appium.uiautomator2.model.internal.CustomUiDevice.getInstance;
-import static io.appium.uiautomator2.utils.Device.getAndroidElement;
 import static io.appium.uiautomator2.utils.Device.getUiDevice;
 import static io.appium.uiautomator2.utils.ReflectionUtils.getField;
 import static io.appium.uiautomator2.utils.ReflectionUtils.getMethod;
@@ -156,12 +154,13 @@ public abstract class ElementHelpers {
         AxNodeInfoHelper.setProgressValue(nodeInfo, value);
     }
 
-    public static AndroidElement findElement(final BySelector ui2BySelector) throws UiAutomator2Exception {
+    public static AndroidElement findElement(final BySelector ui2BySelector) {
         Object ui2Object = getInstance().findObject(ui2BySelector);
         if (ui2Object == null) {
             throw new ElementNotFoundException();
         }
-        return getAndroidElement(UUID.randomUUID().toString(), ui2Object, true);
+        Session session = AppiumUIA2Driver.getInstance().getSessionOrThrow();
+        return session.getElementsCache().add(ui2Object, true);
     }
 
     public static NoSuchAttributeException generateNoAttributeException(@Nullable String attributeName) {
@@ -172,7 +171,6 @@ public abstract class ElementHelpers {
 
     @NonNull
     public static String getText(Object element) {
-        //noinspection ConstantConditions
         return getText(element, true);
     }
 
@@ -363,6 +361,7 @@ public abstract class ElementHelpers {
         return touchPadding / 2;
     }
 
+    @SuppressWarnings("UnusedReturnValue")
     private static boolean swipe(final int startX, final int startY, final int endX, final int endY) {
         Logger.debug(String.format("Swiping from [%s, %s] to [%s, %s]", startX, startY, endX, endY));
         return EventRegister.runAndRegisterScrollEvents(new ReturningRunnable<Boolean>() {

--- a/app/src/main/java/io/appium/uiautomator2/utils/w3c/ActionsTokenizer.java
+++ b/app/src/main/java/io/appium/uiautomator2/utils/w3c/ActionsTokenizer.java
@@ -198,7 +198,7 @@ public class ActionsTokenizer {
         Rect bounds;
         Session session = AppiumUIA2Driver.getInstance().getSessionOrThrow();
         try {
-            final AndroidElement element = session.getElementsCache().getElementFromCache(elementId);
+            final AndroidElement element = session.getElementsCache().get(elementId);
             bounds = element.getBounds();
             if (bounds.width() == 0 || bounds.height() == 0) {
                 throw new ActionsParseException(String.format(

--- a/app/src/main/java/io/appium/uiautomator2/utils/w3c/ActionsTokenizer.java
+++ b/app/src/main/java/io/appium/uiautomator2/utils/w3c/ActionsTokenizer.java
@@ -198,8 +198,7 @@ public class ActionsTokenizer {
         Rect bounds;
         Session session = AppiumUIA2Driver.getInstance().getSessionOrThrow();
         try {
-            final AndroidElement element = session.getKnownElements().getElementFromCache(elementId);
-            //noinspection ConstantConditions
+            final AndroidElement element = session.getElementsCache().getElementFromCache(elementId);
             bounds = element.getBounds();
             if (bounds.width() == 0 || bounds.height() == 0) {
                 throw new ActionsParseException(String.format(


### PR DESCRIPTION
Sometimes I was observing out-of-memory errors while running longer Android tests. This could only because of the elements cache, because we never limit its size in scope of a single session. This PRs reorders the cache access logic and sets the maximum size for it (current 500 elements). The idea is to perform older elements cleanup (in chunks) as soon as cache size reaches the maximum value.