### PR TITLE
Changing functionality to reflect decorationless sizes

### DIFF
--- a/app/src/main/java/io/appium/uiautomator2/utils/PositionHelper.java
+++ b/app/src/main/java/io/appium/uiautomator2/utils/PositionHelper.java
@@ -68,7 +68,8 @@ public abstract class PositionHelper {
 
     public static Point getDeviceAbsPos(final Point point) {
         final UiDevice d = UiDevice.getInstance(getInstrumentation());
-        final Rect displayRect = new Rect(0, 0, d.getDisplayWidth(), d.getDisplayHeight());
+        final android.graphics.Point location = d.getDisplaySizeDp();
+        final Rect displayRect = new Rect(0, 0, location.x, location.y);
         Logger.debug("Display bounds: " + displayRect.toShortString());
         return getAbsolutePosition(point, displayRect, ZERO_POINT, true);
     }


### PR DESCRIPTION
Testing these changes with the github PR automated testing, the goal of this is to allow the device to gather the device bounds in contexts where the device bounds are desired, instead of including decorations