### PR TITLE
chore: Apply capabilities validation on session init

### DIFF
--- a/app/src/main/java/io/appium/uiautomator2/model/Session.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/Session.java
@@ -22,6 +22,9 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
+import io.appium.uiautomator2.model.settings.ISetting;
+import io.appium.uiautomator2.model.settings.Settings;
+
 import static io.appium.uiautomator2.model.settings.Settings.ELEMENT_RESPONSE_ATTRIBUTES;
 import static io.appium.uiautomator2.model.settings.Settings.SHOULD_USE_COMPACT_RESPONSES;
 
@@ -36,7 +39,21 @@ public class Session {
 
     Session(String sessionId, Map<String, Object> capabilities) {
         this.sessionId = sessionId;
-        this.capabilities.putAll(capabilities);
+        for (Map.Entry<String, Object> capability: capabilities.entrySet()) {
+            boolean isSetting = false;
+            for (Settings settingsEnumItem: Settings.values()) {
+                ISetting<?> currentSetting = settingsEnumItem.getSetting();
+                if (currentSetting.getName().equalsIgnoreCase(capability.getKey())) {
+                    isSetting = true;
+                    currentSetting.update(capability.getValue());
+                    setCapability(currentSetting.getName(), currentSetting.getValue());
+                    break;
+                }
+            }
+            if (!isSetting) {
+                capabilities.put(capability.getKey(), capability.getValue());
+            }
+        }
     }
 
     @SuppressWarnings("UnusedReturnValue")

--- a/app/src/main/java/io/appium/uiautomator2/model/settings/AbstractSetting.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/settings/AbstractSetting.java
@@ -62,8 +62,8 @@ public abstract class AbstractSetting<T> implements ISetting<T> {
             }
             return valueType.cast(value);
         } catch (ClassCastException e) {
-            String errorMsg = String.format("Invalid setting value type. Got: %s. Expected: %s.",
-                    value.getClass().getName(), valueType.getName());
+            String errorMsg = String.format("Invalid '%s' setting value type. Got: %s. Expected: %s.",
+                    getName(), null == value ? null : value.getClass().getName(), valueType.getName());
             throw new InvalidArgumentException(errorMsg);
         }
     }

--- a/app/src/main/java/io/appium/uiautomator2/model/settings/ISetting.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/settings/ISetting.java
@@ -18,7 +18,7 @@ package io.appium.uiautomator2.model.settings;
 
 public interface ISetting<T> {
 
-    void update(T value);
+    void update(Object value);
 
     T getValue();
 


### PR DESCRIPTION
Capabilities map accepts any values (type Object), but settings require strict value types