### PR TITLE
Changing uiautomator to use decoration-less screen info

### DIFF
--- a/app/src/main/java/io/appium/uiautomator2/handler/GetDeviceSize.java
+++ b/app/src/main/java/io/appium/uiautomator2/handler/GetDeviceSize.java
@@ -37,8 +37,8 @@ public class GetDeviceSize extends SafeRequestHandler {
     protected AppiumResponse safeHandle(IHttpRequest request) {
         Logger.info("Get window size of the device");
         return new AppiumResponse(getSessionId(request), new SizeModel(
-                getUiDevice().getDisplayWidth(),
-                getUiDevice().getDisplayHeight()
+                getUiDevice().getDisplaySizeDp().x,
+                getUiDevice().getDisplaySizeDp().y
         ));
     }
 }


### PR DESCRIPTION
https://developer.android.com/reference/android/support/test/uiautomator/UiDevice#getDisplaySizeDp()

Changing the result to use the display size independent of decorations to allow tapping on elements in fullscreen contexts that would normally be covered by decorations