### PR TITLE
feat: get default display via displaymanager

### DIFF
--- a/app/src/main/java/io/appium/uiautomator2/core/UiAutomatorBridge.java
+++ b/app/src/main/java/io/appium/uiautomator2/core/UiAutomatorBridge.java
@@ -15,7 +15,11 @@
  */
 package io.appium.uiautomator2.core;
 
+import android.app.Instrumentation;
+import android.app.Service;
 import android.app.UiAutomation;
+import android.hardware.display.DisplayManager;
+import android.os.Build;
 import android.view.Display;
 import android.view.accessibility.AccessibilityNodeInfo;
 
@@ -54,6 +58,14 @@ public class UiAutomatorBridge {
     }
 
     public Display getDefaultDisplay() throws UiAutomator2Exception {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            Instrumentation instrumentation = (Instrumentation) invoke(getMethod(UiDevice.class, "getInstrumentation"), Device.getUiDevice());
+            DisplayManager displayManager = (DisplayManager) instrumentation.getContext().getSystemService(Service.DISPLAY_SERVICE);
+            return displayManager.getDisplay(Display.DEFAULT_DISPLAY);
+        }
+
+        // "getDefaultDisplay" called inside the UiDevice calls
+        // https://developer.android.com/reference/android/view/WindowManager#getDefaultDisplay()
         return (Display) invoke(getMethod(UiDevice.class, "getDefaultDisplay"), Device.getUiDevice());
     }
 }

--- a/app/src/main/java/io/appium/uiautomator2/core/UiAutomatorBridge.java
+++ b/app/src/main/java/io/appium/uiautomator2/core/UiAutomatorBridge.java
@@ -15,7 +15,6 @@
  */
 package io.appium.uiautomator2.core;
 
-import android.app.Instrumentation;
 import android.app.Service;
 import android.app.UiAutomation;
 import android.hardware.display.DisplayManager;
@@ -30,6 +29,8 @@ import io.appium.uiautomator2.utils.Device;
 
 import static io.appium.uiautomator2.utils.ReflectionUtils.getMethod;
 import static io.appium.uiautomator2.utils.ReflectionUtils.invoke;
+
+import static androidx.test.platform.app.InstrumentationRegistry.getInstrumentation;
 
 public class UiAutomatorBridge {
     private static UiAutomatorBridge INSTANCE = null;
@@ -59,8 +60,9 @@ public class UiAutomatorBridge {
 
     public Display getDefaultDisplay() throws UiAutomator2Exception {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-            Instrumentation instrumentation = (Instrumentation) invoke(getMethod(UiDevice.class, "getInstrumentation"), Device.getUiDevice());
-            DisplayManager displayManager = (DisplayManager) instrumentation.getContext().getSystemService(Service.DISPLAY_SERVICE);
+            // Device.getUiDevice gets the instance via 'androidx.test.platform.app.InstrumentationRegistry.getInstrumentation'
+            // context, thus here directly calls the method.
+            DisplayManager displayManager = (DisplayManager) getInstrumentation().getContext().getSystemService(Service.DISPLAY_SERVICE);
             return displayManager.getDisplay(Display.DEFAULT_DISPLAY);
         }
 


### PR DESCRIPTION
https://github.com/appium/appium-uiautomator2-server/issues/490#issuecomment-1870480657

Tested on Android 14 by calling `mobile:deviceInfo`:

Before

> {"androidId"=>"6d1ee9298ac43e90", "apiVersion"=>"34", "bluetooth"=>{"state"=>"ON"}, "brand"=>"google", "carrierName"=>"", "displayDensity"=>420, "locale"=>"en_US", "manufacturer"=>"Google", "model"=>"Pixel 7", "networks"=>[{"capabilities"=>{"SSID"=>nil, "linkDownBandwidthKbps"=>55349, "linkUpstreamBandwidthKbps"=>12000, "networkCapabilities"=>"NET_CAPABILITY_NOT_METERED,NET_CAPABILITY_INTERNET,NET_CAPABILITY_NOT_RESTRICTED,NET_CAPABILITY_TRUSTED,NET_CAPABILITY_NOT_VPN,NET_CAPABILITY_VALIDATED,NET_CAPABILITY_NOT_ROAMING,NET_CAPABILITY_FOREGROUND,NET_CAPABILITY_NOT_CONGESTED,NET_CAPABILITY_NOT_SUSPENDED", "signalStrength"=>-41, "transportTypes"=>"TRANSPORT_WIFI"}, "detailedState"=>"CONNECTED", "extraInfo"=>"", "isAvailable"=>true, "isConnected"=>true, "isFailover"=>false, "isRoaming"=>false, "state"=>"CONNECTED", "subtype"=>-1, "subtypeName"=>"", "type"=>1, "typeName"=>"WIFI"}], "platformVersion"=>"14", "realDisplaySize"=>"1080x2400", "timeZone"=>"America/Los_Angeles"}


After (with this change)
> {"androidId"=>"6d1ee9298ac43e90", "apiVersion"=>"34", "bluetooth"=>{"state"=>"ON"}, "brand"=>"google", "carrierName"=>"", "displayDensity"=>420, "locale"=>"en_US", "manufacturer"=>"Google", "model"=>"Pixel 7", "networks"=>[{"capabilities"=>{"SSID"=>nil, "linkDownBandwidthKbps"=>55349, "linkUpstreamBandwidthKbps"=>12000, "networkCapabilities"=>"NET_CAPABILITY_NOT_METERED,NET_CAPABILITY_INTERNET,NET_CAPABILITY_NOT_RESTRICTED,NET_CAPABILITY_TRUSTED,NET_CAPABILITY_NOT_VPN,NET_CAPABILITY_VALIDATED,NET_CAPABILITY_NOT_ROAMING,NET_CAPABILITY_FOREGROUND,NET_CAPABILITY_NOT_CONGESTED,NET_CAPABILITY_NOT_SUSPENDED", "signalStrength"=>-41, "transportTypes"=>"TRANSPORT_WIFI"}, "detailedState"=>"CONNECTED", "extraInfo"=>"", "isAvailable"=>true, "isConnected"=>true, "isFailover"=>false, "isRoaming"=>false, "state"=>"CONNECTED", "subtype"=>-1, "subtypeName"=>"", "type"=>1, "typeName"=>"WIFI"}], "platformVersion"=>"14", "realDisplaySize"=>"1080x2400", "timeZone"=>"America/Los_Angeles"}

Both had the same displayDensity and realDisplaySize, thus this should be ok.



Btw, below one is an error message I got when I called `getDisplay` via `instrumentation.getContext().getDisplay()`
```
[AndroidUiautomator2Driver@d969 (da8c073e)] Got response with status 500: {"sessionId":"6a55ea0a-409c-4a90-b988-ad28632953c2","value":{"error":"unknown error","message":"java.lang.UnsupportedOperationException: Tried to obtain display from a Context not associated with one. Only visual Contexts (such as Activity or one created with Context#createWindowContext) or ones created with Context#createDisplayContext are associated with displays. Other types of Contexts are typically related to background entities and may return an arbitrary display.","stacktrace":"java.lang.UnsupportedOperationException: Tried to obtain display from a Context not associated with one. Only visual Contexts (such as Activity or one created with Context#createWindowContext) or ones created with Context#createDisplayContext are associated with displays. Other types of Contexts are typically related to background entities and may return an arbitrary display.\n\tat android.app.ContextImpl.getDisplay(ContextImpl.java:3025)\n\tat io.appium.uiautomator2.core.UiAutomatorBridge.getDefaultDisplay(UiAutomatorBridge....
[W3C] Matched W3C error code 'unknown error' to UnknownError
[AndroidUiautomator2Driver@d969 (da8c073e)] Encountered internal error running command: An unknown server-side error occurred while processing the command. Original error: java.lang.UnsupportedOperationException: Tried to obtain display from a Context not associated with one. Only visual Contexts (such as Activity or one created with Context#createWindowContext) or ones created with Context#createDisplayContext are associated with displays. Other types of Contexts are typically related to background entities and may return an arbitrary display.
[AndroidUiautomator2Driver@d969 (da8c073e)] java.lang.UnsupportedOperationException: Tried to obtain display from a Context not associated with one. Only visual Contexts (such as Activity or one created with Context#createWindowContext) or ones created with Context#createDisplayContext are associated with displays. Other types of Contexts are typically related to background entities and may return an arbitrary display.
[AndroidUiautomator2Driver@d969 (da8c073e)] 	at android.app.ContextImpl.getDisplay(ContextImpl.java:3025)
```