### PR TITLE
chore: remove "/wd/hub" prefix to improve compatibility

### DIFF
--- a/app/src/main/java/io/appium/uiautomator2/http/ServerHandler.java
+++ b/app/src/main/java/io/appium/uiautomator2/http/ServerHandler.java
@@ -62,6 +62,10 @@ public class ServerHandler extends ChannelInboundHandlerAdapter {
 
         Logger.info(String.format("channel read: %s %s", request.getMethod().toString(), request.getUri()));
 
+        if (request.getUri().startsWith("/wd/hub")) {
+            request.setUri(request.getUri().substring(7));
+        }
+
         IHttpRequest httpRequest = new NettyHttpRequest(request);
         IHttpResponse httpResponse = new NettyHttpResponse(response);
         for (IHttpServlet handler : httpHandlers) {

--- a/app/src/main/java/io/appium/uiautomator2/http/ServerHandler.java
+++ b/app/src/main/java/io/appium/uiautomator2/http/ServerHandler.java
@@ -39,6 +39,9 @@ import static io.netty.handler.codec.http.HttpResponseStatus.OK;
 import static io.netty.handler.codec.http.HttpVersion.HTTP_1_1;
 
 public class ServerHandler extends ChannelInboundHandlerAdapter {
+
+    private static final String LEGACY_URI_PREFIX = "/wd/hub";
+
     private final List<IHttpServlet> httpHandlers;
 
     public ServerHandler(List<IHttpServlet> handlers) {
@@ -62,8 +65,10 @@ public class ServerHandler extends ChannelInboundHandlerAdapter {
 
         Logger.info(String.format("channel read: %s %s", request.getMethod().toString(), request.getUri()));
 
-        if (request.getUri().startsWith("/wd/hub")) {
-            request.setUri(request.getUri().substring(7));
+        // Check if the request URI starts with the legacy prefix, and remove it if present
+        // This ensures compatibility with clients using older versions
+        if (request.getUri().startsWith(LEGACY_URI_PREFIX)) {
+            request.setUri(request.getUri().substring(LEGACY_URI_PREFIX.length()));
         }
 
         IHttpRequest httpRequest = new NettyHttpRequest(request);


### PR DESCRIPTION
This PR aims to enhance compatibility with previous appium versions by removing the "/wd/hub" prefix from URIs.

I am currently using Appium version 1.22.3, and I faced compatibility issues with the latest version of UIAutomator2 regarding the URI. I discovered that requests with the prefix "/wd/hub" were not compatible. By implementing a change to remove this specific prefix from incoming requests, I was able to enhance compatibility, allowing the latest version of UIAutomator2 to work with previous versions of Appium as well. This solution ensures a more seamless integration between these different versions, bridging the gap that existed due to the URI inconsistency.