### PR TITLE
[wip] Remove jcenter

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,6 +1,5 @@
 buildscript {
     repositories {
-        jcenter()
         google()
         maven { url 'https://jitpack.io' }
     }

--- a/build.gradle
+++ b/build.gradle
@@ -7,6 +7,7 @@ import org.apache.tools.ant.taskdefs.condition.Os
 buildscript {
     repositories {
         google()
+        mavenCentral()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:4.1.0'
@@ -34,6 +35,7 @@ allprojects {
     }
     repositories {
         google()
+        mavenCentral()
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,6 @@ import org.apache.tools.ant.taskdefs.condition.Os
 
 buildscript {
     repositories {
-        jcenter()
         google()
     }
     dependencies {
@@ -34,7 +33,6 @@ allprojects {
         }
     }
     repositories {
-        jcenter()
         google()
     }
 }


### PR DESCRIPTION
Still below error occurred with `npm run build`

```
* What went wrong:
A problem occurred configuring root project 'appium-uiautomator2-server'.
> Could not resolve all artifacts for configuration ':classpath'.
   > Could not find org.jetbrains.trove4j:trove4j:20160824.
     Searched in the following locations:
       - https://dl.google.com/dl/android/maven2/org/jetbrains/trove4j/trove4j/20160824/trove4j-20160824.pom
       - https://repo.maven.apache.org/maven2/org/jetbrains/trove4j/trove4j/20160824/trove4j-20160824.pom
     Required by:
         project : > com.android.tools.build:gradle:4.1.0 > com.android.tools.build:builder:4.1.0 > com.android.tools:sdk-common:27.1.0
```