### PR TITLE
feat: bump targetSdkVersion from 30 to 31, and to 32

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -14,11 +14,11 @@ apply plugin: 'com.android.application'
 apply plugin: 'de.mobilej.unmock'
 
 android {
-    compileSdk 30
+    compileSdk 31
     defaultConfig {
         applicationId 'io.appium.uiautomator2'
         minSdkVersion 21
-        targetSdkVersion 30
+        targetSdkVersion 31
         versionCode 145
         archivesBaseName = 'appium-uiautomator2'
         /**

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -14,11 +14,11 @@ apply plugin: 'com.android.application'
 apply plugin: 'de.mobilej.unmock'
 
 android {
-    compileSdk 31
+    compileSdk 32
     defaultConfig {
         applicationId 'io.appium.uiautomator2'
         minSdkVersion 21
-        targetSdkVersion 31
+        targetSdkVersion 32
         versionCode 145
         archivesBaseName = 'appium-uiautomator2'
         /**

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -13,7 +13,9 @@
     <uses-permission android:name="android.permission.WAKE_LOCK" />
     <uses-permission android:name="android.permission.CHANGE_WIFI_STATE" />
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
-    <uses-permission android:name="android.permission.BLUETOOTH" />
+    <uses-permission android:name="android.permission.BLUETOOTH_SCAN" />
+    <uses-permission android:name="android.permission.BLUETOOTH"
+        android:maxSdkVersion="30"/>
     <!-- Note:
     Allowing permission to retrieve all installed applications
     -->


### PR DESCRIPTION
Lets try to use newer `targetSdkVersion`

AS has helpful feature to show suggestions we should fix in the upgrade. According to the hint, we should:

![Screenshot 2023-12-25 at 12 34 10 PM](https://github.com/appium/appium-uiautomator2-server/assets/5511591/86b734a7-3fb8-4fe0-be24-3dc7d14d2943)

![Screenshot 2023-12-25 at 12 34 17 PM](https://github.com/appium/appium-uiautomator2-server/assets/5511591/e53fb2dd-eadf-4e99-8395-0bf33311b813)

Bluetooth is the manifest update.

The 2nd one is https://developer.android.com/topic/performance/app-hibernation :
> If your app targets Android 11 (API level 30) or higher, and the user doesn't [interact with your app](https://developer.android.com/topic/performance/app-hibernation#app-usage) for a few months, the system places your app in a hibernation state. The system optimizes for storage space instead of performance, and the system protects user data. This system behavior is similar to what occurs when the user manually force-stops your app from system settings.

so maybe not related to the uia2 server.

The 3rd one is may not for the case. Possibly our settings app needs some update though.

The 4th one https://developer.android.com/about/versions/12/behavior-changes-12#notification-trampolines

> To improve app performance and UX, apps that target Android 12 or higher can't start activities from [services](https://developer.android.com/guide/components/services) or [broadcast receivers](https://developer.android.com/guide/components/broadcasts) that are used as notification trampolines. In other words, after the user taps on a notification, or an [action button](https://developer.android.com/training/notify-user/build-notification#Actions) within the notification, your app cannot call [startActivity()](https://developer.android.com/reference/android/content/Context#startActivity(android.content.Intent)) inside of a service or broadcast receiver.

Maybe we do not have the usage to start UIA2 server from the notification regularly.


After upgrading to 31, checked 32. Then no diffs as below, so i have bumped to 32 as well.

![Screenshot 2023-12-25 at 1 18 15 PM](https://github.com/appium/appium-uiautomator2-server/assets/5511591/869bdac0-6345-4f7e-975c-a5529534988a)
