### PR TITLE
fix: Ignore start coordinates for the very first move action

### DIFF
--- a/.github/workflows/functional-test.yml
+++ b/.github/workflows/functional-test.yml
@@ -2,10 +2,14 @@ name: Functional Tests
 
 on: [pull_request]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   test:
     strategy:
+      fail-fast: false
       matrix:
         include:
         - platformVersion: "11.0"


### PR DESCRIPTION
We do not want to calculate coordinates for a very first pointerMove action in the chain as it is there to simply define the initial position of the cursor

Related to https://github.com/appium/java-client/issues/1954