### PR TITLE
fix: Do not throw an exception if point coordinates are outside of the calculated screen bounds

### DIFF
--- a/app/src/main/java/io/appium/uiautomator2/model/BaseElement.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/BaseElement.java
@@ -168,8 +168,7 @@ public abstract class BaseElement implements AndroidElement {
     @Override
     public Point getAbsolutePosition(final Point offset) {
         final Rect bounds = this.getBounds();
-        return PositionHelper.getAbsolutePosition(
-                new Point(bounds.left, bounds.top), bounds, offset, false);
+        return PositionHelper.getAbsolutePosition(new Point(bounds.left, bounds.top), bounds, offset);
     }
 
     @Override

--- a/app/src/main/java/io/appium/uiautomator2/utils/PositionHelper.java
+++ b/app/src/main/java/io/appium/uiautomator2/utils/PositionHelper.java
@@ -20,7 +20,6 @@ import android.graphics.Rect;
 
 import androidx.test.uiautomator.UiDevice;
 
-import io.appium.uiautomator2.common.exceptions.InvalidCoordinatesException;
 import io.appium.uiautomator2.model.Point;
 
 import static androidx.test.platform.app.InstrumentationRegistry.getInstrumentation;
@@ -50,18 +49,17 @@ public abstract class PositionHelper {
      * @param displayRect       The display rectangle to which the point is relative.
      * @param offsets           X and Y values by which to offset the point. These are typically the
      *                          absolute coordinates of the display rectangle.
-     * @param shouldCheckBounds Throw if the translated point is outside displayRect?
      */
-    public static Point getAbsolutePosition(final Point point, final Rect displayRect,
-                                            final Point offsets, final boolean shouldCheckBounds) {
+    public static Point getAbsolutePosition(Point point, Rect displayRect, Point offsets) {
         final Point absolutePosition = new Point(
                 translateCoordinate(point.x, displayRect.width(), offsets.x),
                 translateCoordinate(point.y, displayRect.height(), offsets.y)
         );
-        if (shouldCheckBounds &&
-                !displayRect.contains(absolutePosition.x.intValue(), absolutePosition.y.intValue())) {
-            throw new InvalidCoordinatesException("Coordinate " + absolutePosition.toString() +
-                    " is outside of element rect: " + displayRect.toShortString());
+        if (!displayRect.contains(absolutePosition.x.intValue(), absolutePosition.y.intValue())) {
+            Logger.warn(String.format(
+                    "Coordinate %s is outside of the display rect %s. Continuing anyway",
+                    absolutePosition, displayRect.toShortString())
+            );
         }
         return absolutePosition;
     }
@@ -70,6 +68,6 @@ public abstract class PositionHelper {
         final UiDevice d = UiDevice.getInstance(getInstrumentation());
         final Rect displayRect = new Rect(0, 0, d.getDisplayWidth(), d.getDisplayHeight());
         Logger.debug("Display bounds: " + displayRect.toShortString());
-        return getAbsolutePosition(point, displayRect, ZERO_POINT, true);
+        return getAbsolutePosition(point, displayRect, ZERO_POINT);
     }
 }

--- a/app/src/test/java/io/appium/uiautomator2/utils/PositionHelperTests.java
+++ b/app/src/test/java/io/appium/uiautomator2/utils/PositionHelperTests.java
@@ -5,7 +5,6 @@ import android.graphics.Rect;
 import org.junit.Test;
 import org.mockito.Mockito;
 
-import io.appium.uiautomator2.common.exceptions.InvalidCoordinatesException;
 import io.appium.uiautomator2.model.Point;
 
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -14,7 +13,7 @@ import static org.junit.Assert.assertThat;
 public class PositionHelperTests {
 
     @Test
-    public void zeroPointAndOffsets() throws InvalidCoordinatesException {
+    public void zeroPointAndOffsets() {
         Point zeroPoint = new Point();
         Point zeroOffset = new Point();
 
@@ -22,14 +21,14 @@ public class PositionHelperTests {
         Mockito.when(zeroRect.width()).thenReturn(0);
         Mockito.when(zeroRect.height()).thenReturn(0);
 
-        Point actualPoint = PositionHelper.getAbsolutePosition(zeroPoint, zeroRect, zeroOffset, false);
+        Point actualPoint = PositionHelper.getAbsolutePosition(zeroPoint, zeroRect, zeroOffset);
 
         assertThat(actualPoint.x, equalTo(0.0));
         assertThat(actualPoint.y, equalTo(0.0));
     }
 
     @Test
-    public void zeroOnePointAndOneZeroOffsets() throws InvalidCoordinatesException {
+    public void zeroOnePointAndOneZeroOffsets() {
         Point onePoint = new Point(0, 1);
         Point oneOffset = new Point(1, 0);
 
@@ -37,14 +36,14 @@ public class PositionHelperTests {
         Mockito.when(zeroRect.width()).thenReturn(0);
         Mockito.when(zeroRect.height()).thenReturn(0);
 
-        Point actualPoint = PositionHelper.getAbsolutePosition(onePoint, zeroRect, oneOffset, false);
+        Point actualPoint = PositionHelper.getAbsolutePosition(onePoint, zeroRect, oneOffset);
 
         assertThat(actualPoint.x, equalTo(1.0));
         assertThat(actualPoint.y, equalTo(1.0));
     }
 
     @Test
-    public void zeroPointAndOffsetsWithOneRect() throws InvalidCoordinatesException {
+    public void zeroPointAndOffsetsWithOneRect() {
         Point onePoint = new Point(0, 1);
         Point oneOffset = new Point(1, 0);
 
@@ -52,14 +51,14 @@ public class PositionHelperTests {
         Mockito.when(oneRect.width()).thenReturn(1);
         Mockito.when(oneRect.height()).thenReturn(0);
 
-        Point actualPoint = PositionHelper.getAbsolutePosition(onePoint, oneRect, oneOffset, false);
+        Point actualPoint = PositionHelper.getAbsolutePosition(onePoint, oneRect, oneOffset);
 
         assertThat(actualPoint.x, equalTo(1.0));
         assertThat(actualPoint.y, equalTo(1.0));
     }
 
     @Test
-    public void zeroOnePointAndOneZeroOffsetsWithOneRect() throws InvalidCoordinatesException {
+    public void zeroOnePointAndOneZeroOffsetsWithOneRect() {
         Point onePoint = new Point(0, 1);
         Point oneOffset = new Point(1, 0);
 
@@ -67,22 +66,9 @@ public class PositionHelperTests {
         Mockito.when(oneRect.width()).thenReturn(1);
         Mockito.when(oneRect.height()).thenReturn(1);
 
-        Point actualPoint = PositionHelper.getAbsolutePosition(onePoint, oneRect, oneOffset, false);
+        Point actualPoint = PositionHelper.getAbsolutePosition(onePoint, oneRect, oneOffset);
 
         assertThat(actualPoint.x, equalTo(1.0));
         assertThat(actualPoint.y, equalTo(1.0));
-    }
-
-
-    @Test(expected = InvalidCoordinatesException.class)
-    public void onePointOverRect() throws InvalidCoordinatesException {
-        Point onePoint = new Point(1, 1);
-        Point oneOffset = new Point(1, 1);
-
-        Rect zeroRect = Mockito.mock(Rect.class);
-        Mockito.when(zeroRect.width()).thenReturn(0);
-        Mockito.when(zeroRect.height()).thenReturn(0);
-
-        PositionHelper.getAbsolutePosition(onePoint, zeroRect, oneOffset, true);
     }
 }


### PR DESCRIPTION
The PR has the same idea as https://github.com/appium/appium-uiautomator2-server/pull/435

Basically, we are not trying to outsmart anyone and let a user provide whatever coordinates they want to without throwing any exceptions. If then the resulting action works, - everything is fine, and if not, - 🤷 