### PR TITLE
chore: Remove espresso from dependencies list

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -111,7 +111,6 @@ dependencies {
     testImplementation 'org.robolectric:robolectric:4.10.3'
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'
     androidTestImplementation 'com.squareup.okhttp:okhttp:2.7.5'
-    androidTestImplementation 'androidx.test.espresso:espresso-web:3.4.0'
     //noinspection GradleDependency
     androidTestImplementation 'junit:junit:4.12'
 }


### PR DESCRIPTION
It looks like this include was only supposed to be used in e2e tests but I don't observe any real invocation of it. Perhaps, it's some leftover from the past...