### PR TITLE
feat: settings API to get the topmost window from active package

### DIFF
--- a/app/src/main/java/io/appium/uiautomator2/model/settings/EnableTopmostWindowFromActivePackage.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/settings/EnableTopmostWindowFromActivePackage.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.appium.uiautomator2.model.settings;
+
+public class EnableTopmostWindowFromActivePackage extends AbstractSetting<Boolean> {
+    private static final String SETTING_NAME = "enableTopmostWindowFromActivePackage";
+    private static final boolean DEFAULT_VALUE = false;
+    private Boolean value = DEFAULT_VALUE;
+
+    public EnableTopmostWindowFromActivePackage() {
+        super(Boolean.class, SETTING_NAME);
+    }
+
+    @Override
+    public Boolean getValue() {
+        return value;
+    }
+
+    @Override
+    public Boolean getDefaultValue() {
+        return DEFAULT_VALUE;
+    }
+
+    @Override
+    protected void apply(Boolean topmostWindowFromActivePackageEnabled) {
+        value = topmostWindowFromActivePackageEnabled;
+    }
+}

--- a/app/src/main/java/io/appium/uiautomator2/model/settings/Settings.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/settings/Settings.java
@@ -23,6 +23,7 @@ public enum Settings {
     ELEMENT_RESPONSE_ATTRIBUTES(new ElementResponseAttributes()),
     ENABLE_MULTI_WINDOWS(new EnableMultiWindows()),
     ENABLE_NOTIFICATION_LISTENER(new EnableNotificationListener()),
+    ENABLE_TOPMOST_WINDOW_FROM_ACTIVE_PACKAGE(new EnableTopmostWindowFromActivePackage()),
     KEY_INJECTION_DELAY(new KeyInjectionDelay()),
     SCROLL_ACKNOWLEDGMENT_TIMEOUT(new ScrollAcknowledgmentTimeout()),
     SHOULD_USE_COMPACT_RESPONSES(new ShouldUseCompactResponses()),

--- a/app/src/main/java/io/appium/uiautomator2/utils/AXWindowHelpers.java
+++ b/app/src/main/java/io/appium/uiautomator2/utils/AXWindowHelpers.java
@@ -123,7 +123,9 @@ public class AXWindowHelpers {
                 return root;
             }
         }
-        throw new UiAutomator2Exception("No active window root found");
+        throw new UiAutomator2Exception(
+                String.format("Unable to find the active topmost window associated with %s package",
+                        activeRootPackageName));
     }
 
     public static AccessibilityNodeInfo[] getCachedWindowRoots() {

--- a/app/src/main/java/io/appium/uiautomator2/utils/AXWindowHelpers.java
+++ b/app/src/main/java/io/appium/uiautomator2/utils/AXWindowHelpers.java
@@ -22,12 +22,17 @@ import android.view.accessibility.AccessibilityNodeInfo;
 import android.view.accessibility.AccessibilityWindowInfo;
 
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
+import java.util.Objects;
 
+import static androidx.test.internal.util.Checks.checkNotNull;
 import io.appium.uiautomator2.common.exceptions.UiAutomator2Exception;
 import io.appium.uiautomator2.core.UiAutomatorBridge;
 import io.appium.uiautomator2.model.internal.CustomUiDevice;
 import io.appium.uiautomator2.model.settings.EnableMultiWindows;
+import io.appium.uiautomator2.model.settings.EnableTopmostWindowFromActivePackage;
 import io.appium.uiautomator2.model.settings.Settings;
 
 public class AXWindowHelpers {
@@ -101,20 +106,49 @@ public class AXWindowHelpers {
         return result.toArray(new AccessibilityNodeInfo[0]);
     }
 
+    private static AccessibilityNodeInfo getTopmostWindowRootFromActivePackage() {
+        CharSequence activeRootPackageName = checkNotNull(getActiveWindowRoot().getPackageName());
+
+        List<AccessibilityWindowInfo> windows = getWindows();
+        Collections.sort(windows, new Comparator<AccessibilityWindowInfo>() {
+            @Override
+            public int compare(AccessibilityWindowInfo w1, AccessibilityWindowInfo w2) {
+                return Integer.compare(w2.getLayer(), w1.getLayer()); // descending order
+            }
+        });
+        for (AccessibilityWindowInfo window : windows) {
+            AccessibilityNodeInfo root = window.getRoot();
+            if (root != null &&
+                    Objects.equals(root.getPackageName(), activeRootPackageName)) {
+                return root;
+            }
+        }
+        throw new UiAutomator2Exception("No active window root found");
+    }
+
     public static AccessibilityNodeInfo[] getCachedWindowRoots() {
         if (cachedWindowRoots == null) {
             // Multi-window searches are supported since API level 21
-            boolean shouldRetrieveAllWindowRoots = Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP
+            boolean isMultiWindowSupported = Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP;
+            boolean shouldRetrieveAllWindowRoots = isMultiWindowSupported
                     && Settings.get(EnableMultiWindows.class).getValue();
+            // Multi-window retrieval is needed to search the topmost window from active package.
+            boolean shouldRetrieveTopmostWindowRootFromActivePackage = isMultiWindowSupported
+                    && Settings.get(EnableTopmostWindowFromActivePackage.class).getValue();
             /*
-             * ENABLE_MULTI_WINDOWS is disabled by default
+             * ENABLE_MULTI_WINDOWS and ENABLE_TOPMOST_WINDOW_FROM_ACTIVE_PACKAGE
+             * are disabled by default
              * because UIAutomatorViewer captures active window properties and
              * end users always rely on its output while writing their tests.
              * https://code.google.com/p/android/issues/detail?id=207569
              */
             cachedWindowRoots = shouldRetrieveAllWindowRoots
                     ? getWindowRoots()
-                    : new AccessibilityNodeInfo[]{getActiveWindowRoot()};
+                    : new AccessibilityNodeInfo[] {
+                            shouldRetrieveTopmostWindowRootFromActivePackage
+                                    ? getTopmostWindowRootFromActivePackage()
+                                    : getActiveWindowRoot()
+                    };
         }
         return cachedWindowRoots;
     }

--- a/app/src/main/java/io/appium/uiautomator2/utils/AXWindowHelpers.java
+++ b/app/src/main/java/io/appium/uiautomator2/utils/AXWindowHelpers.java
@@ -83,11 +83,13 @@ public class AXWindowHelpers {
                         "manager could do its work", SystemClock.uptimeMillis() - start));
     }
 
+    private static List<AccessibilityWindowInfo> getWindows() {
+        return CustomUiDevice.getInstance().getUiAutomation().getWindows();
+    }
+
     private static AccessibilityNodeInfo[] getWindowRoots() {
         List<AccessibilityNodeInfo> result = new ArrayList<>();
-        List<AccessibilityWindowInfo> windows = CustomUiDevice.getInstance()
-                .getUiAutomation()
-                .getWindows();
+        List<AccessibilityWindowInfo> windows = getWindows();
         for (AccessibilityWindowInfo window : windows) {
             AccessibilityNodeInfo root = window.getRoot();
             if (root == null) {


### PR DESCRIPTION
This mirrors #508 but it addresses the compatibility issue reported in #509 by substituting code segments that are unsupported in certain older API levels.

The motivation and modifications introduced in #508 are also applicable to this one.

## What I checked (in addition to those in #508)

- Manually tested on the specified API levels (including the minimum supported one) to ensure that there are no errors upon launch.
    - [x] Android 5.0 (API level 21) 
    - [x] Android 12.0 (API level 31)
    - [x] Android 13.0 (API level 33)
