### PR TITLE
chore: skip idle checks while retrieving cached node from uiobject2

### DIFF
--- a/app/src/main/java/io/appium/uiautomator2/core/AxNodeInfoExtractor.java
+++ b/app/src/main/java/io/appium/uiautomator2/core/AxNodeInfoExtractor.java
@@ -26,6 +26,7 @@ import androidx.test.uiautomator.UiObject2;
 
 import io.appium.uiautomator2.common.exceptions.StaleElementReferenceException;
 
+import static io.appium.uiautomator2.utils.ReflectionUtils.getField;
 import static io.appium.uiautomator2.utils.ReflectionUtils.getMethod;
 import static io.appium.uiautomator2.utils.ReflectionUtils.invoke;
 
@@ -36,6 +37,13 @@ public abstract class AxNodeInfoExtractor {
         return extractAxNodeInfo(object);
     }
 
+    @Nullable
+    public static AccessibilityNodeInfo toNullableAxNodeInfo(UiObject2 object, boolean checkStaleness) {
+        return checkStaleness
+                ? extractAxNodeInfo(object)
+                : extractAxNodeInfoWithoutStalenessCheck(object);
+    }
+
     @NonNull
     public static AccessibilityNodeInfo toAxNodeInfo(Object object) {
         AccessibilityNodeInfo result = extractAxNodeInfo(object);
@@ -43,6 +51,10 @@ public abstract class AxNodeInfoExtractor {
             throw new StaleElementReferenceException();
         }
         return result;
+    }
+
+    private static AccessibilityNodeInfo extractAxNodeInfoWithoutStalenessCheck(UiObject2 object) {
+        return (AccessibilityNodeInfo) getField("mCachedNode", object);
     }
 
     @Nullable

--- a/app/src/main/java/io/appium/uiautomator2/core/AxNodeInfoExtractor.java
+++ b/app/src/main/java/io/appium/uiautomator2/core/AxNodeInfoExtractor.java
@@ -41,7 +41,7 @@ public abstract class AxNodeInfoExtractor {
     public static AccessibilityNodeInfo toNullableAxNodeInfo(UiObject2 object, boolean checkStaleness) {
         return checkStaleness
                 ? extractAxNodeInfo(object)
-                : extractAxNodeInfoWithoutStalenessCheck(object);
+                : (AccessibilityNodeInfo) getField("mCachedNode", object);
     }
 
     @NonNull
@@ -51,10 +51,6 @@ public abstract class AxNodeInfoExtractor {
             throw new StaleElementReferenceException();
         }
         return result;
-    }
-
-    private static AccessibilityNodeInfo extractAxNodeInfoWithoutStalenessCheck(UiObject2 object) {
-        return (AccessibilityNodeInfo) getField("mCachedNode", object);
     }
 
     @Nullable

--- a/app/src/main/java/io/appium/uiautomator2/handler/FirstVisibleView.java
+++ b/app/src/main/java/io/appium/uiautomator2/handler/FirstVisibleView.java
@@ -16,8 +16,6 @@
 
 package io.appium.uiautomator2.handler;
 
-import android.view.accessibility.AccessibilityNodeInfo;
-
 import androidx.test.uiautomator.UiObject;
 import androidx.test.uiautomator.UiObject2;
 import androidx.test.uiautomator.UiObjectNotFoundException;
@@ -26,7 +24,6 @@ import androidx.test.uiautomator.UiSelector;
 import java.util.List;
 
 import io.appium.uiautomator2.common.exceptions.ElementNotFoundException;
-import io.appium.uiautomator2.common.exceptions.UiAutomator2Exception;
 import io.appium.uiautomator2.handler.request.SafeRequestHandler;
 import io.appium.uiautomator2.http.AppiumResponse;
 import io.appium.uiautomator2.http.IHttpRequest;
@@ -74,13 +71,9 @@ public class FirstVisibleView extends SafeRequestHandler {
                 throw new UiObjectNotFoundException("Could not get children for container object");
             }
             for (UiObject2 childObject : childObjects) {
-                try {
-                    AccessibilityNodeInfo info = toNullableAxNodeInfo(childObject);
-                    if (info != null) {
-                        firstObject = new AccessibleUiObject(childObject, info);
-                        break;
-                    }
-                } catch (UiAutomator2Exception ignored) {
+                firstObject = toAccessibleUiObject(childObject);
+                if (firstObject != null) {
+                    break;
                 }
             }
         }

--- a/app/src/main/java/io/appium/uiautomator2/model/AccessibleUiObject.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/AccessibleUiObject.java
@@ -64,15 +64,16 @@ public class AccessibleUiObject {
     public static List<AccessibleUiObject> toAccessibleUiObjects(List<?> uiObjects) {
         List<AccessibleUiObject> result = new ArrayList<>();
         for (Object obj: uiObjects) {
-            AccessibilityNodeInfo info = toNullableAxNodeInfo(obj);
-            if (info == null) {
-                continue;
-            }
-
             if (obj instanceof UiObject) {
-                result.add(new AccessibleUiObject((UiObject) obj, info));
+                AccessibilityNodeInfo info = toNullableAxNodeInfo(obj);
+                if (info != null) {
+                    result.add(new AccessibleUiObject((UiObject) obj, info));
+                }
             } else if (obj instanceof UiObject2) {
-                result.add(new AccessibleUiObject((UiObject2) obj, info));
+                AccessibilityNodeInfo info = toNullableAxNodeInfo((UiObject2) obj, false);
+                if (info != null) {
+                    result.add(new AccessibleUiObject((UiObject2) obj, info));
+                }
             }
         }
         return result;
@@ -83,7 +84,7 @@ public class AccessibleUiObject {
         if (uiObject2 == null) {
             return null;
         }
-        AccessibilityNodeInfo info = toNullableAxNodeInfo(uiObject2);
+        AccessibilityNodeInfo info = toNullableAxNodeInfo(uiObject2, false);
         return info == null ? null : new AccessibleUiObject(uiObject2, info);
     }
 }


### PR DESCRIPTION
The `getAccessibilityNodeInfo` method of UiObject2 contains calls for `getDevice().waitForIdle()` and `mCachedNode.refresh()`, which are redundant for the case when we want to extract the cached node from a just created UiObject2 instance (and also may affect performance in some cases).