### PR TITLE
chore: Use getTargetContext where possible

### DIFF
--- a/app/src/main/java/io/appium/uiautomator2/handler/GetSystemBars.java
+++ b/app/src/main/java/io/appium/uiautomator2/handler/GetSystemBars.java
@@ -37,7 +37,7 @@ public class GetSystemBars extends SafeRequestHandler {
     }
 
     private static int getStatusBarHeight() {
-        Resources resources = getInstrumentation().getContext().getResources();
+        Resources resources = getInstrumentation().getTargetContext().getResources();
         int resourceId = resources.getIdentifier("status_bar_height", "dimen", "android");
         return resourceId > 0 ? resources.getDimensionPixelSize(resourceId) : 0;
     }

--- a/app/src/main/java/io/appium/uiautomator2/model/ScreenOrientation.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/ScreenOrientation.java
@@ -16,10 +16,9 @@
 
 package io.appium.uiautomator2.model;
 
-import androidx.test.platform.app.InstrumentationRegistry;
-
 import static android.content.res.Configuration.ORIENTATION_LANDSCAPE;
 import static android.content.res.Configuration.ORIENTATION_PORTRAIT;
+import static androidx.test.platform.app.InstrumentationRegistry.getInstrumentation;
 
 public enum ScreenOrientation {
     LANDSCAPE, PORTRAIT;
@@ -48,7 +47,7 @@ public enum ScreenOrientation {
     }
 
     private static int asInteger() {
-        return InstrumentationRegistry.getInstrumentation()
-                .getContext().getResources().getConfiguration().orientation;
+        return getInstrumentation().getTargetContext()
+                .getResources().getConfiguration().orientation;
     }
 }

--- a/app/src/main/java/io/appium/uiautomator2/model/internal/GestureController.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/internal/GestureController.java
@@ -16,13 +16,14 @@
 
 package io.appium.uiautomator2.model.internal;
 
+import static androidx.test.platform.app.InstrumentationRegistry.getInstrumentation;
+
 import android.graphics.Point;
 import android.graphics.Rect;
 import android.os.SystemClock;
 import android.view.ViewConfiguration;
 
 import androidx.annotation.Nullable;
-import androidx.test.platform.app.InstrumentationRegistry;
 import androidx.test.uiautomator.Direction;
 import androidx.test.uiautomator.EventCondition;
 import androidx.test.uiautomator.UiDevice;
@@ -65,7 +66,7 @@ public class GestureController {
     }
 
     private static UiDevice getDevice() {
-        return UiDevice.getInstance(InstrumentationRegistry.getInstrumentation());
+        return UiDevice.getInstance(getInstrumentation());
     }
 
     private class GestureRunnable implements Runnable {
@@ -161,7 +162,7 @@ public class GestureController {
     }
 
     public boolean fling(Rect area, Direction direction, @Nullable Integer speed) {
-        ViewConfiguration vc = ViewConfiguration.get(InstrumentationRegistry.getInstrumentation().getContext());
+        ViewConfiguration vc = ViewConfiguration.get(getInstrumentation().getTargetContext());
         int minVelocity = vc.getScaledMinimumFlingVelocity();
         int flingSpeed = speed == null ? Gestures.getDefaultFlingSpeed() : speed;
         if (flingSpeed < minVelocity) {

--- a/app/src/main/java/io/appium/uiautomator2/model/internal/Gestures.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/internal/Gestures.java
@@ -16,6 +16,8 @@
 
 package io.appium.uiautomator2.model.internal;
 
+import static androidx.test.platform.app.InstrumentationRegistry.getInstrumentation;
+
 import android.graphics.Point;
 import android.graphics.Rect;
 
@@ -72,8 +74,7 @@ public class Gestures {
     }
 
     public static float getDisplayDensity() {
-        return InstrumentationRegistry.getInstrumentation().getContext()
-                .getResources().getDisplayMetrics().density;
+        return getInstrumentation().getTargetContext().getResources().getDisplayMetrics().density;
     }
 
     private static int getSpeedValue(String gestureName) {

--- a/app/src/main/java/io/appium/uiautomator2/utils/Device.java
+++ b/app/src/main/java/io/appium/uiautomator2/utils/Device.java
@@ -16,8 +16,9 @@
 
 package io.appium.uiautomator2.utils;
 
+import static androidx.test.platform.app.InstrumentationRegistry.getInstrumentation;
+
 import androidx.annotation.Nullable;
-import androidx.test.platform.app.InstrumentationRegistry;
 import androidx.test.uiautomator.UiDevice;
 import androidx.test.uiautomator.UiObjectNotFoundException;
 import androidx.test.uiautomator.UiScrollable;
@@ -30,7 +31,7 @@ import io.appium.uiautomator2.model.settings.WaitForIdleTimeout;
 
 public abstract class Device {
     public static UiDevice getUiDevice() {
-        return UiDevice.getInstance(InstrumentationRegistry.getInstrumentation());
+        return UiDevice.getInstance(getInstrumentation());
     }
 
     public static void scrollToElement(@Nullable UiScrollable origin, UiSelector selector,


### PR DESCRIPTION
It turns out newer Android APIs might throw IllegalAccess exception if getContext() instrumentation method is called on the instrumentation instance. Replacing it with getTargetContext() resolves the issue.