### PR TITLE
chore : remove "/wd/hub" prefix to improve compatibility

### DIFF
--- a/app/src/main/java/io/appium/uiautomator2/http/ServerHandler.java
+++ b/app/src/main/java/io/appium/uiautomator2/http/ServerHandler.java
@@ -62,6 +62,10 @@ public class ServerHandler extends ChannelInboundHandlerAdapter {
 
         Logger.info(String.format("channel read: %s %s", request.getMethod().toString(), request.getUri()));
 
+        if (request.getUri().startsWith("/wd/hub")) {
+            request.setUri(request.getUri().substring(7));
+        }
+
         IHttpRequest httpRequest = new NettyHttpRequest(request);
         IHttpResponse httpResponse = new NettyHttpResponse(response);
         for (IHttpServlet handler : httpHandlers) {


### PR DESCRIPTION
This PR aims to enhance compatibility with previous appium versions by removing the "/wd/hub" prefix from URIs.

I am currently using Appium version 1.22.3, and I faced compatibility issues with the latest version of UIAutomator2 regarding the URI. I discovered that requests with the prefix "/wd/hub" were not compatible. By implementing a change to remove this specific prefix from incoming requests, I was able to enhance compatibility, allowing the latest version of UIAutomator2 to work with previous versions of Appium as well. This solution ensures a more seamless integration between these different versions, bridging the gap that existed due to the URI inconsistency.