### PR TITLE
chore: refresh accessibility cache before searching active element

### DIFF
--- a/app/src/main/java/io/appium/uiautomator2/handler/ActiveElement.java
+++ b/app/src/main/java/io/appium/uiautomator2/handler/ActiveElement.java
@@ -29,6 +29,8 @@ import io.appium.uiautomator2.model.AppiumUIA2Driver;
 import io.appium.uiautomator2.model.Session;
 import io.appium.uiautomator2.model.internal.CustomUiDevice;
 
+import static io.appium.uiautomator2.utils.AXWindowHelpers.refreshAccessibilityCache;
+
 public class ActiveElement extends SafeRequestHandler {
 
     public ActiveElement(String mappedUri) {
@@ -51,6 +53,8 @@ public class ActiveElement extends SafeRequestHandler {
 
     @Nullable
     private AccessibleUiObject findFocused() {
+        refreshAccessibilityCache();
+
         return CustomUiDevice.getInstance().findObject(androidx.test.uiautomator.By.focused(true));
     }
 }


### PR DESCRIPTION
hi team, thank you for taking a look.

Recently I faced an issue where Active Element command results in 404 error and found that issue has gone after I added PageSource command before invoking Active Element command. After reading the code, I found that can be caused by a stale accessibility cache.
In my case, I don't use FindElement(s) but Action command (pointerMove + pointerDown + pointerUp) to select the element. Looks like there is no chance to refresh the cache in such a case and ActiveElement cannot find a focused element if node information has been changed by that tap action.

Does it make sense to refresh the accessibility cache when finding the active element?