### PR TITLE
Remove restriction of PointerDown before PointerUp

### DIFF
--- a/app/src/main/java/io/appium/uiautomator2/utils/w3c/ActionsTokenizer.java
+++ b/app/src/main/java/io/appium/uiautomator2/utils/w3c/ActionsTokenizer.java
@@ -403,11 +403,8 @@ public class ActionsTokenizer {
                 }
                 break;
                 case ACTION_ITEM_TYPE_POINTER_UP: {
-                    if (!isPointerDown) {
-                        throw new ActionsParseException(String.format(
-                                "You cannot perform '%s' action without performing '%s' first at " +
-                                        "%sms in '%s' chain", gesture.type, ACTION_ITEM_TYPE_POINTER_DOWN, timeDelta, actionId));
-                    }
+                    // Due to issue #470, removed restriction to demand PointerDown before PointerUp
+
                     if (recentUpDelta == timeDelta) {
                         throw new ActionsParseException(String.format(
                                 "You cannot perform two or more '%s' actions without a pause between them at " +


### PR DESCRIPTION
- To enable long press functionality without any
  preset timeouts, it is now possible to trigger PointerDown
  in one ActionChain, do stuff in between and release the
  button using PointerUp in other ActionChain.

- Example usage with python:

  from appium import webdriver
  from selenium.webdriver.common.action_chains import ActionChains

  ActionChains(driver1).click_and_hold(ptt_button).perform()
  print ("Free to do stuff here!!")
  ActionChains(driver1).release(ptt_button).perform()