### PR TITLE
feat: Add a setting to disable id locators autocompletion

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         maven { url 'https://jitpack.io' }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.0.4'
+        classpath 'com.android.tools.build:gradle:7.1.2'
         classpath 'com.github.bjoernq:unmockplugin:0.7.9'
     }
 }
@@ -41,9 +41,6 @@ android {
         }
     }
     flavorDimensions 'default'
-    lintOptions {
-        abortOnError false
-    }
     productFlavors {
         e2eTest {
             applicationId 'io.appium.uiautomator2.e2etest'
@@ -56,8 +53,12 @@ android {
         unitTests.returnDefaultValues = true
     }
     packagingOptions {
-        exclude 'META-INF/maven/com.google.guava/guava/pom.properties'
-        exclude 'META-INF/maven/com.google.guava/guava/pom.xml'
+        resources {
+            excludes += ['META-INF/maven/com.google.guava/guava/pom.properties', 'META-INF/maven/com.google.guava/guava/pom.xml']
+        }
+    }
+    lint {
+        abortOnError false
     }
 }
 

--- a/app/src/main/java/io/appium/uiautomator2/model/settings/DisableIdLocatorAutocompletion.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/settings/DisableIdLocatorAutocompletion.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.appium.uiautomator2.model.settings;
+
+public class DisableIdLocatorAutocompletion extends AbstractSetting<Boolean> {
+
+    private static final String SETTING_NAME = "disableIdLocatorAutocompletion";
+
+    private boolean disableIdLocatorAutocompletion = false;
+
+    public DisableIdLocatorAutocompletion() {
+        super(Boolean.class, SETTING_NAME);
+    }
+
+    @Override
+    public Boolean getValue() {
+        return disableIdLocatorAutocompletion;
+    }
+
+    @Override
+    protected void apply(Boolean value) {
+        this.disableIdLocatorAutocompletion = value;
+    }
+}

--- a/app/src/main/java/io/appium/uiautomator2/model/settings/Settings.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/settings/Settings.java
@@ -30,6 +30,7 @@ public enum Settings {
     WAIT_FOR_SELECTOR_TIMEOUT(new WaitForSelectorTimeout()),
     NORMALIZE_TAG_NAMES(new NormalizeTagNames()),
     ENFORCE_XPATH1(new EnforceXpath1()),
+    DISABLE_IDS_AUTOCOMPLETION(new DisableIdLocatorAutocompletion()),
     LIMIT_XPATH_CONTEXT_SCOPE(new LimitXpathContextScope()),
     SHUTDOWN_ON_POWER_DISCONNECT(new ShutdownOnPowerDisconnect()),
     SIMPLE_BOUNDS_CALCULATION(new SimpleBoundsCalculation()),

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         maven { url 'https://jitpack.io' }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.0.4'
+        classpath 'com.android.tools.build:gradle:7.1.2'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip


### PR DESCRIPTION
In general Android OS requires resource ids to be prefixed by package identifiers, so they are guaranteed to be unique. Some app frameworks don't follow this rule though. This new `disableIdLocatorAutocompletion` setting makes usage of id locators possible with apps built using these faulty frameworks. By default its value is `false`, which resembles the legacy behavior.