### PR TITLE
refactor: Unify element cache identifiers

### DIFF
--- a/app/src/main/java/io/appium/uiautomator2/core/AxNodeInfoHelper.java
+++ b/app/src/main/java/io/appium/uiautomator2/core/AxNodeInfoHelper.java
@@ -32,7 +32,6 @@ import androidx.test.uiautomator.UiDevice;
 
 import java.util.HashSet;
 import java.util.Set;
-import java.util.UUID;
 
 import io.appium.uiautomator2.common.exceptions.InvalidElementStateException;
 import io.appium.uiautomator2.model.internal.CustomUiDevice;
@@ -55,13 +54,14 @@ public class AxNodeInfoHelper {
             (((long) Integer.MAX_VALUE) << 32) | Integer.MAX_VALUE;
     private static final int UNDEFINED_WINDOW_ID = -1;
 
+    @Nullable
     public static String toUuid(AccessibilityNodeInfo info) {
         // mSourceNodeId and windowId properties define
         // the uniqueness of the particular AccessibilityNodeInfo instance
         long sourceNodeId = (Long) getField("mSourceNodeId", info);
         int windowId = info.getWindowId();
         if (sourceNodeId == UNDEFINED_NODE_ID || windowId == UNDEFINED_WINDOW_ID) {
-            return UUID.randomUUID().toString();
+            return null;
         }
         String sourceNodeIdHex = String.format("%016x", sourceNodeId);
         String windowIdHex = String.format("%016x", windowId);

--- a/app/src/main/java/io/appium/uiautomator2/core/AxNodeInfoHelper.java
+++ b/app/src/main/java/io/appium/uiautomator2/core/AxNodeInfoHelper.java
@@ -25,7 +25,6 @@ import android.os.Bundle;
 import android.util.Range;
 import android.view.accessibility.AccessibilityNodeInfo;
 import android.view.accessibility.AccessibilityNodeInfo.AccessibilityAction;
-import android.view.accessibility.AccessibilityWindowInfo;
 
 import androidx.annotation.Nullable;
 import androidx.test.uiautomator.Direction;
@@ -51,18 +50,17 @@ import static io.appium.uiautomator2.utils.StringHelpers.charSequenceToString;
  */
 public class AxNodeInfoHelper {
     // https://github.com/appium/appium/issues/12892
-    private final static int MAX_DEPTH = 70;
+    private static final int MAX_DEPTH = 70;
+    private static final long UNDEFINED_NODE_ID =
+            (((long) Integer.MAX_VALUE) << 32) | Integer.MAX_VALUE;
+    private static final int UNDEFINED_WINDOW_ID = -1;
 
     public static String toUuid(AccessibilityNodeInfo info) {
         // mSourceNodeId and windowId properties define
         // the uniqueness of the particular AccessibilityNodeInfo instance
         long sourceNodeId = (Long) getField("mSourceNodeId", info);
         int windowId = info.getWindowId();
-        long undefinedSourceNodeId = (Long) getField(
-                AccessibilityNodeInfo.class, "UNDEFINED_NODE_ID", null);
-        int undefinedWindowId = (Integer) getField(
-                AccessibilityWindowInfo.class, "UNDEFINED_WINDOW_ID", null);
-        if (sourceNodeId == undefinedSourceNodeId && windowId == undefinedWindowId) {
+        if (sourceNodeId == UNDEFINED_NODE_ID || windowId == UNDEFINED_WINDOW_ID) {
             return UUID.randomUUID().toString();
         }
         String sourceNodeIdHex = String.format("%016x", sourceNodeId);

--- a/app/src/main/java/io/appium/uiautomator2/core/AxNodeInfoHelper.java
+++ b/app/src/main/java/io/appium/uiautomator2/core/AxNodeInfoHelper.java
@@ -32,7 +32,6 @@ import androidx.test.uiautomator.Direction;
 import androidx.test.uiautomator.UiDevice;
 
 import java.util.HashSet;
-import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
 
@@ -55,15 +54,15 @@ public class AxNodeInfoHelper {
     private final static int MAX_DEPTH = 70;
 
     public static String toUuid(AccessibilityNodeInfo info) {
-        // mSourceNodeId and mWindowId properties define
+        // mSourceNodeId and windowId properties define
         // the uniqueness of the particular AccessibilityNodeInfo instance
-        Long sourceNodeId = (Long) getField("mSourceNodeId", info);
-        Integer windowId = (Integer) getField("mWindowId", info);
-        Long undefinedSourceNodeId = (Long) getField(
+        long sourceNodeId = (Long) getField("mSourceNodeId", info);
+        int windowId = info.getWindowId();
+        long undefinedSourceNodeId = (Long) getField(
                 AccessibilityNodeInfo.class, "UNDEFINED_NODE_ID", null);
-        Integer undefinedWindowId = (Integer) getField(
+        int undefinedWindowId = (Integer) getField(
                 AccessibilityWindowInfo.class, "UNDEFINED_WINDOW_ID", null);
-        if (Objects.equals(sourceNodeId, undefinedSourceNodeId) && Objects.equals(windowId, undefinedWindowId)) {
+        if (sourceNodeId == undefinedSourceNodeId && windowId == undefinedWindowId) {
             return UUID.randomUUID().toString();
         }
         String sourceNodeIdHex = String.format("%016x", sourceNodeId);

--- a/app/src/main/java/io/appium/uiautomator2/handler/FindElement.java
+++ b/app/src/main/java/io/appium/uiautomator2/handler/FindElement.java
@@ -27,8 +27,7 @@ import io.appium.uiautomator2.http.IHttpRequest;
 import io.appium.uiautomator2.model.AndroidElement;
 import io.appium.uiautomator2.model.AppiumUIA2Driver;
 import io.appium.uiautomator2.model.By;
-import io.appium.uiautomator2.model.By.ByClass;
-import io.appium.uiautomator2.model.By.ById;
+import io.appium.uiautomator2.model.AccessibleUiObject;
 import io.appium.uiautomator2.model.Session;
 import io.appium.uiautomator2.model.api.FindElementModel;
 import io.appium.uiautomator2.model.internal.CustomUiDevice;
@@ -63,7 +62,7 @@ public class FindElement extends SafeRequestHandler {
         }
 
         final By by = ElementsLookupStrategy.ofName(method).toNativeSelector(selector);
-        final Object element = isBlank(contextId) ? this.findElement(by) : this.findElement(by, contextId);
+        final AccessibleUiObject element = isBlank(contextId) ? this.findElement(by) : this.findElement(by, contextId);
         if (element == null) {
             throw new ElementNotFoundException();
         }
@@ -74,14 +73,14 @@ public class FindElement extends SafeRequestHandler {
     }
 
     @Nullable
-    private Object findElement(By by) throws UiAutomator2Exception, UiObjectNotFoundException {
+    private AccessibleUiObject findElement(By by) throws UiAutomator2Exception, UiObjectNotFoundException {
         refreshAccessibilityCache();
-        if (by instanceof ById) {
-            String locator = rewriteIdLocator((ById) by);
+        if (by instanceof By.ById) {
+            String locator = rewriteIdLocator((By.ById) by);
             return CustomUiDevice.getInstance().findObject(androidx.test.uiautomator.By.res(locator));
         } else if (by instanceof By.ByAccessibilityId) {
             return CustomUiDevice.getInstance().findObject(androidx.test.uiautomator.By.desc(by.getElementLocator()));
-        } else if (by instanceof ByClass) {
+        } else if (by instanceof By.ByClass) {
             return CustomUiDevice.getInstance().findObject(androidx.test.uiautomator.By.clazz(by.getElementLocator()));
         } else if (by instanceof By.ByXPath) {
             final NodeInfoList matchedNodes = getXPathNodeMatch(by.getElementLocator(), null, false);
@@ -97,16 +96,16 @@ public class FindElement extends SafeRequestHandler {
     }
 
     @Nullable
-    private Object findElement(By by, String contextId) throws UiAutomator2Exception, UiObjectNotFoundException {
+    private AccessibleUiObject findElement(By by, String contextId) throws UiAutomator2Exception, UiObjectNotFoundException {
         Session session = AppiumUIA2Driver.getInstance().getSessionOrThrow();
         AndroidElement element = session.getElementsCache().get(contextId);
 
-        if (by instanceof ById) {
-            String locator = rewriteIdLocator((ById) by);
+        if (by instanceof By.ById) {
+            String locator = rewriteIdLocator((By.ById) by);
             return element.getChild(androidx.test.uiautomator.By.res(locator));
         } else if (by instanceof By.ByAccessibilityId) {
             return element.getChild(androidx.test.uiautomator.By.desc(by.getElementLocator()));
-        } else if (by instanceof ByClass) {
+        } else if (by instanceof By.ByClass) {
             return element.getChild(androidx.test.uiautomator.By.clazz(by.getElementLocator()));
         } else if (by instanceof By.ByXPath) {
             final NodeInfoList matchedNodes = getXPathNodeMatch(by.getElementLocator(), element, false);

--- a/app/src/main/java/io/appium/uiautomator2/handler/FirstVisibleView.java
+++ b/app/src/main/java/io/appium/uiautomator2/handler/FirstVisibleView.java
@@ -1,4 +1,22 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.appium.uiautomator2.handler;
+
+import android.view.accessibility.AccessibilityNodeInfo;
 
 import androidx.test.uiautomator.UiObject;
 import androidx.test.uiautomator.UiObject2;
@@ -9,14 +27,17 @@ import java.util.List;
 
 import io.appium.uiautomator2.common.exceptions.ElementNotFoundException;
 import io.appium.uiautomator2.common.exceptions.UiAutomator2Exception;
-import io.appium.uiautomator2.core.AxNodeInfoExtractor;
 import io.appium.uiautomator2.handler.request.SafeRequestHandler;
 import io.appium.uiautomator2.http.AppiumResponse;
 import io.appium.uiautomator2.http.IHttpRequest;
+import io.appium.uiautomator2.model.AccessibleUiObject;
 import io.appium.uiautomator2.model.AndroidElement;
 import io.appium.uiautomator2.model.AppiumUIA2Driver;
 import io.appium.uiautomator2.model.Session;
 import io.appium.uiautomator2.utils.Logger;
+
+import static io.appium.uiautomator2.core.AxNodeInfoExtractor.toNullableAxNodeInfo;
+import static io.appium.uiautomator2.model.AccessibleUiObject.toAccessibleUiObject;
 
 /**
  * This method return first visible element inside provided element
@@ -34,13 +55,13 @@ public class FirstVisibleView extends SafeRequestHandler {
         Session session = AppiumUIA2Driver.getInstance().getSessionOrThrow();
 
         AndroidElement element = session.getElementsCache().get(elementId);
-        Object firstObject = null;
+        AccessibleUiObject firstObject = null;
         if (element.getUiObject() instanceof UiObject) {
             UiObject uiObject = (UiObject) element.getUiObject();
             Logger.debug("Container for first visible is a uiobject; looping through children");
             for (int i = 0; i < uiObject.getChildCount(); i++) {
-                UiObject object = uiObject.getChild(new UiSelector().index(i));
-                if (object.exists()) {
+                AccessibleUiObject object = toAccessibleUiObject(uiObject.getChild(new UiSelector().index(i)));
+                if (object != null) {
                     firstObject = object;
                     break;
                 }
@@ -54,8 +75,9 @@ public class FirstVisibleView extends SafeRequestHandler {
             }
             for (UiObject2 childObject : childObjects) {
                 try {
-                    if (AxNodeInfoExtractor.toNullableAxNodeInfo(childObject) != null) {
-                        firstObject = childObject;
+                    AccessibilityNodeInfo info = toNullableAxNodeInfo(childObject);
+                    if (info != null) {
+                        firstObject = new AccessibleUiObject(childObject, info);
                         break;
                     }
                 } catch (UiAutomator2Exception ignored) {

--- a/app/src/main/java/io/appium/uiautomator2/model/AccessibleUiObject.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/AccessibleUiObject.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.appium.uiautomator2.model;
+
+import android.view.accessibility.AccessibilityNodeInfo;
+
+import androidx.annotation.Nullable;
+import androidx.test.uiautomator.UiObject;
+import androidx.test.uiautomator.UiObject2;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static io.appium.uiautomator2.core.AxNodeInfoExtractor.toNullableAxNodeInfo;
+
+public class AccessibleUiObject {
+    private final Object value;
+    private final AccessibilityNodeInfo info;
+
+    public AccessibleUiObject(UiObject value, AccessibilityNodeInfo info) {
+        this.value = value;
+        this.info = info;
+    }
+
+    public AccessibleUiObject(UiObject2 value, AccessibilityNodeInfo info) {
+        this.value = value;
+        this.info = info;
+    }
+
+    public Object getValue() {
+        return this.value;
+    }
+
+    public AccessibilityNodeInfo getInfo() {
+        return this.info;
+    }
+
+    @Nullable
+    public static AccessibleUiObject toAccessibleUiObject(@Nullable UiObject uiObject) {
+        if (uiObject == null) {
+            return null;
+        }
+        AccessibilityNodeInfo info = toNullableAxNodeInfo(uiObject);
+        return info == null ? null : new AccessibleUiObject(uiObject, info);
+    }
+
+    public static List<AccessibleUiObject> toAccessibleUiObjects(List<?> uiObjects) {
+        List<AccessibleUiObject> result = new ArrayList<>();
+        for (Object obj: uiObjects) {
+            AccessibilityNodeInfo info = toNullableAxNodeInfo(obj);
+            if (info == null) {
+                continue;
+            }
+
+            if (obj instanceof UiObject) {
+                result.add(new AccessibleUiObject((UiObject) obj, info));
+            } else if (obj instanceof UiObject2) {
+                result.add(new AccessibleUiObject((UiObject2) obj, info));
+            }
+        }
+        return result;
+    }
+
+    @Nullable
+    public static AccessibleUiObject toAccessibleUiObject(@Nullable UiObject2 uiObject2) {
+        if (uiObject2 == null) {
+            return null;
+        }
+        AccessibilityNodeInfo info = toNullableAxNodeInfo(uiObject2);
+        return info == null ? null : new AccessibleUiObject(uiObject2, info);
+    }
+}

--- a/app/src/main/java/io/appium/uiautomator2/model/AndroidElement.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/AndroidElement.java
@@ -50,9 +50,9 @@ public interface AndroidElement {
 
     Rect getBounds();
 
-    Object getChild(final Object sel) throws UiObjectNotFoundException;
+    AccessibleUiObject getChild(final Object sel) throws UiObjectNotFoundException;
 
-    List<?> getChildren(final Object selector, final By by) throws UiObjectNotFoundException;
+    List<AccessibleUiObject> getChildren(final Object selector, final By by) throws UiObjectNotFoundException;
 
     String getContentDesc() throws UiObjectNotFoundException;
 

--- a/app/src/main/java/io/appium/uiautomator2/model/ElementsCache.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/ElementsCache.java
@@ -113,16 +113,15 @@ public class ElementsCache {
             Logger.warn(String.format(
                     "An exception happened while restoring the cached element '%s'", by), e);
         }
-        final boolean isStale;
         if (accessibleUiObject == null) {
-            isStale = true;
-        } else {
-            String uuid = AxNodeInfoHelper.toUuid(accessibleUiObject.getInfo());
-            isStale = uuid != null && !Objects.equals(uuid, element.getId());
-        }
-        if (isStale) {
             throw new StaleElementReferenceException(String.format(
                     "The element '%s' does not exist in DOM anymore", by));
+        } else {
+            String uuid = AxNodeInfoHelper.toUuid(accessibleUiObject.getInfo());
+            if (uuid != null && !Objects.equals(uuid, element.getId())) {
+                throw new StaleElementReferenceException(String.format(
+                        "The element '%s' is not linked to the same object in DOM anymore", by));
+            }
         }
 
         AndroidElement restoredElement = toAndroidElement(accessibleUiObject,

--- a/app/src/main/java/io/appium/uiautomator2/model/ElementsCache.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/ElementsCache.java
@@ -17,17 +17,15 @@
 package io.appium.uiautomator2.model;
 
 import android.util.LruCache;
-import android.view.accessibility.AccessibilityNodeInfo;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.test.uiautomator.UiObject;
 import androidx.test.uiautomator.UiObject2;
 
-import java.util.UUID;
-
 import io.appium.uiautomator2.common.exceptions.ElementNotFoundException;
 import io.appium.uiautomator2.common.exceptions.StaleElementReferenceException;
+import io.appium.uiautomator2.core.AxNodeInfoHelper;
 import io.appium.uiautomator2.model.internal.CustomUiDevice;
 import io.appium.uiautomator2.utils.ByUiAutomatorFinder;
 import io.appium.uiautomator2.utils.Logger;
@@ -35,7 +33,6 @@ import io.appium.uiautomator2.utils.NodeInfoList;
 
 import static io.appium.uiautomator2.utils.ElementLocationHelpers.getXPathNodeMatch;
 import static io.appium.uiautomator2.utils.ElementLocationHelpers.rewriteIdLocator;
-import static io.appium.uiautomator2.utils.ReflectionUtils.getField;
 
 public class ElementsCache {
     private final LruCache<String, AndroidElement> cache;
@@ -49,25 +46,10 @@ public class ElementsCache {
         return toAndroidElement(element, isSingleMatch, by, contextId, null);
     }
 
-    private static String axInfoToId(AccessibilityNodeInfo info) {
-        // mSourceNodeId and mWindowId properties define
-        // the uniqueness of the particular AccessibilityNodeInfo instance
-        Long sourceNodeId = (Long) getField("mSourceNodeId", info);
-        Long windowId = (Long) getField("mWindowId", info);
-        if (sourceNodeId == 0 && windowId == 0) {
-            return UUID.randomUUID().toString();
-        }
-        String sourceNodeIdHex = String.format("%016x", sourceNodeId);
-        String windowIdHex = String.format("%016x", windowId);
-        return String.format("%s-%s-%s-%s-%s",
-                windowIdHex.substring(0, 8), windowIdHex.substring(8, 12), windowIdHex.substring(12, 16),
-                sourceNodeIdHex.substring(0, 4), sourceNodeIdHex.substring(4, 16));
-    }
-
     private static AndroidElement toAndroidElement(AccessibleUiObject element, boolean isSingleMatch,
                                                    @Nullable By by, @Nullable String contextId,
                                                    @Nullable String id) {
-        String cacheId = id == null ? axInfoToId(element.getInfo()) : id;
+        String cacheId = id == null ? AxNodeInfoHelper.toUuid(element.getInfo()) : id;
         if (element.getValue() instanceof UiObject2) {
             UiObject2Element result = new UiObject2Element(
                     (UiObject2) element.getValue(), isSingleMatch, by, contextId);

--- a/app/src/main/java/io/appium/uiautomator2/model/UiObjectElement.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/UiObjectElement.java
@@ -40,6 +40,8 @@ import io.appium.uiautomator2.utils.Logger;
 import io.appium.uiautomator2.utils.PositionHelper;
 
 import static io.appium.uiautomator2.core.AxNodeInfoExtractor.toAxNodeInfo;
+import static io.appium.uiautomator2.model.AccessibleUiObject.toAccessibleUiObject;
+import static io.appium.uiautomator2.model.AccessibleUiObject.toAccessibleUiObjects;
 import static io.appium.uiautomator2.utils.ElementHelpers.generateNoAttributeException;
 
 public class UiObjectElement extends BaseElement {
@@ -159,7 +161,7 @@ public class UiObjectElement extends BaseElement {
 
     @Nullable
     @Override
-    public Object getChild(final Object selector) throws UiObjectNotFoundException {
+    public AccessibleUiObject getChild(final Object selector) throws UiObjectNotFoundException {
         if (selector instanceof BySelector) {
             /*
              * We can't find the child element with BySelector on UiObject,
@@ -167,20 +169,19 @@ public class UiObjectElement extends BaseElement {
              * and finding the child element on UiObject2.
              */
             AccessibilityNodeInfo nodeInfo = toAxNodeInfo(element);
-            Object uiObject2 = CustomUiDevice.getInstance().findObject(nodeInfo);
-            return (uiObject2 instanceof UiObject2)
-                    ? ((UiObject2) uiObject2).findObject((BySelector) selector)
-                    : null;
-        }
-        UiObject result = element.getChild((UiSelector) selector);
-        if (result != null && !result.exists()) {
+            AccessibleUiObject root = CustomUiDevice.getInstance().findObject(nodeInfo);
+            if (root != null && root.getValue() instanceof UiObject2) {
+                UiObject2 child = ((UiObject2) root.getValue()).findObject((BySelector) selector);
+                return toAccessibleUiObject(child);
+            }
             return null;
         }
-        return result;
+        UiObject child = element.getChild((UiSelector) selector);
+        return toAccessibleUiObject(child);
     }
 
     @Override
-    public List<?> getChildren(final Object selector, final By by) throws UiObjectNotFoundException {
+    public List<AccessibleUiObject> getChildren(final Object selector, final By by) throws UiObjectNotFoundException {
         if (selector instanceof BySelector) {
             /*
              * We can't find the child elements with BySelector on UiObject,
@@ -188,19 +189,20 @@ public class UiObjectElement extends BaseElement {
              * and finding the child elements on UiObject2.
              */
             AccessibilityNodeInfo nodeInfo = toAxNodeInfo(element);
-            UiObject2 uiObject2 = (UiObject2) CustomUiDevice.getInstance().findObject(nodeInfo);
-            if (uiObject2 == null) {
+            AccessibleUiObject root = CustomUiDevice.getInstance().findObject(nodeInfo);
+            if (root == null || !(root.getValue() instanceof UiObject2)) {
                 throw new ElementNotFoundException();
             }
-            return uiObject2.findObjects((BySelector) selector);
+            List<UiObject2> children = ((UiObject2) root.getValue()).findObjects((BySelector) selector);
+            return toAccessibleUiObjects(children);
         }
         return this.getChildElements((UiSelector) selector);
     }
 
-    private ArrayList<UiObject> getChildElements(final UiSelector sel) throws UiObjectNotFoundException {
+    private ArrayList<AccessibleUiObject> getChildElements(final UiSelector sel) throws UiObjectNotFoundException {
         final String selectorString = sel.toString();
         Logger.debug("getElements selector:" + selectorString);
-        final ArrayList<UiObject> elements = new ArrayList<>();
+        final ArrayList<AccessibleUiObject> elements = new ArrayList<>();
         // If sel is UiSelector[CLASS=android.widget.Button, INSTANCE=0]
         // then invoking instance with a non-0 argument will corrupt the selector.
         //
@@ -211,19 +213,18 @@ public class UiObjectElement extends BaseElement {
         if (endsWithInstancePattern.matcher(selectorString).matches()) {
             Logger.debug("Selector ends with instance.");
             // There's exactly one element when using instance.
-            UiObject instanceObj = Device.getUiDevice().findObject(sel);
-            if (instanceObj != null && instanceObj.exists()) {
+            AccessibleUiObject instanceObj = toAccessibleUiObject(Device.getUiDevice().findObject(sel));
+            if (instanceObj != null) {
                 elements.add(instanceObj);
             }
             return elements;
         }
 
-        UiObject lastFoundObj;
+        AccessibleUiObject lastFoundObj;
         final boolean useIndex = selectorString.contains("CLASS_REGEX=");
         UiSelector tmp;
         int counter = 0;
-        boolean keepSearching = true;
-        while (keepSearching) {
+        do {
             if (element == null) {
                 Logger.debug("Element] is null: (" + counter + ")");
 
@@ -235,18 +236,17 @@ public class UiObjectElement extends BaseElement {
                 }
 
                 Logger.debug("getElements tmp selector:" + tmp.toString());
-                lastFoundObj = Device.getUiDevice().findObject(tmp);
+                lastFoundObj = toAccessibleUiObject(Device.getUiDevice().findObject(tmp));
             } else {
                 Logger.debug("Element is " + getId() + ", counter: " + counter);
-                lastFoundObj = element.getChild(sel.instance(counter));
+                lastFoundObj = toAccessibleUiObject(element.getChild(sel.instance(counter)));
             }
             counter++;
-            if (lastFoundObj != null && lastFoundObj.exists()) {
+
+            if (lastFoundObj != null) {
                 elements.add(lastFoundObj);
-            } else {
-                keepSearching = false;
             }
-        }
+        } while (lastFoundObj != null);
         return elements;
     }
 

--- a/app/src/main/java/io/appium/uiautomator2/utils/ElementHelpers.java
+++ b/app/src/main/java/io/appium/uiautomator2/utils/ElementHelpers.java
@@ -48,6 +48,7 @@ import io.appium.uiautomator2.core.EventRegister;
 import io.appium.uiautomator2.core.ReturningRunnable;
 import io.appium.uiautomator2.core.UiObjectChildGenerator;
 import io.appium.uiautomator2.model.AccessibilityScrollData;
+import io.appium.uiautomator2.model.AccessibleUiObject;
 import io.appium.uiautomator2.model.AndroidElement;
 import io.appium.uiautomator2.model.AppiumUIA2Driver;
 import io.appium.uiautomator2.model.Session;
@@ -114,12 +115,12 @@ public abstract class ElementHelpers {
     }
 
     public static AndroidElement findElement(final BySelector ui2BySelector) {
-        Object ui2Object = getInstance().findObject(ui2BySelector);
-        if (ui2Object == null) {
+        AccessibleUiObject accessibleUiObject = getInstance().findObject(ui2BySelector);
+        if (accessibleUiObject == null) {
             throw new ElementNotFoundException();
         }
         Session session = AppiumUIA2Driver.getInstance().getSessionOrThrow();
-        return session.getElementsCache().add(ui2Object, true);
+        return session.getElementsCache().add(accessibleUiObject, true);
     }
 
     public static NoSuchAttributeException generateNoAttributeException(@Nullable String attributeName) {


### PR DESCRIPTION
the idea behind this PR is that each located element is backed up by a particular AccessibilityNodeInfo instance with `mSourceNodeId` and `mWindowId` properties, which define the uniqueness of each element. So, instead of assigning random UUID to each newly located element we are trying to be smart instead and calculate the cache identifier value based on the actual property values. This guarantees that equal accessibility elements would have equal cache identifiers.