### PR TITLE
fix: use displayManager.getDisplay only for upcoming androidx.test.uiautomator:uiautomator:2.3.0-beta01

### DIFF
--- a/app/src/main/java/io/appium/uiautomator2/core/UiAutomatorBridge.java
+++ b/app/src/main/java/io/appium/uiautomator2/core/UiAutomatorBridge.java
@@ -59,15 +59,12 @@ public class UiAutomatorBridge {
     }
 
     public Display getDefaultDisplay() throws UiAutomator2Exception {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-            // Device.getUiDevice gets the instance via 'androidx.test.platform.app.InstrumentationRegistry.getInstrumentation'
-            // context, thus here directly calls the method.
-            DisplayManager displayManager = (DisplayManager) getInstrumentation().getContext().getSystemService(Service.DISPLAY_SERVICE);
-            return displayManager.getDisplay(Display.DEFAULT_DISPLAY);
-        }
+        // 'getDefaultDisplay' will be removed from androidx.test.uiautomator.UiDevice in 2.3.0-beta01,
+        // thus here only relies on the getDisplay.
 
-        // "getDefaultDisplay" called inside the UiDevice calls
-        // https://developer.android.com/reference/android/view/WindowManager#getDefaultDisplay()
-        return (Display) invoke(getMethod(UiDevice.class, "getDefaultDisplay"), Device.getUiDevice());
+        // Device.getUiDevice gets the instance via 'androidx.test.platform.app.InstrumentationRegistry.getInstrumentation'
+        // context, thus here directly calls the method.
+        DisplayManager displayManager = (DisplayManager) getInstrumentation().getContext().getSystemService(Service.DISPLAY_SERVICE);
+        return displayManager.getDisplay(Display.DEFAULT_DISPLAY);
     }
 }


### PR DESCRIPTION
A future compatibility fix in https://github.com/appium/appium-uiautomator2-server/issues/490

It looks like androidx.test.uiautomator.UiDevice in 2.3.0-beta01 dropped `getDefaultDisplay`, thus all versions should follow the `displayManager.getDisplay(Display.DEFAULT_DISPLAY);` way. The current master has no issue with the 2.2.0 version.



The API itself has existed since API level 17 https://developer.android.com/reference/android/hardware/display/DisplayManager#getDisplay(int), thus this change should be safe. (I have tested with an Android 9 real device. It worked)

I have tested `displayManager.getDisplay(Display.DEFAULT_DISPLAY);` works with Android 9 as well.