### PR TITLE
refactor: Do not store settings in session capabilities

### DIFF
--- a/app/src/main/java/io/appium/uiautomator2/core/AccessibilityNodeInfoDumper.java
+++ b/app/src/main/java/io/appium/uiautomator2/core/AccessibilityNodeInfoDumper.java
@@ -102,7 +102,7 @@ public class AccessibilityNodeInfoDumper {
                 .replaceAll("\\.+", ".")
                 .replaceAll("(^\\.|\\.$)", "");
 
-        if (((NormalizeTagNames) Settings.NORMALIZE_TAG_NAMES.getSetting()).getValue()) {
+        if (Settings.get(NormalizeTagNames.class).getValue()) {
             // A workaround for the Apache Harmony bug described in https://github.com/appium/appium/issues/11854
             // The buggy implementation: https://android.googlesource.com/platform/dalvik/+/21d27c095fee51fd6eac6a68d50b79df4dc97d85/libcore/xml/src/main/java/org/apache/harmony/xml/dom/DocumentImpl.java#84
             fixedName = unidecode(fixedName).replaceAll("[^A-Za-z0-9\\-._]", "_");

--- a/app/src/main/java/io/appium/uiautomator2/core/AccessibilityNodeInfoDumper.java
+++ b/app/src/main/java/io/appium/uiautomator2/core/AccessibilityNodeInfoDumper.java
@@ -219,9 +219,10 @@ public class AccessibilityNodeInfoDumper {
                     SystemClock.uptimeMillis() - timeStarted, matchedNodes.size(), xpathSelector));
             return matchedNodes;
         } catch (JDOMParseException e) {
-            throw new UiAutomator2Exception(String.format("%s. " +
-                            "Try changing the '%s' driver setting to 'true' in order to workaround the problem.",
-                    e.getMessage(), Settings.NORMALIZE_TAG_NAMES.toString()), e);
+            throw new UiAutomator2Exception(
+                    String.format("%s. Try changing the '%s' driver setting to 'true' in order " +
+                                    "to workaround the problem.", e.getMessage(),
+                    Settings.NORMALIZE_TAG_NAMES.getSetting().getName()), e);
         } catch (Exception e) {
             throw new UiAutomator2Exception(e);
         } finally {

--- a/app/src/main/java/io/appium/uiautomator2/core/AxNodeInfoHelper.java
+++ b/app/src/main/java/io/appium/uiautomator2/core/AxNodeInfoHelper.java
@@ -185,7 +185,7 @@ public class AxNodeInfoHelper {
         if (node == null) {
             return rect;
         }
-        if (((SimpleBoundsCalculation) Settings.SIMPLE_BOUNDS_CALCULATION.getSetting()).getValue()) {
+        if (Settings.get(SimpleBoundsCalculation.class).getValue()) {
             node.getBoundsInScreen(rect);
             return rect;
         }

--- a/app/src/main/java/io/appium/uiautomator2/core/InteractionController.java
+++ b/app/src/main/java/io/appium/uiautomator2/core/InteractionController.java
@@ -67,8 +67,7 @@ public class InteractionController {
     }
 
     public boolean shouldTrackScrollEvents() {
-        final TrackScrollEvents trackScrollEventsSetting =
-                (TrackScrollEvents) Settings.TRACK_SCROLL_EVENTS.getSetting();
+        final TrackScrollEvents trackScrollEventsSetting = Settings.get(TrackScrollEvents.class);
         Boolean trackScrollEvents = trackScrollEventsSetting.getValue();
         Logger.error(String.format("Setting '%s' is set to %b",
                 trackScrollEventsSetting.getName(), trackScrollEvents));

--- a/app/src/main/java/io/appium/uiautomator2/handler/GetOrientation.java
+++ b/app/src/main/java/io/appium/uiautomator2/handler/GetOrientation.java
@@ -21,9 +21,8 @@ import io.appium.uiautomator2.http.AppiumResponse;
 import io.appium.uiautomator2.http.IHttpRequest;
 import io.appium.uiautomator2.model.ScreenOrientation;
 import io.appium.uiautomator2.model.ScreenRotation;
+import io.appium.uiautomator2.model.settings.Settings;
 import io.appium.uiautomator2.model.settings.UseResourcesForOrientationDetection;
-
-import static io.appium.uiautomator2.model.settings.Settings.USE_RESOURCES_FOR_ORIENTATION_DETECTION;
 
 public class GetOrientation extends SafeRequestHandler {
 
@@ -33,7 +32,7 @@ public class GetOrientation extends SafeRequestHandler {
 
     @Override
     protected AppiumResponse safeHandle(IHttpRequest request) {
-        return ((UseResourcesForOrientationDetection) USE_RESOURCES_FOR_ORIENTATION_DETECTION.getSetting()).getValue()
+        return Settings.get(UseResourcesForOrientationDetection.class).getValue()
                 ? new AppiumResponse(getSessionId(request), ScreenOrientation.current().name())
                 : new AppiumResponse(getSessionId(request), ScreenRotation.current().toOrientation().name());
     }

--- a/app/src/main/java/io/appium/uiautomator2/handler/SetOrientation.java
+++ b/app/src/main/java/io/appium/uiautomator2/handler/SetOrientation.java
@@ -23,9 +23,9 @@ import io.appium.uiautomator2.model.ScreenOrientation;
 import io.appium.uiautomator2.model.ScreenRotation;
 import io.appium.uiautomator2.model.api.OrientationModel;
 import io.appium.uiautomator2.model.internal.CustomUiDevice;
+import io.appium.uiautomator2.model.settings.Settings;
 import io.appium.uiautomator2.model.settings.UseResourcesForOrientationDetection;
 
-import static io.appium.uiautomator2.model.settings.Settings.USE_RESOURCES_FOR_ORIENTATION_DETECTION;
 import static io.appium.uiautomator2.utils.ModelUtils.toModel;
 
 public class SetOrientation extends SafeRequestHandler {
@@ -39,7 +39,7 @@ public class SetOrientation extends SafeRequestHandler {
         ScreenOrientation desiredOrientation = ScreenOrientation.ofString(model.orientation);
         ScreenRotation rotation = CustomUiDevice.getInstance()
                 .setRotationSync(ScreenRotation.ofOrientation(desiredOrientation));
-        String result = ((UseResourcesForOrientationDetection) USE_RESOURCES_FOR_ORIENTATION_DETECTION.getSetting()).getValue()
+        String result = Settings.get(UseResourcesForOrientationDetection.class).getValue()
                 ? ScreenOrientation.current().name()
                 : rotation.toOrientation().name();
         return new AppiumResponse(getSessionId(request), result);

--- a/app/src/main/java/io/appium/uiautomator2/handler/UpdateSettings.java
+++ b/app/src/main/java/io/appium/uiautomator2/handler/UpdateSettings.java
@@ -23,8 +23,6 @@ import io.appium.uiautomator2.common.exceptions.UnsupportedSettingException;
 import io.appium.uiautomator2.handler.request.SafeRequestHandler;
 import io.appium.uiautomator2.http.AppiumResponse;
 import io.appium.uiautomator2.http.IHttpRequest;
-import io.appium.uiautomator2.model.AppiumUIA2Driver;
-import io.appium.uiautomator2.model.Session;
 import io.appium.uiautomator2.model.api.SettingsModel;
 import io.appium.uiautomator2.model.settings.ISetting;
 import io.appium.uiautomator2.model.settings.Settings;
@@ -38,19 +36,16 @@ public class UpdateSettings extends SafeRequestHandler {
         super(mappedUri);
     }
 
-    @SuppressWarnings({"unchecked", "rawtypes"})
     @Override
     protected AppiumResponse safeHandle(IHttpRequest request) {
-        Session session = AppiumUIA2Driver.getInstance().getSessionOrThrow();
         SettingsModel model = toModel(request, SettingsModel.class);
         Map<String, Object> settings = model.settings;
         Logger.debug("Update settings: " + settings.toString());
         for (Entry<String, Object> entry : settings.entrySet()) {
             String settingName = entry.getKey();
             Object settingValue = entry.getValue();
-            ISetting setting = getSetting(settingName);
+            ISetting<?> setting = getSetting(settingName);
             setting.update(settingValue);
-            session.setCapability(settingName, settingValue);
         }
         return new AppiumResponse(getSessionId(request));
     }

--- a/app/src/main/java/io/appium/uiautomator2/model/BaseElement.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/BaseElement.java
@@ -31,6 +31,9 @@ import io.appium.uiautomator2.common.exceptions.NoSuchAttributeException;
 import io.appium.uiautomator2.core.AxNodeInfoHelper;
 import io.appium.uiautomator2.model.api.ElementModel;
 import io.appium.uiautomator2.model.api.ElementRectModel;
+import io.appium.uiautomator2.model.settings.ElementResponseAttributes;
+import io.appium.uiautomator2.model.settings.Settings;
+import io.appium.uiautomator2.model.settings.ShouldUseCompactResponses;
 import io.appium.uiautomator2.utils.ElementHelpers;
 import io.appium.uiautomator2.utils.PositionHelper;
 
@@ -191,14 +194,14 @@ public abstract class BaseElement implements AndroidElement {
      */
     @Override
     public Object toModel() throws UiObjectNotFoundException {
-        Session session = AppiumUIA2Driver.getInstance().getSessionOrThrow();
         ElementModel model = new ElementModel(this);
-        if (session.shouldUseCompactResponses()) {
+        if (Settings.get(ShouldUseCompactResponses.class).getValue()) {
             return model;
         }
 
         Map<String, Object> result = new HashMap<>(model.toMap());
-        for (String field : session.getElementResponseAttributes()) {
+        String [] responseAttributes = Settings.get(ElementResponseAttributes.class).asArray();
+        for (String field : responseAttributes) {
             try {
                 if (Objects.equals(field, "name")) {
                     result.put(field, this.getContentDesc());

--- a/app/src/main/java/io/appium/uiautomator2/model/ScreenRotation.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/ScreenRotation.java
@@ -18,10 +18,9 @@ package io.appium.uiautomator2.model;
 
 import java.util.Objects;
 
+import io.appium.uiautomator2.model.settings.Settings;
 import io.appium.uiautomator2.model.settings.UseResourcesForOrientationDetection;
 import io.appium.uiautomator2.utils.Device;
-
-import static io.appium.uiautomator2.model.settings.Settings.USE_RESOURCES_FOR_ORIENTATION_DETECTION;
 
 public enum ScreenRotation {
     ROTATION_0, ROTATION_90, ROTATION_180, ROTATION_270;
@@ -65,7 +64,7 @@ public enum ScreenRotation {
     }
 
     public static ScreenRotation ofOrientation(ScreenOrientation desiredOrientation) {
-        if (!((UseResourcesForOrientationDetection) USE_RESOURCES_FOR_ORIENTATION_DETECTION.getSetting()).getValue()) {
+        if (!Settings.get(UseResourcesForOrientationDetection.class).getValue()) {
             return desiredOrientation == ScreenOrientation.LANDSCAPE ? ROTATION_270 : ROTATION_0;
         }
 

--- a/app/src/main/java/io/appium/uiautomator2/model/Session.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/Session.java
@@ -25,9 +25,6 @@ import java.util.Map;
 import io.appium.uiautomator2.model.settings.ISetting;
 import io.appium.uiautomator2.model.settings.Settings;
 
-import static io.appium.uiautomator2.model.settings.Settings.ELEMENT_RESPONSE_ATTRIBUTES;
-import static io.appium.uiautomator2.model.settings.Settings.SHOULD_USE_COMPACT_RESPONSES;
-
 public class Session {
     public static final String NO_ID = "None";
     public static final int MAX_CACHE_SIZE = 500;
@@ -46,7 +43,6 @@ public class Session {
                 if (currentSetting.getName().equalsIgnoreCase(capability.getKey())) {
                     isSetting = true;
                     currentSetting.update(capability.getValue());
-                    setCapability(currentSetting.getName(), currentSetting.getValue());
                     break;
                 }
             }
@@ -56,10 +52,8 @@ public class Session {
         }
     }
 
-    @SuppressWarnings("UnusedReturnValue")
-    public <T> T setCapability(String name, T value) {
+    private void setCapability(String name, Object value) {
         capabilities.put(name, value);
-        return value;
     }
 
     @Nullable
@@ -78,19 +72,6 @@ public class Session {
 
     public boolean hasCapability(String name) {
         return capabilities.containsKey(name);
-    }
-
-    public boolean shouldUseCompactResponses() {
-        String capName = SHOULD_USE_COMPACT_RESPONSES.toString();
-        return !hasCapability(capName)
-                || String.valueOf(getCapability(capName)).equalsIgnoreCase("true");
-    }
-
-    public String[] getElementResponseAttributes() {
-        String capName = ELEMENT_RESPONSE_ATTRIBUTES.toString();
-        return getCapability(capName, "").trim().isEmpty()
-                ? new String[]{"name", "text"}
-                : getCapability(capName, "").split(",");
     }
 
     public String getSessionId() {

--- a/app/src/main/java/io/appium/uiautomator2/model/Session.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/Session.java
@@ -56,11 +56,6 @@ public class Session {
         capabilities.put(name, value);
     }
 
-    @Nullable
-    public Object getCapability(String name) {
-        return capabilities.get(name);
-    }
-
     public <T> T getCapability(String name, T defaultValue) {
         //noinspection unchecked
         return hasCapability(name) ? (T) capabilities.get(name) : defaultValue;

--- a/app/src/main/java/io/appium/uiautomator2/model/UiElementSnapshot.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/UiElementSnapshot.java
@@ -33,11 +33,12 @@ import java.util.Objects;
 import java.util.Set;
 
 import io.appium.uiautomator2.core.AxNodeInfoHelper;
+import io.appium.uiautomator2.model.settings.AllowInvisibleElements;
+import io.appium.uiautomator2.model.settings.Settings;
 import io.appium.uiautomator2.utils.Attribute;
 import io.appium.uiautomator2.utils.Logger;
 
 import static androidx.test.internal.util.Checks.checkNotNull;
-import static io.appium.uiautomator2.model.settings.Settings.ALLOW_INVISIBLE_ELEMENTS;
 import static io.appium.uiautomator2.utils.ReflectionUtils.setField;
 import static io.appium.uiautomator2.utils.StringHelpers.charSequenceToNullableString;
 
@@ -226,8 +227,7 @@ public class UiElementSnapshot extends UiElement<AccessibilityNodeInfo, UiElemen
         }
 
         List<UiElementSnapshot> children = new ArrayList<>(childCount);
-        boolean areInvisibleElementsAllowed = AppiumUIA2Driver.getInstance().getSessionOrThrow()
-                .getCapability(ALLOW_INVISIBLE_ELEMENTS.toString(), false);
+        boolean areInvisibleElementsAllowed = Settings.get(AllowInvisibleElements.class).getValue();
         for (int index = 0; index < childCount; ++index) {
             AccessibilityNodeInfo child = node.getChild(index);
             if (child == null) {

--- a/app/src/main/java/io/appium/uiautomator2/model/settings/AllowInvisibleElements.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/settings/AllowInvisibleElements.java
@@ -16,11 +16,10 @@
 
 package io.appium.uiautomator2.model.settings;
 
-import io.appium.uiautomator2.model.AppiumUIA2Driver;
-
 public class AllowInvisibleElements extends AbstractSetting<Boolean> {
 
     private static final String SETTING_NAME = "allowInvisibleElements";
+    private Boolean value = false;
 
     public AllowInvisibleElements() {
         super(Boolean.class, SETTING_NAME);
@@ -28,18 +27,12 @@ public class AllowInvisibleElements extends AbstractSetting<Boolean> {
 
     @Override
     public Boolean getValue() {
-        return AppiumUIA2Driver
-                .getInstance()
-                .getSessionOrThrow()
-                .getCapability(SETTING_NAME, false);
+        return value;
     }
 
     @Override
     protected void apply(Boolean allowInvisibleElements) {
-        AppiumUIA2Driver
-                .getInstance()
-                .getSessionOrThrow()
-                .setCapability(SETTING_NAME, allowInvisibleElements);
+        value = allowInvisibleElements;
     }
 
 }

--- a/app/src/main/java/io/appium/uiautomator2/model/settings/ElementResponseAttributes.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/settings/ElementResponseAttributes.java
@@ -16,11 +16,11 @@
 
 package io.appium.uiautomator2.model.settings;
 
-import io.appium.uiautomator2.model.AppiumUIA2Driver;
-
 public class ElementResponseAttributes extends AbstractSetting<String> {
 
     private static final String SETTING_NAME = "elementResponseAttributes";
+    private static final String DEFAULT_ATTRIBUTES = "name,text";
+    private String value = DEFAULT_ATTRIBUTES;
 
     public ElementResponseAttributes() {
         super(String.class, SETTING_NAME);
@@ -28,16 +28,16 @@ public class ElementResponseAttributes extends AbstractSetting<String> {
 
     @Override
     public String getValue() {
-        return AppiumUIA2Driver.getInstance()
-                .getSessionOrThrow()
-                .getCapability(getName(), "");
+        return value;
+    }
+
+    public String[] asArray() {
+        return value.split(",");
     }
 
     @Override
     protected void apply(String elementResponseAttributes) {
-        AppiumUIA2Driver.getInstance()
-                .getSessionOrThrow()
-                .setCapability(SETTING_NAME, elementResponseAttributes);
+        value = elementResponseAttributes;
     }
 
 }

--- a/app/src/main/java/io/appium/uiautomator2/model/settings/EnableMultiWindows.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/settings/EnableMultiWindows.java
@@ -16,11 +16,11 @@
 
 package io.appium.uiautomator2.model.settings;
 
-import io.appium.uiautomator2.model.AppiumUIA2Driver;
-
 public class EnableMultiWindows extends AbstractSetting<Boolean> {
 
     private static final String SETTING_NAME = "enableMultiWindows";
+
+    private Boolean value = false;
 
     public EnableMultiWindows() {
         super(Boolean.class, SETTING_NAME);
@@ -28,17 +28,11 @@ public class EnableMultiWindows extends AbstractSetting<Boolean> {
 
     @Override
     public Boolean getValue() {
-        return AppiumUIA2Driver.getInstance()
-                .getSessionOrThrow()
-                .getCapability(getName(), false);
+        return value;
     }
 
     @Override
     protected void apply(Boolean multiWindowsEnabled) {
-        AppiumUIA2Driver
-                .getInstance()
-                .getSessionOrThrow()
-                .setCapability(getName(), multiWindowsEnabled);
+        value = multiWindowsEnabled;
     }
-
 }

--- a/app/src/main/java/io/appium/uiautomator2/model/settings/Settings.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/settings/Settings.java
@@ -55,9 +55,9 @@ public enum Settings {
     }
 
     public static <T extends ISetting<?>> T get(Class<T> settingType) {
-        for (Settings setting: values()) {
-            if (setting.getSetting().getClass() == settingType) {
-                return settingType.cast(setting);
+        for (Settings enumItem: values()) {
+            if (enumItem.getSetting().getClass() == settingType) {
+                return settingType.cast(enumItem.getSetting());
             }
         }
         throw new IllegalArgumentException(String.format("%s setting is not known",

--- a/app/src/main/java/io/appium/uiautomator2/model/settings/Settings.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/settings/Settings.java
@@ -54,6 +54,16 @@ public enum Settings {
         return setting;
     }
 
+    public static <T extends ISetting<?>> T get(Class<T> settingType) {
+        for (Settings setting: values()) {
+            if (setting.getSetting().getClass() == settingType) {
+                return settingType.cast(setting);
+            }
+        }
+        throw new IllegalArgumentException(String.format("%s setting is not known",
+                settingType.getCanonicalName()));
+    }
+
     @Override
     public String toString() {
         return setting.getName();

--- a/app/src/main/java/io/appium/uiautomator2/model/settings/ShouldUseCompactResponses.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/settings/ShouldUseCompactResponses.java
@@ -16,11 +16,11 @@
 
 package io.appium.uiautomator2.model.settings;
 
-import io.appium.uiautomator2.model.AppiumUIA2Driver;
-
 public class ShouldUseCompactResponses extends AbstractSetting<Boolean> {
 
     private static final String SETTING_NAME = "shouldUseCompactResponses";
+
+    private Boolean value = true;
 
     public ShouldUseCompactResponses() {
         super(Boolean.class, SETTING_NAME);
@@ -28,18 +28,12 @@ public class ShouldUseCompactResponses extends AbstractSetting<Boolean> {
 
     @Override
     public Boolean getValue() {
-        return AppiumUIA2Driver
-                .getInstance()
-                .getSessionOrThrow()
-                .shouldUseCompactResponses();
+        return value;
     }
 
     @Override
     protected void apply(Boolean shouldUseCompactResponses) {
-        AppiumUIA2Driver
-                .getInstance()
-                .getSessionOrThrow()
-                .setCapability(SETTING_NAME, shouldUseCompactResponses);
+        value = shouldUseCompactResponses;
     }
 
 }

--- a/app/src/main/java/io/appium/uiautomator2/model/settings/UseResourcesForOrientationDetection.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/settings/UseResourcesForOrientationDetection.java
@@ -16,11 +16,10 @@
 
 package io.appium.uiautomator2.model.settings;
 
-import io.appium.uiautomator2.model.AppiumUIA2Driver;
-
 public class UseResourcesForOrientationDetection extends AbstractSetting<Boolean> {
 
     private static final String SETTING_NAME = "useResourcesForOrientationDetection";
+    private Boolean value = false;
 
     public UseResourcesForOrientationDetection() {
         super(Boolean.class, SETTING_NAME);
@@ -28,18 +27,12 @@ public class UseResourcesForOrientationDetection extends AbstractSetting<Boolean
 
     @Override
     public Boolean getValue() {
-        return AppiumUIA2Driver
-                .getInstance()
-                .getSessionOrThrow()
-                .getCapability(SETTING_NAME, false);
+        return value;
     }
 
     @Override
     protected void apply(Boolean useResourcesForOrientationDetection) {
-        AppiumUIA2Driver
-                .getInstance()
-                .getSessionOrThrow()
-                .setCapability(SETTING_NAME, useResourcesForOrientationDetection);
+        value = useResourcesForOrientationDetection;
     }
 
 }

--- a/app/src/main/java/io/appium/uiautomator2/server/ServerInstrumentation.java
+++ b/app/src/main/java/io/appium/uiautomator2/server/ServerInstrumentation.java
@@ -273,8 +273,7 @@ public class ServerInstrumentation {
                 return;
             }
 
-            final ShutdownOnPowerDisconnect shutdownOnPowerDisconnect =
-                    (ShutdownOnPowerDisconnect) Settings.SHUTDOWN_ON_POWER_DISCONNECT.getSetting();
+            final ShutdownOnPowerDisconnect shutdownOnPowerDisconnect = Settings.get(ShutdownOnPowerDisconnect.class);
             if (!shutdownOnPowerDisconnect.getValue()) {
                 Logger.debug(String.format("The value of `%s` setting is false - " +
                         "ignoring broadcasting.", shutdownOnPowerDisconnect.getName()));

--- a/app/src/main/java/io/appium/uiautomator2/utils/AXWindowHelpers.java
+++ b/app/src/main/java/io/appium/uiautomator2/utils/AXWindowHelpers.java
@@ -27,6 +27,7 @@ import java.util.List;
 import io.appium.uiautomator2.common.exceptions.UiAutomator2Exception;
 import io.appium.uiautomator2.core.UiAutomatorBridge;
 import io.appium.uiautomator2.model.internal.CustomUiDevice;
+import io.appium.uiautomator2.model.settings.EnableMultiWindows;
 import io.appium.uiautomator2.model.settings.Settings;
 
 public class AXWindowHelpers {
@@ -104,7 +105,7 @@ public class AXWindowHelpers {
             // Multi-window searches are supported since API level 21
             boolean shouldRetrieveAllWindowRoots = CustomUiDevice.getInstance()
                     .getApiLevelActual() >= Build.VERSION_CODES.LOLLIPOP
-                    && (Boolean) Settings.ENABLE_MULTI_WINDOWS.getSetting().getValue();
+                    && Settings.get(EnableMultiWindows.class).getValue();
             /*
              * ENABLE_MULTI_WINDOWS is disabled by default
              * because UIAutomatorViewer captures active window properties and

--- a/app/src/main/java/io/appium/uiautomator2/utils/Device.java
+++ b/app/src/main/java/io/appium/uiautomator2/utils/Device.java
@@ -65,7 +65,7 @@ public abstract class Device {
     }
 
     public static void waitForIdle() {
-        long timeoutMs = ((WaitForIdleTimeout) Settings.WAIT_FOR_IDLE_TIMEOUT.getSetting()).getValue();
+        long timeoutMs = Settings.get(WaitForIdleTimeout.class).getValue();
         if (timeoutMs <= 0) {
             Logger.info("Idle timeout is not greater than zero. Skipping the wait");
             return;

--- a/app/src/test/java/io/appium/uiautomator2/handler/UpdateSettingsTests.java
+++ b/app/src/test/java/io/appium/uiautomator2/handler/UpdateSettingsTests.java
@@ -99,7 +99,7 @@ public class UpdateSettingsTests {
     private final UpdateSettings updateSettings = new UpdateSettings("my_uri");
 
     @Mock
-    private AbstractSetting mySetting;
+    private AbstractSetting<?> mySetting;
 
     @Mock
     private IHttpRequest req;
@@ -237,7 +237,7 @@ public class UpdateSettingsTests {
         assertThat(resp.getValue(), is(instanceOf(Throwable.class)));
     }
 
-    private void verifySettingIsAvailable(Settings setting, Class<? extends AbstractSetting> clazz) {
+    private void verifySettingIsAvailable(Settings setting, Class<? extends AbstractSetting<?>> clazz) {
         assertThat(updateSettings.getSetting(setting.toString()), instanceOf(clazz));
     }
 }

--- a/app/src/test/java/io/appium/uiautomator2/handler/UpdateSettingsTests.java
+++ b/app/src/test/java/io/appium/uiautomator2/handler/UpdateSettingsTests.java
@@ -35,7 +35,6 @@ import io.appium.uiautomator2.handler.request.BaseRequestHandler;
 import io.appium.uiautomator2.http.AppiumResponse;
 import io.appium.uiautomator2.http.IHttpRequest;
 import io.appium.uiautomator2.model.AppiumUIA2Driver;
-import io.appium.uiautomator2.model.Session;
 import io.appium.uiautomator2.model.api.SettingsModel;
 import io.appium.uiautomator2.model.settings.AbstractSetting;
 import io.appium.uiautomator2.model.settings.ActionAcknowledgmentTimeout;
@@ -93,7 +92,6 @@ import static org.powermock.api.mockito.PowerMockito.when;
 public class UpdateSettingsTests {
     private static final String SETTING_NAME = "my_setting";
     private static final String SETTING_VALUE = "my_value";
-    private Session session;
 
     @Spy
     private final UpdateSettings updateSettings = new UpdateSettings("my_uri");
@@ -107,7 +105,6 @@ public class UpdateSettingsTests {
     @Before
     public void setUp() throws JSONException {
         AppiumUIA2Driver.getInstance().initializeSession(Collections.<String, Object>emptyMap());
-        session = AppiumUIA2Driver.getInstance().getSessionOrThrow();
         HashMap<String, Object> payload = new HashMap<>();
         payload.put(SETTING_NAME, SETTING_VALUE);
 
@@ -224,7 +221,6 @@ public class UpdateSettingsTests {
                 .thenReturn(toJsonString(new SettingsModel(SETTING_NAME, SETTING_VALUE)));
         AppiumResponse response = updateSettings.handle(req);
         verify(mySetting).update(SETTING_VALUE);
-        assertEquals(session.getCapability(SETTING_NAME), SETTING_VALUE);
         assertEquals(response.getHttpStatus(), HttpResponseStatus.OK);
     }
 

--- a/app/src/test/java/io/appium/uiautomator2/model/settings/AllowInvisibleElementsTest.java
+++ b/app/src/test/java/io/appium/uiautomator2/model/settings/AllowInvisibleElementsTest.java
@@ -20,19 +20,11 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.util.Collections;
-
-import io.appium.uiautomator2.model.AppiumUIA2Driver;
-import io.appium.uiautomator2.model.Session;
-
 public class AllowInvisibleElementsTest {
-    private Session session;
     private AllowInvisibleElements allowInvisibleElements;
 
     @Before
     public void setup() {
-        AppiumUIA2Driver.getInstance().initializeSession(Collections.<String, Object>emptyMap());
-        session = AppiumUIA2Driver.getInstance().getSessionOrThrow();
         allowInvisibleElements = new AllowInvisibleElements();
     }
 
@@ -48,13 +40,13 @@ public class AllowInvisibleElementsTest {
 
     @Test
     public void shouldBeAbleToDisableAllowInvisibleElements() {
-        session.setCapability(allowInvisibleElements.getName(), false);
+        allowInvisibleElements.apply(false);
         Assert.assertEquals(false, allowInvisibleElements.getValue());
     }
 
     @Test
     public void shouldBeAbleToEnableAllowInvisibleElements() {
-        session.setCapability(allowInvisibleElements.getName(), true);
+        allowInvisibleElements.apply(true);
         Assert.assertEquals(true, allowInvisibleElements.getValue());
     }
 }

--- a/app/src/test/java/io/appium/uiautomator2/model/settings/ElementResponseAttributesTest.java
+++ b/app/src/test/java/io/appium/uiautomator2/model/settings/ElementResponseAttributesTest.java
@@ -20,21 +20,11 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.util.Collections;
-
-import io.appium.uiautomator2.model.AppiumUIA2Driver;
-import io.appium.uiautomator2.model.Session;
-
-import static io.appium.uiautomator2.model.settings.Settings.ELEMENT_RESPONSE_ATTRIBUTES;
-
 public class ElementResponseAttributesTest {
-    private Session session;
     private ElementResponseAttributes elementResponseAttributes;
 
     @Before
     public void setup() {
-        AppiumUIA2Driver.getInstance().initializeSession(Collections.<String, Object>emptyMap());
-        session = AppiumUIA2Driver.getInstance().getSessionOrThrow();
         elementResponseAttributes = new ElementResponseAttributes();
     }
 
@@ -50,13 +40,14 @@ public class ElementResponseAttributesTest {
 
     @Test
     public void shouldBeAbleToDisableElementResponseAttributes() {
-        session.setCapability(ELEMENT_RESPONSE_ATTRIBUTES.toString(), "");
+        elementResponseAttributes.apply("");
         Assert.assertEquals("", elementResponseAttributes.getValue());
     }
 
     @Test
     public void shouldBeAbleToEnableElementResponseAttributes() {
-        session.setCapability(ELEMENT_RESPONSE_ATTRIBUTES.toString(), "a,b");
+        elementResponseAttributes.apply("a,b");
         Assert.assertEquals("a,b", elementResponseAttributes.getValue());
+        Assert.assertArrayEquals(new String[] {"a", "b"}, elementResponseAttributes.asArray());
     }
 }

--- a/app/src/test/java/io/appium/uiautomator2/model/settings/ShouldUseCompactResponsesTest.java
+++ b/app/src/test/java/io/appium/uiautomator2/model/settings/ShouldUseCompactResponsesTest.java
@@ -20,22 +20,12 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.util.Collections;
-
-import io.appium.uiautomator2.model.AppiumUIA2Driver;
-import io.appium.uiautomator2.model.Session;
-
-import static io.appium.uiautomator2.model.settings.Settings.SHOULD_USE_COMPACT_RESPONSES;
-
 public class ShouldUseCompactResponsesTest {
 
     private ShouldUseCompactResponses shouldUseCompactResponses;
-    private Session session;
 
     @Before
     public void setup() {
-        AppiumUIA2Driver.getInstance().initializeSession(Collections.<String, Object>emptyMap());
-        session = AppiumUIA2Driver.getInstance().getSessionOrThrow();
         shouldUseCompactResponses = new ShouldUseCompactResponses();
     }
 
@@ -51,13 +41,13 @@ public class ShouldUseCompactResponsesTest {
 
     @Test
     public void shouldBeAbleToEnableShouldUseCompactResponses() {
-        session.setCapability(SHOULD_USE_COMPACT_RESPONSES.toString(), "true");
+        shouldUseCompactResponses.apply(true);
         Assert.assertEquals(true, shouldUseCompactResponses.getValue());
     }
 
     @Test
     public void shouldBeAbleToDisableShouldUseCompactResponses() {
-        session.setCapability(SHOULD_USE_COMPACT_RESPONSES.toString(), "false");
+        shouldUseCompactResponses.apply(false);
         Assert.assertEquals(false, shouldUseCompactResponses.getValue());
     }
 }


### PR DESCRIPTION
There is currently a mess there, since some settings are stored in caps and some other are stored in their own classes. This PR unifies that approach, so that each setting is not stored separately. Also, the way these settings are retrieved has been simplified.