### PR TITLE
feat: bump targetSdkVersion to 33

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -14,11 +14,11 @@ apply plugin: 'com.android.application'
 apply plugin: 'de.mobilej.unmock'
 
 android {
-    compileSdk 32
+    compileSdk 33
     defaultConfig {
         applicationId 'io.appium.uiautomator2'
         minSdkVersion 21
-        targetSdkVersion 32
+        targetSdkVersion 33
         versionCode 145
         archivesBaseName = 'appium-uiautomator2'
         /**

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -14,11 +14,11 @@ apply plugin: 'com.android.application'
 apply plugin: 'de.mobilej.unmock'
 
 android {
-    compileSdk 30
+    compileSdk 31
     defaultConfig {
         applicationId 'io.appium.uiautomator2'
         minSdkVersion 21
-        targetSdkVersion 30
+        targetSdkVersion 31
         versionCode 145
         archivesBaseName = 'appium-uiautomator2'
         /**

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -14,11 +14,11 @@ apply plugin: 'com.android.application'
 apply plugin: 'de.mobilej.unmock'
 
 android {
-    compileSdk 31
+    compileSdk 32
     defaultConfig {
         applicationId 'io.appium.uiautomator2'
         minSdkVersion 21
-        targetSdkVersion 31
+        targetSdkVersion 32
         versionCode 145
         archivesBaseName = 'appium-uiautomator2'
         /**

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -13,7 +13,9 @@
     <uses-permission android:name="android.permission.WAKE_LOCK" />
     <uses-permission android:name="android.permission.CHANGE_WIFI_STATE" />
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
-    <uses-permission android:name="android.permission.BLUETOOTH" />
+    <uses-permission android:name="android.permission.BLUETOOTH_SCAN" />
+    <uses-permission android:name="android.permission.BLUETOOTH"
+        android:maxSdkVersion="30"/>
     <!-- Note:
     Allowing permission to retrieve all installed applications
     -->

--- a/app/src/main/java/io/appium/uiautomator2/utils/AXWindowHelpers.java
+++ b/app/src/main/java/io/appium/uiautomator2/utils/AXWindowHelpers.java
@@ -16,6 +16,7 @@
 
 package io.appium.uiautomator2.utils;
 
+import android.accessibilityservice.AccessibilityService;
 import android.os.Build;
 import android.os.SystemClock;
 import android.view.accessibility.AccessibilityNodeInfo;
@@ -28,6 +29,9 @@ import java.util.List;
 import java.util.Objects;
 
 import static androidx.test.internal.util.Checks.checkNotNull;
+
+import static androidx.test.platform.app.InstrumentationRegistry.getInstrumentation;
+
 import io.appium.uiautomator2.common.exceptions.UiAutomator2Exception;
 import io.appium.uiautomator2.core.UiAutomatorBridge;
 import io.appium.uiautomator2.model.internal.CustomUiDevice;
@@ -47,8 +51,13 @@ public class AXWindowHelpers {
      */
     private static void clearAccessibilityCache() {
         try {
-            // This call invokes `AccessibilityInteractionClient.getInstance().clearCache();` method
-            UiAutomatorBridge.getInstance().getUiAutomation().setServiceInfo(null);
+            if (android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                AccessibilityService accessibilityService = getInstrumentation().getContext().getSystemService(AccessibilityService.class);
+                accessibilityService.clearCache();
+            } else {
+                // This call invokes `AccessibilityInteractionClient.getInstance().clearCache();` method
+                UiAutomatorBridge.getInstance().getUiAutomation().setServiceInfo(null);
+            }
         } catch (NullPointerException npe) {
             // it is fine
             // ignore


### PR DESCRIPTION
![Screenshot 2023-12-25 at 9 15 57 PM](https://github.com/appium/appium-uiautomator2-server/assets/5511591/84010fb9-f46e-4541-b533-401acb9563ab)

![Screenshot 2023-12-25 at 9 16 05 PM](https://github.com/appium/appium-uiautomator2-server/assets/5511591/7e28e196-08cc-4c07-9119-0d57442cd4f2)


[Update]:
Below one has been resolved by calling `Build.VERSION_CODES.TIRAMISU` condition with `accessibilityService.clearCache();` While existing method works with Android 14, probably the recommended way will be safe.


[Original]
One concern is https://developer.android.com/about/versions/13/changes/non-sdk-13#new-blocked

> The following code box lists all of the non-SDK interfaces that were unsupported in Android 12 (API level 31) that are blocked in Android 13 (API level 33). That is, these interfaces belong to the max-target-s list, so your app can only use these interfaces if it targets Android 12 (API level 31) or lower.
> Our goal is to make sure that public alternatives are available before we restrict non-SDK interfaces, and we understand that your app might have a valid use case for using these interfaces. If an interface that your app uses in a prior version is now blocked in Android 13, you should [request a new public API](https://developer.android.com/guide/app-compatibility/restrictions-non-sdk-interfaces#feature-request) for that interface.

> Landroid/view/accessibility/AccessibilityInteractionClient;->clearCache(I)V # Use [android.accessibilityservice.AccessibilityService#clearCache()](https://developer.android.com/reference/android/accessibilityservice/AccessibilityService#clearCache()) instead.


https://github.com/appium/appium-uiautomator2-server/blob/1a1d473fd2cae7b91dd30e2d2201f2afa078bf94/app/src/main/java/io/appium/uiautomator2/utils/AXWindowHelpers.java#L50-L51 could be related one.


i have tested the code with Android 13 and Android 14 by adding `Logger.info("Calling UiAutomatorBridge.getInstance().getUiAutomation().setServiceInfo(null);");` before the `UiAutomatorBridge.getInstance().getUiAutomation().setServiceInfo(null);` call. Then, like `driver.page_source` and find element printed logs as below and they worked without issue. Thus I think it should not be our concern for now.
```
12-25 21:24:01.221 21448 21508 I appium  : Waiting up to 10000ms for the device to idle
12-25 21:24:01.221 21448 21508 I appium  : Calling UiAutomatorBridge.getInstance().getUiAutomation().setServiceInfo(null);
12-25 21:24:01.254 21448 21508 W tomator2.server: Accessing hidden field Landroid/view/accessibility/AccessibilityNodeInfo;->mSourceNodeId:J (unsupported, reflection, allowed)
12-25 21:24:01.262 21448 21508 I appium  : AppiumResponse: {"sessionId":"26f68b31-9a37-42c4-8383-361594d89cbd","value":{"ELEMENT":"00000000-0000-0018-ffff-ffff000000d8","element-6066-11e4-a52e-4f735466cecf":"00000000-0000-0018-ffff-ffff000000d8"}}
12-25 21:24:01.437  1083  1200 D VSC     : @ 185020.220: [WO] Proposed rotation: 0, flat angle threshold: 65
```

