### PR TITLE
feat: bump targetSdkVersion to 34

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -14,11 +14,11 @@ apply plugin: 'com.android.application'
 apply plugin: 'de.mobilej.unmock'
 
 android {
-    compileSdk 33
+    compileSdk 34
     defaultConfig {
         applicationId 'io.appium.uiautomator2'
         minSdkVersion 21
-        targetSdkVersion 33
+        targetSdkVersion 34
         versionCode 148
         archivesBaseName = 'appium-uiautomator2'
         /**


### PR DESCRIPTION
Once concern was regex related, but in my testing with this build on android 14 with page source, find element with XPath and send keys did not have any errors. Maybe should be ok. Lets see how CI will be...

![Screenshot 2023-12-29 at 7 32 40 PM](https://github.com/appium/appium-uiautomator2-server/assets/5511591/44bad880-5586-4fcf-8024-ac89d5a56e1f)

![Screenshot 2023-12-29 at 7 32 48 PM](https://github.com/appium/appium-uiautomator2-server/assets/5511591/a2e3e2df-f863-4db7-81d3-91f4be9802e6)

![Screenshot 2023-12-29 at 7 32 54 PM](https://github.com/appium/appium-uiautomator2-server/assets/5511591/2c0abfc2-2154-4ab1-889a-0ba7a70b193b)
