### PR TITLE
feat: settings API to get the topmost window from active package

### DIFF
--- a/app/src/main/java/io/appium/uiautomator2/model/settings/EnableTopmostWindowFromActivePackage.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/settings/EnableTopmostWindowFromActivePackage.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.appium.uiautomator2.model.settings;
+
+public class EnableTopmostWindowFromActivePackage extends AbstractSetting<Boolean> {
+    private static final String SETTING_NAME = "enableTopmostWindowFromActivePackage";
+    private static final boolean DEFAULT_VALUE = false;
+    private Boolean value = DEFAULT_VALUE;
+
+    public EnableTopmostWindowFromActivePackage() {
+        super(Boolean.class, SETTING_NAME);
+    }
+
+    @Override
+    public Boolean getValue() {
+        return value;
+    }
+
+    @Override
+    public Boolean getDefaultValue() {
+        return DEFAULT_VALUE;
+    }
+
+    @Override
+    protected void apply(Boolean topmostWindowFromActivePackageEnabled) {
+        value = topmostWindowFromActivePackageEnabled;
+    }
+}

--- a/app/src/main/java/io/appium/uiautomator2/model/settings/Settings.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/settings/Settings.java
@@ -23,6 +23,7 @@ public enum Settings {
     ELEMENT_RESPONSE_ATTRIBUTES(new ElementResponseAttributes()),
     ENABLE_MULTI_WINDOWS(new EnableMultiWindows()),
     ENABLE_NOTIFICATION_LISTENER(new EnableNotificationListener()),
+    ENABLE_TOPMOST_WINDOW_FROM_ACTIVE_PACKAGE(new EnableTopmostWindowFromActivePackage()),
     KEY_INJECTION_DELAY(new KeyInjectionDelay()),
     SCROLL_ACKNOWLEDGMENT_TIMEOUT(new ScrollAcknowledgmentTimeout()),
     SHOULD_USE_COMPACT_RESPONSES(new ShouldUseCompactResponses()),

--- a/app/src/main/java/io/appium/uiautomator2/utils/AXWindowHelpers.java
+++ b/app/src/main/java/io/appium/uiautomator2/utils/AXWindowHelpers.java
@@ -114,11 +114,8 @@ public class AXWindowHelpers {
                 .max(Comparator.comparing(AccessibilityWindowInfo::getLayer))
                 .map(AccessibilityWindowInfo::getRoot);
 
-        if (topmostWindowRootFromActivePackage.isPresent()) {
-            return topmostWindowRootFromActivePackage.get();
-        } else {
-            throw new UiAutomator2Exception("No active window root found");
-        }
+        return topmostWindowRootFromActivePackage
+                .orElseThrow(() -> new UiAutomator2Exception("No active window root found"));
     }
 
     public static AccessibilityNodeInfo[] getCachedWindowRoots() {

--- a/app/src/main/java/io/appium/uiautomator2/utils/AXWindowHelpers.java
+++ b/app/src/main/java/io/appium/uiautomator2/utils/AXWindowHelpers.java
@@ -112,7 +112,7 @@ public class AXWindowHelpers {
 
         return windows.stream()
                 .filter(window -> window.getRoot() != null)
-                .filter(window -> Objects.equals(window.getRoot().getPackageName().toString(), activeRootPackageName))
+                .filter(window -> Objects.equals(window.getRoot().getPackageName(), activeRootPackageName))
                 .max(Comparator.comparing(AccessibilityWindowInfo::getLayer))
                 .map(AccessibilityWindowInfo::getRoot)
                 .orElseThrow(() -> new UiAutomator2Exception("No active window root found"));

--- a/app/src/main/java/io/appium/uiautomator2/utils/AXWindowHelpers.java
+++ b/app/src/main/java/io/appium/uiautomator2/utils/AXWindowHelpers.java
@@ -27,6 +27,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 
+import static androidx.test.internal.util.Checks.checkNotNull;
 import io.appium.uiautomator2.common.exceptions.UiAutomator2Exception;
 import io.appium.uiautomator2.core.UiAutomatorBridge;
 import io.appium.uiautomator2.model.internal.CustomUiDevice;
@@ -106,7 +107,7 @@ public class AXWindowHelpers {
     }
 
     private static AccessibilityNodeInfo getTopmostWindowRootFromActivePackage() {
-        CharSequence activeRootPackageName = getActiveWindowRoot().getPackageName();
+        CharSequence activeRootPackageName = checkNotNull(getActiveWindowRoot().getPackageName());
         List<AccessibilityWindowInfo> windows = getWindows();
 
         return windows.stream()

--- a/app/src/main/java/io/appium/uiautomator2/utils/AXWindowHelpers.java
+++ b/app/src/main/java/io/appium/uiautomator2/utils/AXWindowHelpers.java
@@ -83,11 +83,13 @@ public class AXWindowHelpers {
                         "manager could do its work", SystemClock.uptimeMillis() - start));
     }
 
+    private static List<AccessibilityWindowInfo> getWindows() {
+        return CustomUiDevice.getInstance().getUiAutomation().getWindows();
+    }
+
     private static AccessibilityNodeInfo[] getWindowRoots() {
         List<AccessibilityNodeInfo> result = new ArrayList<>();
-        List<AccessibilityWindowInfo> windows = CustomUiDevice.getInstance()
-                .getUiAutomation()
-                .getWindows();
+        List<AccessibilityWindowInfo> windows = getWindows();
         for (AccessibilityWindowInfo window : windows) {
             AccessibilityNodeInfo root = window.getRoot();
             if (root == null) {

--- a/app/src/main/java/io/appium/uiautomator2/utils/AXWindowHelpers.java
+++ b/app/src/main/java/io/appium/uiautomator2/utils/AXWindowHelpers.java
@@ -108,9 +108,8 @@ public class AXWindowHelpers {
 
     private static AccessibilityNodeInfo getTopmostWindowRootFromActivePackage() {
         CharSequence activeRootPackageName = checkNotNull(getActiveWindowRoot().getPackageName());
-        List<AccessibilityWindowInfo> windows = getWindows();
 
-        return windows.stream()
+        return getWindows().stream()
                 .filter(window -> window.getRoot() != null)
                 .filter(window -> Objects.equals(window.getRoot().getPackageName(), activeRootPackageName))
                 .max(Comparator.comparing(AccessibilityWindowInfo::getLayer))

--- a/app/src/main/java/io/appium/uiautomator2/utils/AXWindowHelpers.java
+++ b/app/src/main/java/io/appium/uiautomator2/utils/AXWindowHelpers.java
@@ -24,6 +24,7 @@ import android.view.accessibility.AccessibilityWindowInfo;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 
 import io.appium.uiautomator2.common.exceptions.UiAutomator2Exception;
@@ -110,7 +111,7 @@ public class AXWindowHelpers {
 
         return windows.stream()
                 .filter(window -> window.getRoot() != null)
-                .filter(window -> window.getRoot().getPackageName().toString().contentEquals(activeRootPackageName))
+                .filter(window -> Objects.equals(window.getRoot().getPackageName().toString(), activeRootPackageName))
                 .max(Comparator.comparing(AccessibilityWindowInfo::getLayer))
                 .map(AccessibilityWindowInfo::getRoot)
                 .orElseThrow(() -> new UiAutomator2Exception("No active window root found"));

--- a/app/src/main/java/io/appium/uiautomator2/utils/AXWindowHelpers.java
+++ b/app/src/main/java/io/appium/uiautomator2/utils/AXWindowHelpers.java
@@ -108,13 +108,11 @@ public class AXWindowHelpers {
         CharSequence activeRootPackageName = getActiveWindowRoot().getPackageName();
         List<AccessibilityWindowInfo> windows = getWindows();
 
-        Optional<AccessibilityNodeInfo> topmostWindowRootFromActivePackage = windows.stream()
+        return windows.stream()
                 .filter(window -> window.getRoot() != null)
                 .filter(window -> window.getRoot().getPackageName().toString().contentEquals(activeRootPackageName))
                 .max(Comparator.comparing(AccessibilityWindowInfo::getLayer))
-                .map(AccessibilityWindowInfo::getRoot);
-
-        return topmostWindowRootFromActivePackage
+                .map(AccessibilityWindowInfo::getRoot)
                 .orElseThrow(() -> new UiAutomator2Exception("No active window root found"));
     }
 


### PR DESCRIPTION
## Motivation

This Pull Request presents a feature that enables the retrieval of a non-focusable window from the same package, positioned at a layer above the active window. Similar to #301.

This enhancement offers an additional advantage (especially when using XPath locators) in E2E tests. Unlike the `enableMultiWindows` setting, this new feature negates the need to consider the number of windows displayed at any given time, thereby improving test portability.

## What I change

- Implementation of a new strategy to identify and retrieve the topmost window among all windows corresponds to the active package.
- Addition of `enableTopmostWindowFromActivePackage` settings API to toggle this feature.
- By default, the feature is disabled, ensuring that existing functionalities remain unaffected unless the user explicitly enables it.

## What I checked

- A manual checked was carried out using [Appium Inspector](https://github.com/appium/appium-inspector) both when the option was enabled and disabled.
- All unit tests, as outlined in the `README.md`, were successfully executed.