### PR TITLE
fix: Active element should be a GET not a POST

### DIFF
--- a/app/src/main/java/io/appium/uiautomator2/server/AppiumServlet.java
+++ b/app/src/main/java/io/appium/uiautomator2/server/AppiumServlet.java
@@ -117,7 +117,6 @@ public class AppiumServlet implements IHttpServlet {
     private void registerPostHandler() {
         register(postHandler, new NewSession("/wd/hub/session"));
         register(postHandler, new FindElement("/wd/hub/session/:sessionId/element"));
-        register(postHandler, new ActiveElement("/wd/hub/session/:sessionId/element/active"));
         register(postHandler, new FindElements("/wd/hub/session/:sessionId/elements"));
         register(postHandler, new Click("/wd/hub/session/:sessionId/element/:id/click"));
         register(postHandler, new Tap("/wd/hub/session/:sessionId/appium/tap"));
@@ -170,6 +169,7 @@ public class AppiumServlet implements IHttpServlet {
         register(getHandler, new GetRect("/wd/hub/session/:sessionId/element/:id/rect"));
         register(getHandler, new GetSize("/wd/hub/session/:sessionId/element/:id/size"));
         register(getHandler, new GetName("/wd/hub/session/:sessionId/element/:id/name"));
+        register(getHandler, new ActiveElement("/wd/hub/session/:sessionId/element/active"));
         // W3C endpoint
         register(getHandler, new GetElementScreenshot("/wd/hub/session/:sessionId/element/:id/screenshot"));
         // JSONWP endpoint


### PR DESCRIPTION
Per the _WebDriver_ protocol spec, get active element should be a `GET` not a `POST` (https://www.w3.org/TR/webdriver/#dfn-get-active-element). This change-set corrects a recently merged change.

As a future task we will submit a PR to deprecate the `POST` version of `/active` if it still exists on _XCUITest_ and add the `GET` variant.