### PR TITLE
feat: Add a possibility of scheduling and unscheduling actions

### DIFF
--- a/app/src/main/java/io/appium/uiautomator2/handler/DeleteSession.java
+++ b/app/src/main/java/io/appium/uiautomator2/handler/DeleteSession.java
@@ -26,6 +26,7 @@ import io.appium.uiautomator2.model.AppiumUIA2Driver;
 import io.appium.uiautomator2.model.NotificationListener;
 import io.appium.uiautomator2.model.Session;
 import io.appium.uiautomator2.server.ServerInstrumentation;
+import io.appium.uiautomator2.utils.actions_scheduler.ScheduledActionsManager;
 
 public class DeleteSession extends SafeRequestHandler {
 
@@ -40,6 +41,7 @@ public class DeleteSession extends SafeRequestHandler {
         if (currentSession == null || !Objects.equals(sessionId, currentSession.getSessionId())) {
             throw new NoSuchDriverException(String.format("The session %s cannot be found", sessionId));
         }
+        ScheduledActionsManager.getInstance().clear();
         NotificationListener.getInstance().stop();
         ServerInstrumentation.getInstance().stopServer();
         return new AppiumResponse(sessionId);

--- a/app/src/main/java/io/appium/uiautomator2/handler/FindElement.java
+++ b/app/src/main/java/io/appium/uiautomator2/handler/FindElement.java
@@ -16,11 +16,9 @@
 
 package io.appium.uiautomator2.handler;
 
-import androidx.annotation.Nullable;
 import androidx.test.uiautomator.UiObjectNotFoundException;
 
 import io.appium.uiautomator2.common.exceptions.ElementNotFoundException;
-import io.appium.uiautomator2.common.exceptions.NotImplementedException;
 import io.appium.uiautomator2.handler.request.SafeRequestHandler;
 import io.appium.uiautomator2.http.AppiumResponse;
 import io.appium.uiautomator2.http.IHttpRequest;
@@ -30,15 +28,10 @@ import io.appium.uiautomator2.model.AppiumUIA2Driver;
 import io.appium.uiautomator2.model.By;
 import io.appium.uiautomator2.model.ElementsCache;
 import io.appium.uiautomator2.model.api.FindElementModel;
-import io.appium.uiautomator2.model.internal.CustomUiDevice;
 import io.appium.uiautomator2.model.internal.ElementsLookupStrategy;
-import io.appium.uiautomator2.utils.ByUiAutomatorFinder;
 import io.appium.uiautomator2.utils.Logger;
-import io.appium.uiautomator2.utils.NodeInfoList;
 
-import static io.appium.uiautomator2.utils.AXWindowHelpers.refreshAccessibilityCache;
-import static io.appium.uiautomator2.utils.ElementLocationHelpers.getXPathNodeMatch;
-import static io.appium.uiautomator2.utils.ElementLocationHelpers.rewriteIdLocator;
+import static io.appium.uiautomator2.utils.ElementLocationHelpers.findElement;
 import static io.appium.uiautomator2.utils.ModelUtils.toModel;
 import static io.appium.uiautomator2.utils.StringHelpers.isBlank;
 
@@ -64,62 +57,12 @@ public class FindElement extends SafeRequestHandler {
         ElementsCache elementsCache = AppiumUIA2Driver.getInstance().getSessionOrThrow().getElementsCache();
         final By by = ElementsLookupStrategy.ofName(method).toNativeSelector(selector);
         final AccessibleUiObject element = contextId == null
-                ? this.findElement(by)
-                : this.findElement(by, elementsCache.get(contextId));
+                ? findElement(by)
+                : findElement(by, elementsCache.get(contextId));
         if (element == null) {
             throw new ElementNotFoundException();
         }
         AndroidElement androidElement = elementsCache.add(element, true, by, contextId);
         return new AppiumResponse(getSessionId(request), androidElement.toModel());
-    }
-
-    @Nullable
-    private AccessibleUiObject findElement(By by) throws UiObjectNotFoundException {
-        refreshAccessibilityCache();
-
-        if (by instanceof By.ById) {
-            String locator = rewriteIdLocator((By.ById) by);
-            return CustomUiDevice.getInstance().findObject(androidx.test.uiautomator.By.res(locator));
-        } else if (by instanceof By.ByAccessibilityId) {
-            return CustomUiDevice.getInstance().findObject(androidx.test.uiautomator.By.desc(by.getElementLocator()));
-        } else if (by instanceof By.ByClass) {
-            return CustomUiDevice.getInstance().findObject(androidx.test.uiautomator.By.clazz(by.getElementLocator()));
-        } else if (by instanceof By.ByXPath) {
-            final NodeInfoList matchedNodes = getXPathNodeMatch(by.getElementLocator(), null, false);
-            if (matchedNodes.isEmpty()) {
-                throw new ElementNotFoundException();
-            }
-            return CustomUiDevice.getInstance().findObject(matchedNodes);
-        } else if (by instanceof By.ByAndroidUiAutomator) {
-            return new ByUiAutomatorFinder().findOne((By.ByAndroidUiAutomator) by);
-        }
-
-        throw new NotImplementedException(
-                String.format("%s locator is not supported", by.getClass().getSimpleName())
-        );
-    }
-
-    @Nullable
-    private AccessibleUiObject findElement(By by, AndroidElement context) throws UiObjectNotFoundException {
-        if (by instanceof By.ById) {
-            String locator = rewriteIdLocator((By.ById) by);
-            return context.getChild(androidx.test.uiautomator.By.res(locator));
-        } else if (by instanceof By.ByAccessibilityId) {
-            return context.getChild(androidx.test.uiautomator.By.desc(by.getElementLocator()));
-        } else if (by instanceof By.ByClass) {
-            return context.getChild(androidx.test.uiautomator.By.clazz(by.getElementLocator()));
-        } else if (by instanceof By.ByXPath) {
-            final NodeInfoList matchedNodes = getXPathNodeMatch(by.getElementLocator(), context, false);
-            if (matchedNodes.isEmpty()) {
-                throw new ElementNotFoundException();
-            }
-            return CustomUiDevice.getInstance().findObject(matchedNodes);
-        } else if (by instanceof By.ByAndroidUiAutomator) {
-            return new ByUiAutomatorFinder().findOne((By.ByAndroidUiAutomator) by, context);
-        }
-
-        throw new NotImplementedException(
-                String.format("%s locator is not supported", by.getClass().getSimpleName())
-        );
     }
 }

--- a/app/src/main/java/io/appium/uiautomator2/handler/GetActionHistory.java
+++ b/app/src/main/java/io/appium/uiautomator2/handler/GetActionHistory.java
@@ -26,9 +26,9 @@ import io.appium.uiautomator2.model.api.scheduled.ScheduledActionStepsHistoryMod
 import io.appium.uiautomator2.model.api.scheduled.FindActionModel;
 import io.appium.uiautomator2.utils.actions_scheduler.ScheduledActionsManager;
 
-public class UnscheduleAction extends SafeRequestHandler {
+public class GetActionHistory extends SafeRequestHandler {
 
-    public UnscheduleAction(String mappedUri) {
+    public GetActionHistory(String mappedUri) {
         super(mappedUri);
     }
 
@@ -42,7 +42,6 @@ public class UnscheduleAction extends SafeRequestHandler {
                 "The action name '%s' is not known. Have you scheduled it before?", model.name
             ));
         }
-        manager.remove(model.name);
         return new AppiumResponse(getSessionId(request), history);
     }
 }

--- a/app/src/main/java/io/appium/uiautomator2/handler/ScheduleAction.java
+++ b/app/src/main/java/io/appium/uiautomator2/handler/ScheduleAction.java
@@ -14,25 +14,26 @@
  * limitations under the License.
  */
 
-package io.appium.uiautomator2.handler.gestures;
+package io.appium.uiautomator2.handler;
 
 import static io.appium.uiautomator2.utils.ModelUtils.toModel;
 
 import io.appium.uiautomator2.handler.request.SafeRequestHandler;
 import io.appium.uiautomator2.http.AppiumResponse;
 import io.appium.uiautomator2.http.IHttpRequest;
-import io.appium.uiautomator2.model.api.gestures.ClickModel;
+import io.appium.uiautomator2.model.api.scheduled.ScheduledActionModel;
+import io.appium.uiautomator2.utils.actions_scheduler.ScheduledActionsManager;
 
-public class Click extends SafeRequestHandler {
+public class ScheduleAction extends SafeRequestHandler {
 
-    public Click(String mappedUri) {
+    public ScheduleAction(String mappedUri) {
         super(mappedUri);
     }
 
     @Override
     protected AppiumResponse safeHandle(IHttpRequest request) {
-        ClickModel clickModel = toModel(request, ClickModel.class);
-        io.appium.uiautomator2.utils.gestures.Click.perform(clickModel);
+        ScheduledActionModel model = toModel(request, ScheduledActionModel.class);
+        ScheduledActionsManager.getInstance().add(model);
         return new AppiumResponse(getSessionId(request));
     }
 }

--- a/app/src/main/java/io/appium/uiautomator2/handler/UnscheduleAction.java
+++ b/app/src/main/java/io/appium/uiautomator2/handler/UnscheduleAction.java
@@ -14,25 +14,35 @@
  * limitations under the License.
  */
 
-package io.appium.uiautomator2.handler.gestures;
+package io.appium.uiautomator2.handler;
 
 import static io.appium.uiautomator2.utils.ModelUtils.toModel;
 
+import io.appium.uiautomator2.common.exceptions.InvalidArgumentException;
 import io.appium.uiautomator2.handler.request.SafeRequestHandler;
 import io.appium.uiautomator2.http.AppiumResponse;
 import io.appium.uiautomator2.http.IHttpRequest;
-import io.appium.uiautomator2.model.api.gestures.ClickModel;
+import io.appium.uiautomator2.model.api.scheduled.ScheduledActionStepsHistoryModel;
+import io.appium.uiautomator2.model.api.scheduled.UncheduledActionModel;
+import io.appium.uiautomator2.utils.actions_scheduler.ScheduledActionsManager;
 
-public class Click extends SafeRequestHandler {
+public class UnscheduleAction extends SafeRequestHandler {
 
-    public Click(String mappedUri) {
+    public UnscheduleAction(String mappedUri) {
         super(mappedUri);
     }
 
     @Override
     protected AppiumResponse safeHandle(IHttpRequest request) {
-        ClickModel clickModel = toModel(request, ClickModel.class);
-        io.appium.uiautomator2.utils.gestures.Click.perform(clickModel);
-        return new AppiumResponse(getSessionId(request));
+        UncheduledActionModel model = toModel(request, UncheduledActionModel.class);
+        ScheduledActionsManager manager = ScheduledActionsManager.getInstance();
+        ScheduledActionStepsHistoryModel history = manager.getHistory(model.name);
+        if (history == null) {
+            throw new InvalidArgumentException(String.format(
+                "The action name '%s' is not known. Have you scheduled it before?", model.name
+            ));
+        }
+        manager.remove(model.name);
+        return new AppiumResponse(getSessionId(request), history);
     }
 }

--- a/app/src/main/java/io/appium/uiautomator2/handler/gestures/DoubleClick.java
+++ b/app/src/main/java/io/appium/uiautomator2/handler/gestures/DoubleClick.java
@@ -16,17 +16,10 @@
 
 package io.appium.uiautomator2.handler.gestures;
 
-import android.graphics.Point;
-import android.graphics.Rect;
-
 import io.appium.uiautomator2.handler.request.SafeRequestHandler;
 import io.appium.uiautomator2.http.AppiumResponse;
 import io.appium.uiautomator2.http.IHttpRequest;
-import io.appium.uiautomator2.model.AndroidElement;
-import io.appium.uiautomator2.model.AppiumUIA2Driver;
-import io.appium.uiautomator2.model.Session;
 import io.appium.uiautomator2.model.api.gestures.DoubleClickModel;
-import io.appium.uiautomator2.model.internal.CustomUiDevice;
 
 import static io.appium.uiautomator2.utils.ModelUtils.toModel;
 
@@ -39,28 +32,7 @@ public class DoubleClick extends SafeRequestHandler {
     @Override
     protected AppiumResponse safeHandle(IHttpRequest request) {
         DoubleClickModel doubleClickModel = toModel(request, DoubleClickModel.class);
-        final String elementId = doubleClickModel.origin == null ? null : doubleClickModel.origin.getUnifiedId();
-        if (elementId == null) {
-            if (doubleClickModel.offset == null) {
-                throw new IllegalArgumentException("Double click offset coordinates must be provided " +
-                        "if element is not set");
-            }
-            CustomUiDevice.getInstance().getGestureController().doubleClick(
-                    doubleClickModel.offset.toNativePoint()
-            );
-        } else {
-            Session session = AppiumUIA2Driver.getInstance().getSessionOrThrow();
-            AndroidElement element = session.getElementsCache().get(elementId);
-            if (doubleClickModel.offset == null) {
-                element.doubleClick();
-            } else {
-                Rect bounds = element.getBounds();
-                Point location = new Point(bounds.left + doubleClickModel.offset.x.intValue(),
-                        bounds.top + doubleClickModel.offset.y.intValue());
-                CustomUiDevice.getInstance().getGestureController().doubleClick(location);
-            }
-        }
-
+        io.appium.uiautomator2.utils.gestures.DoubleClick.perform(doubleClickModel);
         return new AppiumResponse(getSessionId(request));
     }
 }

--- a/app/src/main/java/io/appium/uiautomator2/handler/gestures/LongClick.java
+++ b/app/src/main/java/io/appium/uiautomator2/handler/gestures/LongClick.java
@@ -16,17 +16,10 @@
 
 package io.appium.uiautomator2.handler.gestures;
 
-import android.graphics.Point;
-import android.graphics.Rect;
-
 import io.appium.uiautomator2.handler.request.SafeRequestHandler;
 import io.appium.uiautomator2.http.AppiumResponse;
 import io.appium.uiautomator2.http.IHttpRequest;
-import io.appium.uiautomator2.model.AndroidElement;
-import io.appium.uiautomator2.model.AppiumUIA2Driver;
-import io.appium.uiautomator2.model.Session;
 import io.appium.uiautomator2.model.api.gestures.LongClickModel;
-import io.appium.uiautomator2.model.internal.CustomUiDevice;
 
 import static io.appium.uiautomator2.utils.ModelUtils.toModel;
 
@@ -39,35 +32,7 @@ public class LongClick extends SafeRequestHandler {
     @Override
     protected AppiumResponse safeHandle(IHttpRequest request) {
         LongClickModel longClickModel = toModel(request, LongClickModel.class);
-        final String elementId = longClickModel.origin == null ? null : longClickModel.origin.getUnifiedId();
-        if (elementId == null) {
-            if (longClickModel.offset == null) {
-                throw new IllegalArgumentException("Long click offset coordinates must be provided " +
-                        "if element is not set");
-            }
-            CustomUiDevice.getInstance().getGestureController().longClick(
-                    longClickModel.offset.toNativePoint(),
-                    longClickModel.duration == null ? null : longClickModel.duration.longValue()
-            );
-        } else {
-            Session session = AppiumUIA2Driver.getInstance().getSessionOrThrow();
-            AndroidElement element = session.getElementsCache().get(elementId);
-            if (longClickModel.offset == null) {
-                if (longClickModel.duration == null) {
-                    element.longClick();
-                } else {
-                    element.longClick(longClickModel.duration.longValue());
-                }
-            } else {
-                Rect bounds = element.getBounds();
-                Point location = new Point(bounds.left + longClickModel.offset.x.intValue(),
-                        bounds.top + longClickModel.offset.y.intValue());
-                CustomUiDevice.getInstance().getGestureController().longClick(location,
-                        longClickModel.duration == null ? null : longClickModel.duration.longValue()
-                );
-            }
-        }
-
+        io.appium.uiautomator2.utils.gestures.LongClick.perform(longClickModel);
         return new AppiumResponse(getSessionId(request));
     }
 }

--- a/app/src/main/java/io/appium/uiautomator2/model/ElementsCache.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/ElementsCache.java
@@ -43,7 +43,7 @@ public class ElementsCache {
         this.cache = new LruCache<>(maxSize);
     }
 
-    private static AndroidElement toAndroidElement(AccessibleUiObject element, boolean isSingleMatch,
+    public static AndroidElement toAndroidElement(AccessibleUiObject element, boolean isSingleMatch,
                                                    @Nullable By by, @Nullable String contextId) {
         return toAndroidElement(element, isSingleMatch, by, contextId, null);
     }

--- a/app/src/main/java/io/appium/uiautomator2/model/Session.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/Session.java
@@ -24,6 +24,7 @@ import java.util.Map;
 
 import io.appium.uiautomator2.model.settings.ISetting;
 import io.appium.uiautomator2.model.settings.Settings;
+import io.appium.uiautomator2.utils.actions_scheduler.ScheduledActionsManager;
 
 public class Session {
     public static final String NO_ID = "None";
@@ -36,6 +37,7 @@ public class Session {
 
     Session(String sessionId, Map<String, Object> capabilities) {
         this.sessionId = sessionId;
+        ScheduledActionsManager.getInstance().clear();
         for (Map.Entry<String, Object> capability: capabilities.entrySet()) {
             boolean isSetting = false;
             for (Settings settingsEnumItem: Settings.values()) {

--- a/app/src/main/java/io/appium/uiautomator2/model/api/scheduled/FindActionModel.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/api/scheduled/FindActionModel.java
@@ -19,9 +19,9 @@ package io.appium.uiautomator2.model.api.scheduled;
 import io.appium.uiautomator2.model.RequiredField;
 import io.appium.uiautomator2.model.api.BaseModel;
 
-public class UncheduledActionModel extends BaseModel {
+public class FindActionModel extends BaseModel {
     @RequiredField
     public String name;
 
-    public UncheduledActionModel() {}
+    public FindActionModel() {}
 }

--- a/app/src/main/java/io/appium/uiautomator2/model/api/scheduled/ScheduledActionModel.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/api/scheduled/ScheduledActionModel.java
@@ -14,14 +14,21 @@
  * limitations under the License.
  */
 
-package io.appium.uiautomator2.model.api.gestures;
+package io.appium.uiautomator2.model.api.scheduled;
 
+import java.util.List;
+
+import io.appium.uiautomator2.model.RequiredField;
 import io.appium.uiautomator2.model.api.BaseModel;
-import io.appium.uiautomator2.model.api.ElementModel;
-import io.appium.uiautomator2.model.api.FindElementModel;
 
-public class ClickModel extends BaseModel {
-    public ElementModel origin;
-    public FindElementModel locator;
-    public PointModel offset;
+public class ScheduledActionModel extends BaseModel {
+    @RequiredField
+    public String name;
+    @RequiredField
+    public List<ScheduledActionStepModel> steps;
+    public int times = 1;
+    public long interval = 1000L; // in milliseconds
+    public int maxHistory = 20;
+
+    public ScheduledActionModel() {}
 }

--- a/app/src/main/java/io/appium/uiautomator2/model/api/scheduled/ScheduledActionModel.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/api/scheduled/ScheduledActionModel.java
@@ -29,6 +29,8 @@ public class ScheduledActionModel extends BaseModel {
     public int times = 1;
     public long intervalMs = 1000L; // in milliseconds
     public int maxHistoryItems = 20;
+    public int maxPass = -1;
+    public int maxFail = -1;
 
     public ScheduledActionModel() {}
 }

--- a/app/src/main/java/io/appium/uiautomator2/model/api/scheduled/ScheduledActionModel.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/api/scheduled/ScheduledActionModel.java
@@ -27,8 +27,8 @@ public class ScheduledActionModel extends BaseModel {
     @RequiredField
     public List<ScheduledActionStepModel> steps;
     public int times = 1;
-    public long interval = 1000L; // in milliseconds
-    public int maxHistory = 20;
+    public long intervalMs = 1000L; // in milliseconds
+    public int maxHistoryItems = 20;
 
     public ScheduledActionModel() {}
 }

--- a/app/src/main/java/io/appium/uiautomator2/model/api/scheduled/ScheduledActionStatusModel.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/api/scheduled/ScheduledActionStatusModel.java
@@ -14,14 +14,18 @@
  * limitations under the License.
  */
 
-package io.appium.uiautomator2.model.api.gestures;
+package io.appium.uiautomator2.model.api.scheduled;
 
 import io.appium.uiautomator2.model.api.BaseModel;
-import io.appium.uiautomator2.model.api.ElementModel;
-import io.appium.uiautomator2.model.api.FindElementModel;
 
-public class ClickModel extends BaseModel {
-    public ElementModel origin;
-    public FindElementModel locator;
-    public PointModel offset;
+public class ScheduledActionStatusModel extends BaseModel {
+    public String name;
+    public ScheduledActionStepsHistoryModel stepsHistory;
+
+    public ScheduledActionStatusModel() {}
+
+    public ScheduledActionStatusModel(String name, ScheduledActionStepsHistoryModel stepsHistory) {
+        this.name = name;
+        this.stepsHistory = stepsHistory;
+    }
 }

--- a/app/src/main/java/io/appium/uiautomator2/model/api/scheduled/ScheduledActionStepExceptionModel.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/api/scheduled/ScheduledActionStepExceptionModel.java
@@ -14,14 +14,20 @@
  * limitations under the License.
  */
 
-package io.appium.uiautomator2.model.api.gestures;
+package io.appium.uiautomator2.model.api.scheduled;
 
 import io.appium.uiautomator2.model.api.BaseModel;
-import io.appium.uiautomator2.model.api.ElementModel;
-import io.appium.uiautomator2.model.api.FindElementModel;
 
-public class ClickModel extends BaseModel {
-    public ElementModel origin;
-    public FindElementModel locator;
-    public PointModel offset;
+public class ScheduledActionStepExceptionModel extends BaseModel {
+    public String name;
+    public String message;
+    public String stacktrace;
+
+    public ScheduledActionStepExceptionModel() {}
+
+    public ScheduledActionStepExceptionModel(String name, String message, String stacktrace) {
+        this.name = name;
+        this.message = message;
+        this.stacktrace = stacktrace;
+    }
 }

--- a/app/src/main/java/io/appium/uiautomator2/model/api/scheduled/ScheduledActionStepModel.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/api/scheduled/ScheduledActionStepModel.java
@@ -14,14 +14,19 @@
  * limitations under the License.
  */
 
-package io.appium.uiautomator2.model.api.gestures;
+package io.appium.uiautomator2.model.api.scheduled;
 
+import java.util.Map;
+
+import io.appium.uiautomator2.model.RequiredField;
 import io.appium.uiautomator2.model.api.BaseModel;
-import io.appium.uiautomator2.model.api.ElementModel;
-import io.appium.uiautomator2.model.api.FindElementModel;
 
-public class ClickModel extends BaseModel {
-    public ElementModel origin;
-    public FindElementModel locator;
-    public PointModel offset;
+public class ScheduledActionStepModel extends BaseModel {
+    @RequiredField
+    public String type;
+    @RequiredField
+    public String name;
+    public Map<String, ?> payload;
+
+    public ScheduledActionStepModel() {}
 }

--- a/app/src/main/java/io/appium/uiautomator2/model/api/scheduled/ScheduledActionStepResultModel.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/api/scheduled/ScheduledActionStepResultModel.java
@@ -14,14 +14,24 @@
  * limitations under the License.
  */
 
-package io.appium.uiautomator2.model.api.gestures;
+package io.appium.uiautomator2.model.api.scheduled;
 
 import io.appium.uiautomator2.model.api.BaseModel;
-import io.appium.uiautomator2.model.api.ElementModel;
-import io.appium.uiautomator2.model.api.FindElementModel;
 
-public class ClickModel extends BaseModel {
-    public ElementModel origin;
-    public FindElementModel locator;
-    public PointModel offset;
+public class ScheduledActionStepResultModel extends BaseModel {
+    public String name;
+    public String type;
+    public long timestamp;
+    public boolean passed;
+    public Object result;
+    public ScheduledActionStepExceptionModel exception;
+
+    public ScheduledActionStepResultModel() {}
+
+    public ScheduledActionStepResultModel(String name, String type, long timestamp
+    ) {
+        this.name = name;
+        this.type = type;
+        this.timestamp = timestamp;
+    }
 }

--- a/app/src/main/java/io/appium/uiautomator2/model/api/scheduled/ScheduledActionStepResultModel.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/api/scheduled/ScheduledActionStepResultModel.java
@@ -28,10 +28,17 @@ public class ScheduledActionStepResultModel extends BaseModel {
 
     public ScheduledActionStepResultModel() {}
 
-    public ScheduledActionStepResultModel(String name, String type, long timestamp
-    ) {
+    public ScheduledActionStepResultModel(String name, String type, long timestamp) {
         this.name = name;
         this.type = type;
         this.timestamp = timestamp;
+    }
+
+    public ScheduledActionStepResultModel(String name, String type, long timestamp, Throwable exc) {
+        this.name = name;
+        this.type = type;
+        this.timestamp = timestamp;
+        this.passed = false;
+        this.exception = new ScheduledActionStepExceptionModel(exc);
     }
 }

--- a/app/src/main/java/io/appium/uiautomator2/model/api/scheduled/ScheduledActionStepsHistoryModel.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/api/scheduled/ScheduledActionStepsHistoryModel.java
@@ -14,14 +14,21 @@
  * limitations under the License.
  */
 
-package io.appium.uiautomator2.model.api.gestures;
+package io.appium.uiautomator2.model.api.scheduled;
+
+import java.util.ArrayList;
+import java.util.LinkedList;
+import java.util.List;
 
 import io.appium.uiautomator2.model.api.BaseModel;
-import io.appium.uiautomator2.model.api.ElementModel;
-import io.appium.uiautomator2.model.api.FindElementModel;
 
-public class ClickModel extends BaseModel {
-    public ElementModel origin;
-    public FindElementModel locator;
-    public PointModel offset;
+public class ScheduledActionStepsHistoryModel extends BaseModel {
+    public long repeats = 0L;
+    public List<List<ScheduledActionStepResultModel>> stepResults = new LinkedList<>();
+
+    public ScheduledActionStepsHistoryModel() {}
+
+    public ScheduledActionStepsHistoryModel(List<List<ScheduledActionStepResultModel>> stepResults) {
+        this.stepResults = stepResults;
+    }
 }

--- a/app/src/main/java/io/appium/uiautomator2/model/api/scheduled/UncheduledActionModel.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/api/scheduled/UncheduledActionModel.java
@@ -14,14 +14,14 @@
  * limitations under the License.
  */
 
-package io.appium.uiautomator2.model.api.gestures;
+package io.appium.uiautomator2.model.api.scheduled;
 
+import io.appium.uiautomator2.model.RequiredField;
 import io.appium.uiautomator2.model.api.BaseModel;
-import io.appium.uiautomator2.model.api.ElementModel;
-import io.appium.uiautomator2.model.api.FindElementModel;
 
-public class ClickModel extends BaseModel {
-    public ElementModel origin;
-    public FindElementModel locator;
-    public PointModel offset;
+public class UncheduledActionModel extends BaseModel {
+    @RequiredField
+    public String name;
+
+    public UncheduledActionModel() {}
 }

--- a/app/src/main/java/io/appium/uiautomator2/server/AppiumServlet.java
+++ b/app/src/main/java/io/appium/uiautomator2/server/AppiumServlet.java
@@ -65,6 +65,7 @@ import io.appium.uiautomator2.handler.NewSession;
 import io.appium.uiautomator2.handler.OpenNotification;
 import io.appium.uiautomator2.handler.PressBack;
 import io.appium.uiautomator2.handler.PressKeyCode;
+import io.appium.uiautomator2.handler.ScheduleAction;
 import io.appium.uiautomator2.handler.ScrollTo;
 import io.appium.uiautomator2.handler.ScrollToElement;
 import io.appium.uiautomator2.handler.SendKeysToElement;
@@ -79,6 +80,7 @@ import io.appium.uiautomator2.handler.TouchDown;
 import io.appium.uiautomator2.handler.TouchLongClick;
 import io.appium.uiautomator2.handler.TouchMove;
 import io.appium.uiautomator2.handler.TouchUp;
+import io.appium.uiautomator2.handler.UnscheduleAction;
 import io.appium.uiautomator2.handler.UpdateSettings;
 import io.appium.uiautomator2.handler.W3CActions;
 import io.appium.uiautomator2.handler.request.BaseRequestHandler;
@@ -158,6 +160,9 @@ public class AppiumServlet implements IHttpServlet {
         register(postHandler, new io.appium.uiautomator2.handler.gestures.PinchOpen("/session/:sessionId/appium/gestures/pinch_open"));
         register(postHandler, new io.appium.uiautomator2.handler.gestures.Scroll("/session/:sessionId/appium/gestures/scroll"));
         register(postHandler, new io.appium.uiautomator2.handler.gestures.Swipe("/session/:sessionId/appium/gestures/swipe"));
+
+        register(postHandler, new ScheduleAction("/session/:sessionId/appium/schedule_action"));
+        register(postHandler, new UnscheduleAction("/session/:sessionId/appium/unschedule_action"));
     }
 
     private void registerGetHandler() {

--- a/app/src/main/java/io/appium/uiautomator2/server/AppiumServlet.java
+++ b/app/src/main/java/io/appium/uiautomator2/server/AppiumServlet.java
@@ -37,6 +37,7 @@ import io.appium.uiautomator2.handler.FindElement;
 import io.appium.uiautomator2.handler.FindElements;
 import io.appium.uiautomator2.handler.FirstVisibleView;
 import io.appium.uiautomator2.handler.Flick;
+import io.appium.uiautomator2.handler.GetActionHistory;
 import io.appium.uiautomator2.handler.GetAlertText;
 import io.appium.uiautomator2.handler.GetBatteryInfo;
 import io.appium.uiautomator2.handler.GetClipboard;
@@ -162,6 +163,7 @@ public class AppiumServlet implements IHttpServlet {
         register(postHandler, new io.appium.uiautomator2.handler.gestures.Swipe("/session/:sessionId/appium/gestures/swipe"));
 
         register(postHandler, new ScheduleAction("/session/:sessionId/appium/schedule_action"));
+        register(postHandler, new GetActionHistory("/session/:sessionId/appium/action_history"));
         register(postHandler, new UnscheduleAction("/session/:sessionId/appium/unschedule_action"));
     }
 

--- a/app/src/main/java/io/appium/uiautomator2/utils/ModelUtils.java
+++ b/app/src/main/java/io/appium/uiautomator2/utils/ModelUtils.java
@@ -13,8 +13,11 @@ import io.appium.uiautomator2.model.api.BaseModel;
 
 public class ModelUtils {
     public static <T extends BaseModel> T toModel(IHttpRequest request, Class<T> modelCls) {
-        //noinspection unchecked
-        return (T) new Gson().fromJson(request.body(), modelCls).validate();
+        return toModel(request.body(), modelCls);
+    }
+
+    public static <T extends BaseModel> T toModel(String body, Class<T> modelCls) {
+        return modelCls.cast(new Gson().fromJson(body, modelCls).validate());
     }
 
     public static Object toObject(JSONArray json, Type type) {

--- a/app/src/main/java/io/appium/uiautomator2/utils/actions_scheduler/BaseActionStep.java
+++ b/app/src/main/java/io/appium/uiautomator2/utils/actions_scheduler/BaseActionStep.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.appium.uiautomator2.utils.actions_scheduler;
+
+import java.util.Objects;
+
+import javax.annotation.Nullable;
+
+import io.appium.uiautomator2.model.api.scheduled.ScheduledActionStepExceptionModel;
+import io.appium.uiautomator2.model.api.scheduled.ScheduledActionStepModel;
+import io.appium.uiautomator2.model.api.scheduled.ScheduledActionStepResultModel;
+
+public abstract class BaseActionStep {
+    protected final ScheduledActionStepModel model;
+
+    public BaseActionStep(ScheduledActionStepModel model) {
+        this.model = model;
+    }
+
+    protected abstract String[] getSupportedSubtypes();
+
+    protected String getSubtype() throws UnknownStepSubtypeException {
+        if (!model.payload.containsKey(Constants.STEP_SUBTYPE)
+                || !(model.payload.get(Constants.STEP_SUBTYPE) instanceof String)) {
+            throw new UnknownStepSubtypeException(
+                    model,
+                    String.valueOf(model.payload.get(Constants.STEP_SUBTYPE)),
+                    getSupportedSubtypes()
+            );
+        }
+        return (String) Objects.requireNonNull(model.payload.get(Constants.STEP_SUBTYPE));
+    }
+
+    @Nullable
+    protected abstract Object runInternalImplementation(String subtype) throws UnknownStepSubtypeException;
+
+    public ScheduledActionStepResultModel run() {
+        ScheduledActionStepResultModel result = new ScheduledActionStepResultModel(
+                model.name,
+                model.type,
+                System.currentTimeMillis()
+        );
+        try {
+            result.result = runInternalImplementation(getSubtype());
+            result.passed = true;
+        } catch (RuntimeException | UnknownStepSubtypeException e) {
+            result.exception = new ScheduledActionStepExceptionModel(e);
+            result.passed = false;
+        }
+        return result;
+    }
+}

--- a/app/src/main/java/io/appium/uiautomator2/utils/actions_scheduler/BaseActionStep.java
+++ b/app/src/main/java/io/appium/uiautomator2/utils/actions_scheduler/BaseActionStep.java
@@ -18,8 +18,6 @@ package io.appium.uiautomator2.utils.actions_scheduler;
 
 import java.util.Objects;
 
-import javax.annotation.Nullable;
-
 import io.appium.uiautomator2.model.api.scheduled.ScheduledActionStepExceptionModel;
 import io.appium.uiautomator2.model.api.scheduled.ScheduledActionStepModel;
 import io.appium.uiautomator2.model.api.scheduled.ScheduledActionStepResultModel;
@@ -45,7 +43,6 @@ public abstract class BaseActionStep {
         return (String) Objects.requireNonNull(model.payload.get(Constants.STEP_SUBTYPE));
     }
 
-    @Nullable
     protected abstract Object runInternalImplementation(String subtype) throws UnknownStepSubtypeException;
 
     public ScheduledActionStepResultModel run() {

--- a/app/src/main/java/io/appium/uiautomator2/utils/actions_scheduler/Constants.java
+++ b/app/src/main/java/io/appium/uiautomator2/utils/actions_scheduler/Constants.java
@@ -14,22 +14,9 @@
  * limitations under the License.
  */
 
-package io.appium.uiautomator2.model.api.scheduled;
+package io.appium.uiautomator2.utils.actions_scheduler;
 
-import android.util.Log;
-
-import io.appium.uiautomator2.model.api.BaseModel;
-
-public class ScheduledActionStepExceptionModel extends BaseModel {
-    public String name;
-    public String message;
-    public String stacktrace;
-
-    public ScheduledActionStepExceptionModel() {}
-
-    public ScheduledActionStepExceptionModel(Throwable exc) {
-        this.name = exc.getClass().getName();
-        this.message = exc.getMessage();
-        this.stacktrace = Log.getStackTraceString(exc);
-    }
+public interface Constants {
+    String STEP_SUBTYPE = "subtype";
+    String STEP_TYPE = "type";
 }

--- a/app/src/main/java/io/appium/uiautomator2/utils/actions_scheduler/GestureStep.java
+++ b/app/src/main/java/io/appium/uiautomator2/utils/actions_scheduler/GestureStep.java
@@ -19,34 +19,46 @@ package io.appium.uiautomator2.utils.actions_scheduler;
 import static io.appium.uiautomator2.utils.ModelUtils.toJsonString;
 import static io.appium.uiautomator2.utils.ModelUtils.toModel;
 
-import android.util.Log;
-
-import java.util.Arrays;
 import java.util.Map;
-import java.util.Objects;
 
-import io.appium.uiautomator2.common.exceptions.InvalidArgumentException;
+import javax.annotation.Nullable;
+
 import io.appium.uiautomator2.model.api.gestures.ClickModel;
 import io.appium.uiautomator2.model.api.gestures.DoubleClickModel;
 import io.appium.uiautomator2.model.api.gestures.LongClickModel;
-import io.appium.uiautomator2.model.api.scheduled.ScheduledActionStepExceptionModel;
 import io.appium.uiautomator2.model.api.scheduled.ScheduledActionStepModel;
-import io.appium.uiautomator2.model.api.scheduled.ScheduledActionStepResultModel;
 import io.appium.uiautomator2.utils.gestures.Click;
 import io.appium.uiautomator2.utils.gestures.DoubleClick;
 import io.appium.uiautomator2.utils.gestures.LongClick;
 
-public class GestureStep {
+public class GestureStep extends BaseActionStep {
     public static final String TYPE = "gesture";
-    private static final String KIND = "kind";
-    private static final String CLICK = "click";
-    private static final String DOUBLE_CLICK = "doubleClick";
-    private static final String LONG_CLICK = "longClick";
-
-    private final ScheduledActionStepModel model;
+    private static final String SUBTYPE_CLICK = "click";
+    private static final String SUBTYPE_DOUBLE_CLICK = "doubleClick";
+    private static final String SUBTYPE_LONG_CLICK = "longClick";
 
     public GestureStep (ScheduledActionStepModel model) {
-        this.model = model;
+        super(model);
+    }
+
+    @Override
+    protected String[] getSupportedSubtypes() {
+        return new String[] {SUBTYPE_CLICK, SUBTYPE_DOUBLE_CLICK, SUBTYPE_LONG_CLICK};
+    }
+
+    @Nullable
+    @Override
+    protected Object runInternalImplementation(String subtype) throws UnknownStepSubtypeException {
+        switch (subtype) {
+            case SUBTYPE_CLICK:
+                return performClick(model.payload);
+            case SUBTYPE_DOUBLE_CLICK:
+                return performDoubleClick(model.payload);
+            case SUBTYPE_LONG_CLICK:
+                return performLongClick(model.payload);
+            default:
+                throw new UnknownStepSubtypeException(model, subtype, getSupportedSubtypes());
+        }
     }
 
     private Object performClick(Map<?, ?> payload) {
@@ -59,59 +71,5 @@ public class GestureStep {
 
     private Object performLongClick(Map<?, ?> payload) {
         return LongClick.perform(toModel(toJsonString(payload), LongClickModel.class));
-    }
-
-    public ScheduledActionStepResultModel run() {
-        ScheduledActionStepResultModel result = new ScheduledActionStepResultModel(
-                model.name,
-                model.type,
-                System.currentTimeMillis()
-        );
-        if (!model.payload.containsKey(KIND) || !(model.payload.get(KIND) instanceof String)) {
-            throw new InvalidArgumentException(String.format(
-               "The payload of '%s' step (type '%s') must contain a valid '%s' value",
-               model.name, model.type, KIND
-            ));
-        }
-        String kind = (String) Objects.requireNonNull(model.payload.get(KIND));
-        RuntimeException error = null;
-        Object stepResult = null;
-        try {
-            switch (kind) {
-                case CLICK:
-                    stepResult = performClick(model.payload);
-                    break;
-                case DOUBLE_CLICK:
-                    stepResult = performDoubleClick(model.payload);
-                    break;
-                case LONG_CLICK:
-                    stepResult = performLongClick(model.payload);
-                    break;
-                default:
-                    throw new InvalidArgumentException(String.format(
-                            "The value of '%s' field in step '%s' (type '%s') is unknown. " +
-                                    "Only the following kinds are supported: %s",
-                            kind, model.name, model.type, Arrays.toString(new String[]{
-                                    CLICK, DOUBLE_CLICK, LONG_CLICK
-                            })
-                    ));
-            }
-        } catch (InvalidArgumentException e) {
-            throw e;
-        } catch (RuntimeException e) {
-            error = e;
-        }
-        if (error == null) {
-            result.passed = true;
-            result.result = stepResult;
-        } else {
-            result.passed = false;
-            result.exception = new ScheduledActionStepExceptionModel(
-                    error.getClass().getName(),
-                    error.getMessage(),
-                    Log.getStackTraceString(error)
-            );
-        }
-        return result;
     }
 }

--- a/app/src/main/java/io/appium/uiautomator2/utils/actions_scheduler/GestureStep.java
+++ b/app/src/main/java/io/appium/uiautomator2/utils/actions_scheduler/GestureStep.java
@@ -1,0 +1,117 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.appium.uiautomator2.utils.actions_scheduler;
+
+import static io.appium.uiautomator2.utils.ModelUtils.toJsonString;
+import static io.appium.uiautomator2.utils.ModelUtils.toModel;
+
+import android.util.Log;
+
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Objects;
+
+import io.appium.uiautomator2.common.exceptions.InvalidArgumentException;
+import io.appium.uiautomator2.model.api.gestures.ClickModel;
+import io.appium.uiautomator2.model.api.gestures.DoubleClickModel;
+import io.appium.uiautomator2.model.api.gestures.LongClickModel;
+import io.appium.uiautomator2.model.api.scheduled.ScheduledActionStepExceptionModel;
+import io.appium.uiautomator2.model.api.scheduled.ScheduledActionStepModel;
+import io.appium.uiautomator2.model.api.scheduled.ScheduledActionStepResultModel;
+import io.appium.uiautomator2.utils.gestures.Click;
+import io.appium.uiautomator2.utils.gestures.DoubleClick;
+import io.appium.uiautomator2.utils.gestures.LongClick;
+
+public class GestureStep {
+    public static final String TYPE = "gesture";
+    private static final String KIND = "kind";
+    private static final String CLICK = "click";
+    private static final String DOUBLE_CLICK = "doubleClick";
+    private static final String LONG_CLICK = "longClick";
+
+    private final ScheduledActionStepModel model;
+
+    public GestureStep (ScheduledActionStepModel model) {
+        this.model = model;
+    }
+
+    private Object performClick(Map<?, ?> payload) {
+        return Click.perform(toModel(toJsonString(payload), ClickModel.class));
+    }
+
+    private Object performDoubleClick(Map<?, ?> payload) {
+        return DoubleClick.perform(toModel(toJsonString(payload), DoubleClickModel.class));
+    }
+
+    private Object performLongClick(Map<?, ?> payload) {
+        return LongClick.perform(toModel(toJsonString(payload), LongClickModel.class));
+    }
+
+    public ScheduledActionStepResultModel run() {
+        ScheduledActionStepResultModel result = new ScheduledActionStepResultModel(
+                model.name,
+                model.type,
+                System.currentTimeMillis()
+        );
+        if (!model.payload.containsKey(KIND) || !(model.payload.get(KIND) instanceof String)) {
+            throw new InvalidArgumentException(String.format(
+               "The payload of '%s' step (type '%s') must contain a valid '%s' value",
+               model.name, model.type, KIND
+            ));
+        }
+        String kind = (String) Objects.requireNonNull(model.payload.get(KIND));
+        RuntimeException error = null;
+        Object stepResult = null;
+        try {
+            switch (kind) {
+                case CLICK:
+                    stepResult = performClick(model.payload);
+                    break;
+                case DOUBLE_CLICK:
+                    stepResult = performDoubleClick(model.payload);
+                    break;
+                case LONG_CLICK:
+                    stepResult = performLongClick(model.payload);
+                    break;
+                default:
+                    throw new InvalidArgumentException(String.format(
+                            "The value of '%s' field in step '%s' (type '%s') is unknown. " +
+                                    "Only the following kinds are supported: %s",
+                            kind, model.name, model.type, Arrays.toString(new String[]{
+                                    CLICK, DOUBLE_CLICK, LONG_CLICK
+                            })
+                    ));
+            }
+        } catch (InvalidArgumentException e) {
+            throw e;
+        } catch (RuntimeException e) {
+            error = e;
+        }
+        if (error == null) {
+            result.passed = true;
+            result.result = stepResult;
+        } else {
+            result.passed = false;
+            result.exception = new ScheduledActionStepExceptionModel(
+                    error.getClass().getName(),
+                    error.getMessage(),
+                    Log.getStackTraceString(error)
+            );
+        }
+        return result;
+    }
+}

--- a/app/src/main/java/io/appium/uiautomator2/utils/actions_scheduler/ScheduledActionsManager.java
+++ b/app/src/main/java/io/appium/uiautomator2/utils/actions_scheduler/ScheduledActionsManager.java
@@ -70,6 +70,11 @@ public class ScheduledActionsManager {
                     "The amount of provided action steps must be greater than zero"
             );
         }
+        if (actionToSchedule.maxHistory < 1) {
+            throw new InvalidArgumentException(
+                    "The amount of maximum action history items must be greater than zero"
+            );
+        }
         if (scheduledActions.containsKey(actionToSchedule.name)) {
             throw new InvalidArgumentException(String.format(
                     "The action with the same name '%s' has been already scheduled. Please remove it first",

--- a/app/src/main/java/io/appium/uiautomator2/utils/actions_scheduler/ScheduledActionsManager.java
+++ b/app/src/main/java/io/appium/uiautomator2/utils/actions_scheduler/ScheduledActionsManager.java
@@ -117,12 +117,17 @@ public class ScheduledActionsManager {
     private ScheduledActionStepResultModel runActionStep(
             ScheduledActionStepModel step
     ) throws UnknownStepTypeException {
+        final BaseActionStep actionStep;
         if (GestureStep.TYPE.equals(step.type)) {
-            return new GestureStep(step).run();
+            actionStep = new GestureStep(step);
         } else if (SourceStep.TYPE.equals(step.type)) {
-            return new SourceStep(step).run();
+            actionStep = new SourceStep(step);
+        } else if (ScreenshotStep.TYPE.equals(step.type)) {
+            actionStep = new ScreenshotStep(step);
+        } else {
+            throw new UnknownStepTypeException(step, new String[]{GestureStep.TYPE, SourceStep.TYPE});
         }
-        throw new UnknownStepTypeException(step, new String[] { GestureStep.TYPE, SourceStep.TYPE });
+        return actionStep.run();
     }
 
     private void runActionSteps(ScheduledActionModel info) {

--- a/app/src/main/java/io/appium/uiautomator2/utils/actions_scheduler/ScheduledActionsManager.java
+++ b/app/src/main/java/io/appium/uiautomator2/utils/actions_scheduler/ScheduledActionsManager.java
@@ -1,0 +1,170 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.appium.uiautomator2.utils.actions_scheduler;
+
+import static io.appium.uiautomator2.utils.StringHelpers.isBlank;
+
+import android.os.Handler;
+import android.os.Looper;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+import javax.annotation.Nullable;
+
+import io.appium.uiautomator2.common.exceptions.InvalidArgumentException;
+import io.appium.uiautomator2.model.api.scheduled.ScheduledActionModel;
+import io.appium.uiautomator2.model.api.scheduled.ScheduledActionStepModel;
+import io.appium.uiautomator2.model.api.scheduled.ScheduledActionStepResultModel;
+import io.appium.uiautomator2.model.api.scheduled.ScheduledActionStepsHistoryModel;
+import io.appium.uiautomator2.utils.Logger;
+
+public class ScheduledActionsManager {
+    private static ScheduledActionsManager INSTANCE;
+
+    public static synchronized ScheduledActionsManager getInstance() {
+        if (INSTANCE == null) {
+            INSTANCE = new ScheduledActionsManager();
+        }
+        return INSTANCE;
+    }
+
+    private final Map<String, ScheduledActionModel> scheduledActions = new HashMap<>();
+    private final Map<String, ScheduledActionStepsHistoryModel> scheduledActionsHistory = new HashMap<>();
+    private final Set<String> activeActionNames = new HashSet<>();
+
+    private ScheduledActionsManager() {}
+
+    public ScheduledActionsManager add(ScheduledActionModel actionToSchedule) {
+        if (isBlank(actionToSchedule.name)) {
+            throw new InvalidArgumentException("Action name must not be blank");
+        }
+        if (actionToSchedule.interval < 0) {
+            throw new InvalidArgumentException(String.format(
+                    "The scheduled action interval must not be negative. You have provided %s",
+                    actionToSchedule.interval
+            ));
+        }
+        if (actionToSchedule.steps.isEmpty()) {
+            throw new InvalidArgumentException(
+                    "The amount of provided action steps must be greater than zero"
+            );
+        }
+        if (scheduledActions.containsKey(actionToSchedule.name)) {
+            throw new InvalidArgumentException(String.format(
+                    "The action with the same name '%s' has been already scheduled. Please remove it first",
+                    actionToSchedule.name
+            ));
+        }
+        scheduledActions.put(actionToSchedule.name, actionToSchedule);
+        scheduledActionsHistory.put(actionToSchedule.name, new ScheduledActionStepsHistoryModel());
+        return scheduleAction(actionToSchedule);
+    }
+
+    @Nullable
+    public ScheduledActionStepsHistoryModel getHistory(String name) {
+        return scheduledActionsHistory.get(name);
+    }
+
+    public ScheduledActionsManager remove(String name) {
+        activeActionNames.remove(name);
+        scheduledActions.remove(name);
+        scheduledActionsHistory.remove(name);
+        return this;
+    }
+
+    public ScheduledActionsManager clear() {
+        activeActionNames.clear();
+        scheduledActions.clear();
+        scheduledActionsHistory.clear();
+        return this;
+    }
+
+    private ScheduledActionStepResultModel runActionStep(ScheduledActionStepModel step) {
+        if (GestureStep.TYPE.equals(step.type)) {
+            return new GestureStep(step).run();
+        }
+
+        throw new InvalidArgumentException(String.format(
+                "The step type '%s' is not known. Only the following step types are supported: %s",
+                step.type, Arrays.toString(new String[]{GestureStep.TYPE})
+        ));
+    }
+
+    private void runActionSteps(ScheduledActionModel info) {
+        if (!activeActionNames.contains(info.name)) {
+            return;
+        }
+
+        ScheduledActionStepsHistoryModel history = new ScheduledActionStepsHistoryModel();
+        if (scheduledActionsHistory.containsKey(info.name)) {
+            history = Objects.requireNonNull(scheduledActionsHistory.get(info.name));
+        } else {
+            scheduledActionsHistory.put(info.name, history);
+        }
+        Logger.info(String.format(
+                "About to run steps of the scheduled action '%s' (execution %s of %s)",
+                info.name, history.repeats + 1, info.times
+        ));
+        if (history.stepResults.size() >= info.maxHistory) {
+            // Remove the oldest step, so we still have the space for the current one
+            history.stepResults.remove(history.stepResults.size() - 1);
+        }
+        List<ScheduledActionStepResultModel> stepResults = new ArrayList<>();
+        int stepIndex = 1;
+        for (ScheduledActionStepModel step: info.steps) {
+            Logger.info(String.format(
+                    "About to run step '%s (%s)' (%s of %s) belonging to the scheduled action '%s'",
+                    step.name, step.type, stepIndex, info.steps.size(), info.name
+            ));
+            stepResults.add(runActionStep(step));
+            stepIndex++;
+        }
+        // Newest steps go first
+        if (history.stepResults.isEmpty()) {
+            history.stepResults.add(stepResults);
+        } else {
+            history.stepResults.add(0, stepResults);
+        }
+        history.repeats++;
+        if (info.times < history.repeats) {
+            Logger.info(String.format(
+                    "Will run the repeatable scheduled action '%s' again in %s milliseconds " +
+                    "(completed %s of %s repeats)", info.name, info.interval, history.repeats, info.times
+            ));
+            new Handler(Looper.getMainLooper()).postDelayed(() -> runActionSteps(info), info.interval);
+        } else {
+            Logger.info(String.format(
+                    "The scheduled action '%s' has been executed %s times in total", info.name, info.times
+            ));
+            activeActionNames.remove(info.name);
+        }
+    }
+
+    private ScheduledActionsManager scheduleAction(ScheduledActionModel info) {
+        activeActionNames.add(info.name);
+        // No concurrency here. Everything is still being executed on the main thread
+        new Handler(Looper.getMainLooper()).post(() -> runActionSteps(info));
+        return this;
+    }
+}

--- a/app/src/main/java/io/appium/uiautomator2/utils/actions_scheduler/ScheduledActionsManager.java
+++ b/app/src/main/java/io/appium/uiautomator2/utils/actions_scheduler/ScheduledActionsManager.java
@@ -59,10 +59,10 @@ public class ScheduledActionsManager {
         if (isBlank(actionToSchedule.name)) {
             throw new InvalidArgumentException("Action name must not be blank");
         }
-        if (actionToSchedule.interval < 0) {
+        if (actionToSchedule.intervalMs < 0) {
             throw new InvalidArgumentException(String.format(
                     "The scheduled action interval must not be negative. You have provided %s",
-                    actionToSchedule.interval
+                    actionToSchedule.intervalMs
             ));
         }
         if (actionToSchedule.steps.isEmpty()) {
@@ -70,7 +70,7 @@ public class ScheduledActionsManager {
                     "The amount of provided action steps must be greater than zero"
             );
         }
-        if (actionToSchedule.maxHistory < 1) {
+        if (actionToSchedule.maxHistoryItems < 1) {
             throw new InvalidArgumentException(
                     "The amount of maximum action history items must be greater than zero"
             );
@@ -131,7 +131,7 @@ public class ScheduledActionsManager {
                 "About to run steps of the scheduled action '%s' (execution %s of %s)",
                 info.name, history.repeats + 1, info.times
         ));
-        if (history.stepResults.size() >= info.maxHistory) {
+        if (history.stepResults.size() >= info.maxHistoryItems) {
             // Remove the oldest step, so we still have the space for the current one
             history.stepResults.remove(history.stepResults.size() - 1);
         }
@@ -155,9 +155,9 @@ public class ScheduledActionsManager {
         if (info.times < history.repeats) {
             Logger.info(String.format(
                     "Will run the repeatable scheduled action '%s' again in %s milliseconds " +
-                    "(completed %s of %s repeats)", info.name, info.interval, history.repeats, info.times
+                    "(completed %s of %s repeats)", info.name, info.intervalMs, history.repeats, info.times
             ));
-            new Handler(Looper.getMainLooper()).postDelayed(() -> runActionSteps(info), info.interval);
+            new Handler(Looper.getMainLooper()).postDelayed(() -> runActionSteps(info), info.intervalMs);
         } else {
             Logger.info(String.format(
                     "The scheduled action '%s' has been executed %s times in total", info.name, info.times

--- a/app/src/main/java/io/appium/uiautomator2/utils/actions_scheduler/ScreenshotStep.java
+++ b/app/src/main/java/io/appium/uiautomator2/utils/actions_scheduler/ScreenshotStep.java
@@ -16,36 +16,27 @@
 
 package io.appium.uiautomator2.utils.actions_scheduler;
 
-import static io.appium.uiautomator2.utils.AXWindowHelpers.refreshAccessibilityCache;
-
-import java.util.Collections;
-
-import io.appium.uiautomator2.core.AccessibilityNodeInfoDumper;
 import io.appium.uiautomator2.model.api.scheduled.ScheduledActionStepModel;
+import io.appium.uiautomator2.utils.ScreenshotHelper;
 
-public class SourceStep extends BaseActionStep {
-    public static final String TYPE = "source";
-    private static final String XML = "xml";
+public class ScreenshotStep extends BaseActionStep {
+    public static final String TYPE = "screenshot";
+    private static final String PNG = "png";
 
-    public SourceStep(ScheduledActionStepModel model) {
+    public ScreenshotStep(ScheduledActionStepModel model) {
         super(model);
     }
 
     @Override
     protected String[] getSupportedSubtypes() {
-        return new String[]{XML};
+        return new String[]{PNG};
     }
 
     @Override
     protected Object runInternalImplementation(String subtype) throws UnknownStepSubtypeException {
-        if (XML.equals(subtype)) {
-            return fetchXmlSource();
+        if (PNG.equals(subtype)) {
+            return ScreenshotHelper.takeScreenshot();
         }
         throw new UnknownStepSubtypeException(model, subtype, getSupportedSubtypes());
-    }
-
-    private String fetchXmlSource() {
-        refreshAccessibilityCache();
-        return new AccessibilityNodeInfoDumper(null, Collections.emptySet()).dumpToXml();
     }
 }

--- a/app/src/main/java/io/appium/uiautomator2/utils/actions_scheduler/SourceStep.java
+++ b/app/src/main/java/io/appium/uiautomator2/utils/actions_scheduler/SourceStep.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.appium.uiautomator2.utils.actions_scheduler;
+
+import static io.appium.uiautomator2.utils.AXWindowHelpers.refreshAccessibilityCache;
+
+import java.util.Collections;
+
+import javax.annotation.Nullable;
+
+import io.appium.uiautomator2.core.AccessibilityNodeInfoDumper;
+import io.appium.uiautomator2.model.api.scheduled.ScheduledActionStepModel;
+
+public class SourceStep extends BaseActionStep {
+    public static final String TYPE = "source";
+    private static final String XML = "xml";
+
+    public SourceStep(ScheduledActionStepModel model) {
+        super(model);
+    }
+
+    @Override
+    protected String[] getSupportedSubtypes() {
+        return new String[]{XML};
+    }
+
+    @Override
+    @Nullable
+    protected Object runInternalImplementation(String subtype) throws UnknownStepSubtypeException {
+        if (XML.equals(subtype)) {
+            return fetchXmlSource();
+        }
+        throw new UnknownStepSubtypeException(model, subtype, getSupportedSubtypes());
+    }
+
+    private String fetchXmlSource() {
+        refreshAccessibilityCache();
+        return new AccessibilityNodeInfoDumper(null, Collections.emptySet()).dumpToXml();
+    }
+}

--- a/app/src/main/java/io/appium/uiautomator2/utils/actions_scheduler/UnknownStepSubtypeException.java
+++ b/app/src/main/java/io/appium/uiautomator2/utils/actions_scheduler/UnknownStepSubtypeException.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.appium.uiautomator2.utils.actions_scheduler;
+
+import java.util.Arrays;
+
+import io.appium.uiautomator2.model.api.scheduled.ScheduledActionStepModel;
+
+public class UnknownStepSubtypeException extends Exception {
+    public UnknownStepSubtypeException(
+            ScheduledActionStepModel model, String actualSubtype, String[] availableSubtypes
+    ) {
+        super(String.format(
+                "The value '%s' of '%s' field in step '%s' (type '%s') is unknown. " +
+                        "Only the following subtypes are supported: %s",
+                actualSubtype, Constants.STEP_SUBTYPE, model.name, model.type,
+                Arrays.toString(availableSubtypes)
+        ));
+    }
+}

--- a/app/src/main/java/io/appium/uiautomator2/utils/actions_scheduler/UnknownStepTypeException.java
+++ b/app/src/main/java/io/appium/uiautomator2/utils/actions_scheduler/UnknownStepTypeException.java
@@ -14,22 +14,18 @@
  * limitations under the License.
  */
 
-package io.appium.uiautomator2.model.api.scheduled;
+package io.appium.uiautomator2.utils.actions_scheduler;
 
-import android.util.Log;
+import java.util.Arrays;
 
-import io.appium.uiautomator2.model.api.BaseModel;
+import io.appium.uiautomator2.model.api.scheduled.ScheduledActionStepModel;
 
-public class ScheduledActionStepExceptionModel extends BaseModel {
-    public String name;
-    public String message;
-    public String stacktrace;
-
-    public ScheduledActionStepExceptionModel() {}
-
-    public ScheduledActionStepExceptionModel(Throwable exc) {
-        this.name = exc.getClass().getName();
-        this.message = exc.getMessage();
-        this.stacktrace = Log.getStackTraceString(exc);
+public class UnknownStepTypeException extends Exception {
+    public UnknownStepTypeException(ScheduledActionStepModel model, String[] availableTypes) {
+        super(String.format(
+                "The value '%s' of '%s' field in step '%s' is unknown. " +
+                        "Only the following kinds are supported: %s",
+                model.type ,Constants.STEP_TYPE, model.name, Arrays.toString(availableTypes)
+        ));
     }
 }

--- a/app/src/main/java/io/appium/uiautomator2/utils/gestures/BaseGesture.java
+++ b/app/src/main/java/io/appium/uiautomator2/utils/gestures/BaseGesture.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.appium.uiautomator2.utils.gestures;
+
+import static io.appium.uiautomator2.model.ElementsCache.toAndroidElement;
+import static io.appium.uiautomator2.utils.ElementLocationHelpers.findElement;
+import static io.appium.uiautomator2.utils.StringHelpers.isBlank;
+
+import androidx.test.uiautomator.UiObjectNotFoundException;
+
+import io.appium.uiautomator2.common.exceptions.ElementNotFoundException;
+import io.appium.uiautomator2.model.AccessibleUiObject;
+import io.appium.uiautomator2.model.AndroidElement;
+import io.appium.uiautomator2.model.AppiumUIA2Driver;
+import io.appium.uiautomator2.model.By;
+import io.appium.uiautomator2.model.ElementsCache;
+import io.appium.uiautomator2.model.api.FindElementModel;
+import io.appium.uiautomator2.model.internal.ElementsLookupStrategy;
+
+public class BaseGesture {
+    protected static AndroidElement locateElement(FindElementModel locator) {
+        String strategy = locator.strategy;
+        String selector = locator.selector;
+        String contextId = isBlank(locator.context) ? null : locator.context;
+
+        ElementsCache elementsCache = AppiumUIA2Driver.getInstance().getSessionOrThrow().getElementsCache();
+        final By by = ElementsLookupStrategy.ofName(strategy).toNativeSelector(selector);
+        AccessibleUiObject accessibleUiObject;
+        try {
+            accessibleUiObject = contextId == null
+                    ? findElement(by)
+                    : findElement(by, elementsCache.get(contextId));
+        } catch (UiObjectNotFoundException e) {
+            throw new ElementNotFoundException();
+        }
+        if (accessibleUiObject == null) {
+            throw new ElementNotFoundException();
+        }
+        // We deliberately don't put the found element into the cache as it is expected
+        // that scheduled actions might be repeated frequently and we don't want to fill the
+        // cache only with these elements
+        return toAndroidElement(accessibleUiObject, true, by, contextId);
+    }
+}

--- a/app/src/main/java/io/appium/uiautomator2/utils/gestures/Click.java
+++ b/app/src/main/java/io/appium/uiautomator2/utils/gestures/Click.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.appium.uiautomator2.utils.gestures;
+
+import android.graphics.Point;
+import android.graphics.Rect;
+
+import javax.annotation.Nullable;
+
+import io.appium.uiautomator2.model.AndroidElement;
+import io.appium.uiautomator2.model.AppiumUIA2Driver;
+import io.appium.uiautomator2.model.Session;
+import io.appium.uiautomator2.model.api.gestures.ClickModel;
+import io.appium.uiautomator2.model.internal.CustomUiDevice;
+
+public class Click extends BaseGesture {
+    @Nullable
+    public static Object perform(ClickModel clickModel) {
+        String elementId = clickModel.origin == null ? null : clickModel.origin.getUnifiedId();
+        AndroidElement element = null;
+        if (elementId == null && clickModel.locator != null) {
+            element = locateElement(clickModel.locator);
+        } else if (elementId != null) {
+            Session session = AppiumUIA2Driver.getInstance().getSessionOrThrow();
+            element = session.getElementsCache().get(elementId);
+        }
+        if (element == null) {
+            if (clickModel.offset == null) {
+                throw new IllegalArgumentException("Click offset coordinates must be provided " +
+                        "if element is not set");
+            }
+            CustomUiDevice.getInstance().getGestureController().click(
+                    clickModel.offset.toNativePoint()
+            );
+        } else {
+            if (clickModel.offset == null) {
+                element.click();
+            } else {
+                Rect bounds = element.getBounds();
+                Point location = new Point(
+                        bounds.left + clickModel.offset.x.intValue(),
+                        bounds.top + clickModel.offset.y.intValue()
+                );
+                CustomUiDevice.getInstance().getGestureController().click(location);
+            }
+        }
+        return null;
+    }
+}

--- a/app/src/main/java/io/appium/uiautomator2/utils/gestures/DoubleClick.java
+++ b/app/src/main/java/io/appium/uiautomator2/utils/gestures/DoubleClick.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.appium.uiautomator2.utils.gestures;
+
+import android.graphics.Point;
+import android.graphics.Rect;
+
+import javax.annotation.Nullable;
+
+import io.appium.uiautomator2.model.AndroidElement;
+import io.appium.uiautomator2.model.AppiumUIA2Driver;
+import io.appium.uiautomator2.model.Session;
+import io.appium.uiautomator2.model.api.gestures.DoubleClickModel;
+import io.appium.uiautomator2.model.internal.CustomUiDevice;
+
+public class DoubleClick extends BaseGesture {
+    @Nullable
+    public static Object perform(DoubleClickModel doubleClickModel) {
+        final String elementId = doubleClickModel.origin == null
+                ? null
+                : doubleClickModel.origin.getUnifiedId();
+        AndroidElement element = null;
+        if (elementId == null && doubleClickModel.locator != null) {
+            element = locateElement(doubleClickModel.locator);
+        } else if (elementId != null) {
+            Session session = AppiumUIA2Driver.getInstance().getSessionOrThrow();
+            element = session.getElementsCache().get(elementId);
+        }
+        if (element == null) {
+            if (doubleClickModel.offset == null) {
+                throw new IllegalArgumentException("Double click offset coordinates must be provided " +
+                        "if element is not set");
+            }
+            CustomUiDevice.getInstance().getGestureController().doubleClick(
+                    doubleClickModel.offset.toNativePoint()
+            );
+        } else {
+            if (doubleClickModel.offset == null) {
+                element.doubleClick();
+            } else {
+                Rect bounds = element.getBounds();
+                Point location = new Point(bounds.left + doubleClickModel.offset.x.intValue(),
+                        bounds.top + doubleClickModel.offset.y.intValue());
+                CustomUiDevice.getInstance().getGestureController().doubleClick(location);
+            }
+        }
+        return null;
+    }
+}

--- a/app/src/main/java/io/appium/uiautomator2/utils/gestures/LongClick.java
+++ b/app/src/main/java/io/appium/uiautomator2/utils/gestures/LongClick.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.appium.uiautomator2.utils.gestures;
+
+import android.graphics.Point;
+import android.graphics.Rect;
+
+import javax.annotation.Nullable;
+
+import io.appium.uiautomator2.model.AndroidElement;
+import io.appium.uiautomator2.model.AppiumUIA2Driver;
+import io.appium.uiautomator2.model.Session;
+import io.appium.uiautomator2.model.api.gestures.LongClickModel;
+import io.appium.uiautomator2.model.internal.CustomUiDevice;
+
+public class LongClick extends BaseGesture {
+    @Nullable
+    public static Object perform(LongClickModel longClickModel) {
+        final String elementId = longClickModel.origin == null
+                ? null
+                : longClickModel.origin.getUnifiedId();
+        AndroidElement element = null;
+        if (elementId == null && longClickModel.locator != null) {
+            element = locateElement(longClickModel.locator);
+        } else if (elementId != null) {
+            Session session = AppiumUIA2Driver.getInstance().getSessionOrThrow();
+            element = session.getElementsCache().get(elementId);
+        }
+        if (element == null) {
+            if (longClickModel.offset == null) {
+                throw new IllegalArgumentException("Long click offset coordinates must be provided " +
+                        "if element is not set");
+            }
+            CustomUiDevice.getInstance().getGestureController().longClick(
+                    longClickModel.offset.toNativePoint(),
+                    longClickModel.duration == null ? null : longClickModel.duration.longValue()
+            );
+        } else {
+            if (longClickModel.offset == null) {
+                if (longClickModel.duration == null) {
+                    element.longClick();
+                } else {
+                    element.longClick(longClickModel.duration.longValue());
+                }
+            } else {
+                Rect bounds = element.getBounds();
+                Point location = new Point(bounds.left + longClickModel.offset.x.intValue(),
+                        bounds.top + longClickModel.offset.y.intValue());
+                CustomUiDevice.getInstance().getGestureController().longClick(location,
+                        longClickModel.duration == null ? null : longClickModel.duration.longValue()
+                );
+            }
+        }
+        return null;
+    }
+}


### PR DESCRIPTION
The idea of this PR is to improve the handling of shortly-living UI elements on the client side. 

Webdriver protocol is REST-based, which means each particular command must be received from a remote client, processed by the server and then replied. It gets even longer in case we have proxies in between, which is always the case for cloud providers. This whole process takes time, which might be critical if the script tries to handle short-living UI primitives, like popups. Basically, a popup might already disappear until the UIA2 server gets a command to click it if the TTL of the popup is 3 seconds and the comm between server and client takes more than that.

Now about how this PR approaches the above issue:

If we known that the popup will appear later then on the client side we call something like

```python
driver.execute_script('mobile: scheduleAction', {
  'name': 'myPopupHandlingAction',
  'steps': [{
    'type': 'gesture',
    'name': 'clickPopupButtonStep',
    'payload': {
      'subtype': 'click',
      'locator': {
        'strategy': 'id',
        'selector': 'buttonIdentifier',
      }
    }
  }],
  'maxPass': 1,
  'times': 20,
})
```

which asks the server to *asynchronously* try the click action on the element located by `buttonIdentifier` every second up to 20 times. The script is also asked to stop as soon as at least one click passes.

Afterwards the client may asynchronously request to fetch the action history or to unschedule it explicitly.

Currently I have implemented 3 subtypes of `gesture` actions (click, doubleClick, and longClick) and 1 subtype of `source` action (xml).
