### PR TITLE
chore: remove android.permission.WRITE_EXTERNAL_STORAGE

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,7 +3,6 @@
 
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.INTERNET" />
-    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.WAKE_LOCK" />
     <uses-permission android:name="android.permission.CHANGE_WIFI_STATE" />
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,6 +1,13 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
           xmlns:tools="http://schemas.android.com/tools" package="io.appium.uiautomator2.test">
 
+    <!-- Note:
+    android.permission.WRITE_EXTERNAL_STORAGE and android.permission.READ_EXTERNAL_STORAGE
+    could cause the server process is killed since Android 6 as permission changes.
+    We should avoid using them as possible to prevent the behavior.
+    https://github.com/appium/appium/issues/17679
+    -->
+
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.WAKE_LOCK" />


### PR DESCRIPTION
Afaik, this external storage permission existed from the beginning. Espresso driver does not have this, so potentially can uia2 server also remove this...? This may needed something old devices such as SD card required one to save data...?

I tested with this change in ruby_lib_core's test cases locally, including push/pull files and screenshot stuff, but no error occurred related to this permission.

(This is not https://github.com/appium/appium/issues/17679 's fix. I just thought this permission's necessity)


updated:

Perhaps.... push to SD card storage area may require this...? <- push/pull is basically via adb, so maybe not needed for the permission


> In particular, if your app targets Android 11 (API level 30) or higher, the WRITE_EXTERNAL_STORAGE permission doesn't have any effect on your app's access to storage.

https://developer.android.com/training/data-storage
Current `targetSdkVersion` is 30, so the permission no longer have effort anyway...?