### PR TITLE
fix: Pass Uiautomator flags to all instances

### DIFF
--- a/app/src/main/java/io/appium/uiautomator2/model/internal/CustomUiDevice.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/internal/CustomUiDevice.java
@@ -90,8 +90,8 @@ public class CustomUiDevice {
     }
 
     public UiAutomation getUiAutomation() {
-        int flags = Configurator.getInstance().getUiAutomationFlags();
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+            int flags = Configurator.getInstance().getUiAutomationFlags();
             return getInstrumentation().getUiAutomation(flags);
         } else {
             return getInstrumentation().getUiAutomation();

--- a/app/src/main/java/io/appium/uiautomator2/model/internal/CustomUiDevice.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/internal/CustomUiDevice.java
@@ -93,9 +93,8 @@ public class CustomUiDevice {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
             int flags = Configurator.getInstance().getUiAutomationFlags();
             return getInstrumentation().getUiAutomation(flags);
-        } else {
-            return getInstrumentation().getUiAutomation();
         }
+        return getInstrumentation().getUiAutomation();
     }
 
     public int getApiLevelActual() {

--- a/app/src/main/java/io/appium/uiautomator2/model/internal/CustomUiDevice.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/internal/CustomUiDevice.java
@@ -17,6 +17,8 @@
 package io.appium.uiautomator2.model.internal;
 
 import android.app.Instrumentation;
+import android.app.UiAutomation;
+import android.os.Build;
 import android.os.SystemClock;
 import android.view.accessibility.AccessibilityNodeInfo;
 
@@ -26,6 +28,7 @@ import androidx.test.uiautomator.BySelector;
 import androidx.test.uiautomator.UiDevice;
 import androidx.test.uiautomator.UiObject2;
 import androidx.test.uiautomator.UiSelector;
+import androidx.test.uiautomator.Configurator;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
@@ -84,6 +87,16 @@ public class CustomUiDevice {
 
     public Instrumentation getInstrumentation() {
         return mInstrumentation;
+    }
+
+    public UiAutomation getUiAutomation() {
+        int flags = Configurator.getInstance().getUiAutomationFlags();
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N)
+        {
+            return getInstrumentation().getUiAutomation(flags);
+        } else {
+            return getInstrumentation().getUiAutomation();
+        }
     }
 
     public int getApiLevelActual() {
@@ -173,7 +186,7 @@ public class CustomUiDevice {
             return desired;
         }
 
-        getInstrumentation().getUiAutomation().setRotation(desired.ordinal());
+        getUiAutomation().setRotation(desired.ordinal());
         long start = System.currentTimeMillis();
         do {
             if (ScreenRotation.current() == desired) {

--- a/app/src/main/java/io/appium/uiautomator2/model/internal/CustomUiDevice.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/internal/CustomUiDevice.java
@@ -91,8 +91,7 @@ public class CustomUiDevice {
 
     public UiAutomation getUiAutomation() {
         int flags = Configurator.getInstance().getUiAutomationFlags();
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N)
-        {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
             return getInstrumentation().getUiAutomation(flags);
         } else {
             return getInstrumentation().getUiAutomation();

--- a/app/src/main/java/io/appium/uiautomator2/server/mjpeg/MjpegScreenshotStream.java
+++ b/app/src/main/java/io/appium/uiautomator2/server/mjpeg/MjpegScreenshotStream.java
@@ -40,7 +40,7 @@ public class MjpegScreenshotStream extends Thread {
     private static final int NO_CLIENTS_CONNECTED_SLEEP_TIME_MS = 500;
     private static final byte[] END = "\r\n\r\n".getBytes(UTF_8);
     private static final UiAutomation UI_AUTOMATION =
-        CustomUiDevice.getInstance().getInstrumentation().getUiAutomation();
+        CustomUiDevice.getInstance().getUiAutomation();
     private final List<MjpegScreenshotClient> clients;
     private boolean isStopped = false;
 

--- a/app/src/main/java/io/appium/uiautomator2/server/mjpeg/MjpegScreenshotStream.java
+++ b/app/src/main/java/io/appium/uiautomator2/server/mjpeg/MjpegScreenshotStream.java
@@ -39,7 +39,6 @@ public class MjpegScreenshotStream extends Thread {
         "Content-Length: %d\r\n\r\n";
     private static final int NO_CLIENTS_CONNECTED_SLEEP_TIME_MS = 500;
     private static final byte[] END = "\r\n\r\n".getBytes(UTF_8);
-    private static UiAutomation UI_AUTOMATION = null;
     private final List<MjpegScreenshotClient> clients;
     private boolean isStopped = false;
 
@@ -118,15 +117,8 @@ public class MjpegScreenshotStream extends Thread {
         }
     }
 
-    private static synchronized UiAutomation getUiAutomation() {
-        if (UI_AUTOMATION == null) {
-            UI_AUTOMATION = CustomUiDevice.getInstance().getUiAutomation();
-        }
-        return UI_AUTOMATION;
-    }
-
     private byte[] getScreenshot() {
-        Bitmap screenshot = getUiAutomation().takeScreenshot();
+        Bitmap screenshot = CustomUiDevice.getInstance().getUiAutomation().takeScreenshot();
         if (screenshot == null) {
             throw new TakeScreenshotException("Could not take screenshot: UiAutomation returned null");
         }

--- a/app/src/main/java/io/appium/uiautomator2/server/mjpeg/MjpegScreenshotStream.java
+++ b/app/src/main/java/io/appium/uiautomator2/server/mjpeg/MjpegScreenshotStream.java
@@ -39,8 +39,7 @@ public class MjpegScreenshotStream extends Thread {
         "Content-Length: %d\r\n\r\n";
     private static final int NO_CLIENTS_CONNECTED_SLEEP_TIME_MS = 500;
     private static final byte[] END = "\r\n\r\n".getBytes(UTF_8);
-    private static final UiAutomation UI_AUTOMATION =
-        CustomUiDevice.getInstance().getUiAutomation();
+    private static UiAutomation UI_AUTOMATION = null;
     private final List<MjpegScreenshotClient> clients;
     private boolean isStopped = false;
 
@@ -119,8 +118,15 @@ public class MjpegScreenshotStream extends Thread {
         }
     }
 
+    private static synchronized UiAutomation getUiAutomation() {
+        if (UI_AUTOMATION == null) {
+            UI_AUTOMATION = CustomUiDevice.getInstance().getUiAutomation();
+        }
+        return UI_AUTOMATION;
+    }
+
     private byte[] getScreenshot() {
-        Bitmap screenshot = UI_AUTOMATION.takeScreenshot();
+        Bitmap screenshot = getUiAutomation().takeScreenshot();
         if (screenshot == null) {
             throw new TakeScreenshotException("Could not take screenshot: UiAutomation returned null");
         }

--- a/app/src/main/java/io/appium/uiautomator2/utils/AXWindowHelpers.java
+++ b/app/src/main/java/io/appium/uiautomator2/utils/AXWindowHelpers.java
@@ -86,7 +86,6 @@ public class AXWindowHelpers {
     private static AccessibilityNodeInfo[] getWindowRoots() {
         List<AccessibilityNodeInfo> result = new ArrayList<>();
         List<AccessibilityWindowInfo> windows = CustomUiDevice.getInstance()
-                .getInstrumentation()
                 .getUiAutomation()
                 .getWindows();
         for (AccessibilityWindowInfo window : windows) {

--- a/app/src/main/java/io/appium/uiautomator2/utils/ScreenshotHelper.java
+++ b/app/src/main/java/io/appium/uiautomator2/utils/ScreenshotHelper.java
@@ -48,7 +48,7 @@ import static android.util.DisplayMetrics.DENSITY_DEFAULT;
 public class ScreenshotHelper {
     private static final int PNG_MAGIC_LENGTH = 8;
     private static final UiAutomation uia =
-        CustomUiDevice.getInstance().getInstrumentation().getUiAutomation();
+        CustomUiDevice.getInstance().getUiAutomation();
 
     /**
      * Grab device screenshot and crop it to specifyed area if cropArea is not null.

--- a/app/src/main/java/io/appium/uiautomator2/utils/ScreenshotHelper.java
+++ b/app/src/main/java/io/appium/uiautomator2/utils/ScreenshotHelper.java
@@ -47,8 +47,6 @@ import static android.util.DisplayMetrics.DENSITY_DEFAULT;
 
 public class ScreenshotHelper {
     private static final int PNG_MAGIC_LENGTH = 8;
-    private static final UiAutomation uia =
-        CustomUiDevice.getInstance().getUiAutomation();
 
     /**
      * Grab device screenshot and crop it to specifyed area if cropArea is not null.
@@ -86,6 +84,7 @@ public class ScreenshotHelper {
      */
     private static <T> T takeDeviceScreenshot(Class<T> outputType) throws TakeScreenshotException {
         Display display = UiAutomatorBridge.getInstance().getDefaultDisplay();
+        UiAutomation automation = CustomUiDevice.getInstance().getUiAutomation();
         DisplayMetrics metrics = new DisplayMetrics();
         display.getMetrics(metrics);
         Bitmap screenshot = null;
@@ -94,7 +93,7 @@ public class ScreenshotHelper {
         // executeShellCommand seems to be faulty on Android 5
         if (metrics.densityDpi != DENSITY_DEFAULT && Build.VERSION.SDK_INT > Build.VERSION_CODES.LOLLIPOP_MR1) {
             try {
-                ParcelFileDescriptor pfd = uia.executeShellCommand("screencap -p");
+                ParcelFileDescriptor pfd = automation.executeShellCommand("screencap -p");
                 try (InputStream is = new FileInputStream(pfd.getFileDescriptor())) {
                     byte[] pngBytes = IOUtils.toByteArray(is);
                     if (pngBytes.length <= PNG_MAGIC_LENGTH) {
@@ -122,7 +121,7 @@ public class ScreenshotHelper {
         }
 
         if (screenshot == null) {
-            screenshot = uia.takeScreenshot();
+            screenshot = automation.takeScreenshot();
         }
 
         if (screenshot == null || screenshot.getWidth() == 0 || screenshot.getHeight() == 0) {


### PR DESCRIPTION
Related to https://github.com/appium/appium-uiautomator2-server/issues/462

As a part of https://github.com/appium/appium-uiautomator2-server/pull/289 appium started supporting [FLAG_DONT_SUPPRESS_ACCESSIBILITY_SERVICES](https://developer.android.com/reference/android/app/UiAutomation#FLAG_DONT_SUPPRESS_ACCESSIBILITY_SERVICES)

In order to do so the Configurator instance is initialised here 
https://github.com/appium/appium-uiautomator2-server/blob/d3cd4a3baa4209d02afcdd2fc0007717890bf138/app/src/main/java/io/appium/uiautomator2/server/ServerInstrumentation.java#L69-L70

While this configurator comes into affect whenever uiautomation instance is used from UiAutomatorBridge
https://github.com/appium/appium-uiautomator2-server/blob/700eefebb75f8c7e2d3d1feac3b6d0d13e8b339d/app/src/main/java/io/appium/uiautomator2/core/UiAutomatorBridge.java#L52

But there are several instances where fresh instances of uiautomator are initialized using `CustomUiDevice` like
https://github.com/appium/appium-uiautomator2-server/blob/700eefebb75f8c7e2d3d1feac3b6d0d13e8b339d/app/src/main/java/io/appium/uiautomator2/utils/AXWindowHelpers.java#L88-L91

Since in this cases a new instance of uiautomator is created directly from `Instrumentation`. The instance the doesn't read the flags from configurator and initializes with default flags, which would be `FLAG_DONT_SUPPRESS_ACCESSIBILITY_SERVICES` as false thus stopping all accessibility services created and starts behaving in a weird manner.

As a part of this PR, creating a custom `getUiAutomation` method in `CustomUiDevice` which before instantiating the uiautomator checks the configurator flags, and use that method at all the places were it was previously being used.

