### PR TITLE
refactor: Tune the logic of BySelector creation

### DIFF
--- a/app/src/main/java/io/appium/uiautomator2/model/BySelectorHelper.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/BySelectorHelper.java
@@ -58,27 +58,17 @@ public class BySelectorHelper {
         result = result == null
                 ? By.checkable(node.isCheckable())
                 : result.checkable(node.isCheckable());
-        result = result == null
-                ? By.clickable(node.isClickable())
-                : result.clickable(node.isClickable());
-        result = result == null
-                ? By.longClickable(node.isLongClickable())
-                : result.longClickable(node.isLongClickable());
-        result = result == null
-                ? By.focusable(node.isFocusable())
-                : result.focusable(node.isFocusable());
-        result = result == null
-                ? By.scrollable(node.isScrollable())
-                : result.scrollable(node.isScrollable());
-
-        return result == null ? makeDummySelector() : result;
+        return result.clickable(node.isClickable())
+                .longClickable(node.isLongClickable())
+                .focusable(node.isFocusable())
+                .scrollable(node.isScrollable());
     }
 
     private static boolean hasValue(@Nullable CharSequence cs) {
         return cs != null && cs.length() > 0;
     }
 
-    public static BySelector makeDummySelector() {
-        return By.res(String.format("DUMMY:id/%s", UUID.randomUUID()));
+    private static BySelector makeDummySelector() {
+        return By.text(String.format("DUMMY:%s", UUID.randomUUID()));
     }
 }

--- a/app/src/main/java/io/appium/uiautomator2/model/BySelectorHelper.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/BySelectorHelper.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.appium.uiautomator2.model;
+
+import android.view.accessibility.AccessibilityNodeInfo;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.test.uiautomator.By;
+import androidx.test.uiautomator.BySelector;
+
+import java.util.UUID;
+
+public class BySelectorHelper {
+    private static BySelector makeDummySelector() {
+        return By.res(String.format("DUMMY:%s", UUID.randomUUID()));
+    }
+
+    @NonNull
+    public static BySelector toBySelector(@Nullable AccessibilityNodeInfo node) {
+        if (node == null) {
+            return makeDummySelector();
+        }
+
+        BySelector result = null;
+        // This might be simplified, but needs API 24+ with lambdas support
+        CharSequence className = node.getClassName();
+        if (className != null) {
+            result = By.clazz(className.toString());
+        }
+        CharSequence description = node.getContentDescription();
+        if (description != null) {
+            result = result == null
+                    ? By.desc(description.toString())
+                    : result.desc(description.toString());
+        }
+        CharSequence pkg = node.getPackageName();
+        if (pkg != null) {
+            result = result == null ? By.pkg(pkg.toString()) : result.pkg(pkg.toString());
+        }
+        CharSequence res = node.getViewIdResourceName();
+        if (res != null) {
+            result = result == null ? By.res(res.toString()) : result.res(res.toString());
+        }
+        CharSequence text = node.getText();
+        if (text != null) {
+            result = result == null ? By.text(text.toString()) : result.text(text.toString());
+        }
+
+        result = result == null
+                ? By.checkable(node.isCheckable())
+                : result.checkable(node.isCheckable());
+        result = result == null
+                ? By.checked(node.isChecked())
+                : result.checked(node.isChecked());
+        result = result == null
+                ? By.clickable(node.isClickable())
+                : result.clickable(node.isClickable());
+        result = result == null
+                ? By.longClickable(node.isLongClickable())
+                : result.longClickable(node.isLongClickable());
+        result = result == null
+                ? By.enabled(node.isEnabled())
+                : result.enabled(node.isEnabled());
+        result = result == null
+                ? By.focusable(node.isFocusable())
+                : result.focusable(node.isFocusable());
+        result = result == null
+                ? By.focused(node.isFocused())
+                : result.focused(node.isFocused());
+        result = result == null
+                ? By.scrollable(node.isScrollable())
+                : result.scrollable(node.isScrollable());
+        result = result == null
+                ? By.selected(node.isSelected())
+                : result.selected(node.isSelected());
+
+        return result == null ? makeDummySelector() : result;
+    }
+}

--- a/app/src/main/java/io/appium/uiautomator2/model/BySelectorHelper.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/BySelectorHelper.java
@@ -26,10 +26,6 @@ import androidx.test.uiautomator.BySelector;
 import java.util.UUID;
 
 public class BySelectorHelper {
-    private static BySelector makeDummySelector() {
-        return By.res(String.format("DUMMY:%s", UUID.randomUUID()));
-    }
-
     @NonNull
     public static BySelector toBySelector(@Nullable AccessibilityNodeInfo node) {
         if (node == null) {
@@ -37,27 +33,25 @@ public class BySelectorHelper {
         }
 
         BySelector result = null;
-        // This might be simplified, but needs API 24+ with lambdas support
+        // The below conditions might be simplified, but need API 24+ with lambdas support
         CharSequence className = node.getClassName();
-        if (className != null) {
+        if (hasValue(className)) {
             result = By.clazz(className.toString());
         }
-        CharSequence description = node.getContentDescription();
-        if (description != null) {
-            result = result == null
-                    ? By.desc(description.toString())
-                    : result.desc(description.toString());
+        CharSequence desc = node.getContentDescription();
+        if (hasValue(desc)) {
+            result = result == null ? By.desc(desc.toString()) : result.desc(desc.toString());
         }
         CharSequence pkg = node.getPackageName();
-        if (pkg != null) {
+        if (hasValue(pkg)) {
             result = result == null ? By.pkg(pkg.toString()) : result.pkg(pkg.toString());
         }
         CharSequence res = node.getViewIdResourceName();
-        if (res != null) {
+        if (hasValue(res)) {
             result = result == null ? By.res(res.toString()) : result.res(res.toString());
         }
         CharSequence text = node.getText();
-        if (text != null) {
+        if (hasValue(text)) {
             result = result == null ? By.text(text.toString()) : result.text(text.toString());
         }
 
@@ -65,30 +59,26 @@ public class BySelectorHelper {
                 ? By.checkable(node.isCheckable())
                 : result.checkable(node.isCheckable());
         result = result == null
-                ? By.checked(node.isChecked())
-                : result.checked(node.isChecked());
-        result = result == null
                 ? By.clickable(node.isClickable())
                 : result.clickable(node.isClickable());
         result = result == null
                 ? By.longClickable(node.isLongClickable())
                 : result.longClickable(node.isLongClickable());
         result = result == null
-                ? By.enabled(node.isEnabled())
-                : result.enabled(node.isEnabled());
-        result = result == null
                 ? By.focusable(node.isFocusable())
                 : result.focusable(node.isFocusable());
         result = result == null
-                ? By.focused(node.isFocused())
-                : result.focused(node.isFocused());
-        result = result == null
                 ? By.scrollable(node.isScrollable())
                 : result.scrollable(node.isScrollable());
-        result = result == null
-                ? By.selected(node.isSelected())
-                : result.selected(node.isSelected());
 
         return result == null ? makeDummySelector() : result;
+    }
+
+    private static boolean hasValue(@Nullable CharSequence cs) {
+        return cs != null && cs.length() > 0;
+    }
+
+    public static BySelector makeDummySelector() {
+        return By.res(String.format("DUMMY:id/%s", UUID.randomUUID()));
     }
 }

--- a/app/src/main/java/io/appium/uiautomator2/model/UiElementSnapshot.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/UiElementSnapshot.java
@@ -16,10 +16,7 @@
 
 package io.appium.uiautomator2.model;
 
-import android.annotation.TargetApi;
 import android.os.Build;
-import android.os.Bundle;
-import android.text.TextUtils;
 import android.util.Pair;
 import android.view.accessibility.AccessibilityNodeInfo;
 import android.widget.Toast;
@@ -44,8 +41,6 @@ import io.appium.uiautomator2.model.settings.Settings;
 import io.appium.uiautomator2.utils.Attribute;
 import io.appium.uiautomator2.utils.Logger;
 
-import static androidx.test.internal.util.Checks.checkNotNull;
-import static io.appium.uiautomator2.core.AxNodeInfoExtractor.toAxNodeInfo;
 import static io.appium.uiautomator2.utils.ReflectionUtils.setField;
 import static io.appium.uiautomator2.utils.StringHelpers.charSequenceToNullableString;
 
@@ -53,7 +48,6 @@ import static io.appium.uiautomator2.utils.StringHelpers.charSequenceToNullableS
  * A UiElement that gets attributes via the Accessibility API.
  * https://android.googlesource.com/platform/frameworks/testing/+/476328047e3f82d6d9be8ab23f502a670613f94c/uiautomator/library/src/com/android/uiautomator/core/AccessibilityNodeInfoDumper.java
  */
-@TargetApi(18)
 public class UiElementSnapshot extends UiElement<AccessibilityNodeInfo, UiElementSnapshot> {
     private final static String ROOT_NODE_NAME = "hierarchy";
     // The same order will be used for node attributes in xml page source
@@ -81,7 +75,7 @@ public class UiElementSnapshot extends UiElement<AccessibilityNodeInfo, UiElemen
 
     private UiElementSnapshot(AccessibilityNodeInfo node, int index, int depth, int maxDepth,
                               Set<Attribute> includedAttributes) {
-        super(checkNotNull(node));
+        super(Objects.requireNonNull(node));
         this.depth = depth;
         this.maxDepth = maxDepth;
         this.index = index;

--- a/app/src/main/java/io/appium/uiautomator2/model/internal/CustomUiDevice.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/internal/CustomUiDevice.java
@@ -47,6 +47,7 @@ import io.appium.uiautomator2.utils.NodeInfoList;
 import io.appium.uiautomator2.utils.ReflectionUtils;
 
 import static io.appium.uiautomator2.model.AccessibleUiObject.toAccessibleUiObject;
+import static io.appium.uiautomator2.model.BySelectorHelper.makeDummySelector;
 import static io.appium.uiautomator2.model.BySelectorHelper.toBySelector;
 import static io.appium.uiautomator2.utils.AXWindowHelpers.getCachedWindowRoots;
 import static io.appium.uiautomator2.utils.Device.getUiDevice;
@@ -153,7 +154,7 @@ public class CustomUiDevice {
 
     public synchronized GestureController getGestureController() {
         if (gestureController == null) {
-            UiObject2 dummyElement = toUiObject2(toBySelector(null), null);
+            UiObject2 dummyElement = toUiObject2(makeDummySelector(), null);
             Gestures gestures = new Gestures(getField("mGestures", dummyElement));
             gestureController = new GestureController(getField("mGestureController", dummyElement), gestures);
         }

--- a/app/src/main/java/io/appium/uiautomator2/model/internal/CustomUiDevice.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/internal/CustomUiDevice.java
@@ -22,8 +22,8 @@ import android.os.Build;
 import android.os.SystemClock;
 import android.view.accessibility.AccessibilityNodeInfo;
 
+import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-import androidx.test.uiautomator.By;
 import androidx.test.uiautomator.BySelector;
 import androidx.test.uiautomator.UiDevice;
 import androidx.test.uiautomator.UiObject2;
@@ -47,6 +47,7 @@ import io.appium.uiautomator2.utils.NodeInfoList;
 import io.appium.uiautomator2.utils.ReflectionUtils;
 
 import static io.appium.uiautomator2.model.AccessibleUiObject.toAccessibleUiObject;
+import static io.appium.uiautomator2.model.BySelectorHelper.toBySelector;
 import static io.appium.uiautomator2.utils.AXWindowHelpers.getCachedWindowRoots;
 import static io.appium.uiautomator2.utils.Device.getUiDevice;
 import static io.appium.uiautomator2.utils.ReflectionUtils.getConstructor;
@@ -56,7 +57,6 @@ import static io.appium.uiautomator2.utils.ReflectionUtils.invoke;
 
 public class CustomUiDevice {
     private static final int CHANGE_ROTATION_TIMEOUT_MS = 2000;
-
     private static final String FIELD_M_INSTRUMENTATION = "mInstrumentation";
 
     private static CustomUiDevice INSTANCE = null;
@@ -66,6 +66,7 @@ public class CustomUiDevice {
     private final Constructor<?> uiObject2Constructor;
     private final Instrumentation mInstrumentation;
     private GestureController gestureController;
+
 
     private CustomUiDevice() {
         this.mInstrumentation = (Instrumentation) getField(UiDevice.class, FIELD_M_INSTRUMENTATION, Device.getUiDevice());
@@ -94,24 +95,21 @@ public class CustomUiDevice {
         return getInstrumentation().getUiAutomation();
     }
 
-    private UiObject2 toUiObject2(@Nullable Object selector, @Nullable AccessibilityNodeInfo node) {
-        if (selector == null) {
-            // FIXME: The 'selector' should be proper By instance as non-null in the interaction.
-            Logger.debug("FIXME: selector argument should not be null in androidx.test.uiautomator:uiautomator:2.3.0");
-        }
-
+    private UiObject2 toUiObject2(@NonNull BySelector selector, @Nullable AccessibilityNodeInfo node) {
         // TODO: remove this comment after upgrading to androidx.test.uiautomator:uiautomator:2.3.0
         // UiObject2 with androidx.test.uiautomator:uiautomator:2.3.0 has below code to crate the instance,
         // thus if the node was None, it should create an empty element for the AccessibilityNodeInfo.
+        // <pre>
         //    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
         //        AccessibilityWindowInfo window = UiObject2.Api21Impl.getWindow(cachedNode);
         //        mDisplayId = window == null ? Display.DEFAULT_DISPLAY : UiObject2.Api30Impl.getDisplayId(window);
         //    } else {
         //        mDisplayId = Display.DEFAULT_DISPLAY;
         //    }
+        // </pre>
         AccessibilityNodeInfo accessibilityNodeInfo =
                 (node == null && android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.R)
-                ?  new AccessibilityNodeInfo()
+                ? new AccessibilityNodeInfo()
                 : node;
         Object[] constructorParams = {getUiDevice(), selector, accessibilityNodeInfo};
         try {
@@ -131,26 +129,31 @@ public class CustomUiDevice {
     @Nullable
     public AccessibleUiObject findObject(Object selector) throws UiAutomator2Exception {
         final AccessibilityNodeInfo node;
+        final BySelector realSelector;
         if (selector instanceof BySelector) {
             node = (AccessibilityNodeInfo) invoke(METHOD_FIND_MATCH, ByMatcherClass,
                     Device.getUiDevice(), selector, getCachedWindowRoots());
+            realSelector = (BySelector) selector;
         } else if (selector instanceof NodeInfoList) {
             node = ((NodeInfoList) selector).getFirst();
-            selector = toSelector(node);
+            realSelector = toBySelector(node);
         } else if (selector instanceof AccessibilityNodeInfo) {
             node = (AccessibilityNodeInfo) selector;
-            selector = toSelector(node);
+            realSelector = toBySelector(node);
         } else if (selector instanceof UiSelector) {
             return toAccessibleUiObject(getUiDevice().findObject((UiSelector) selector));
         } else {
-            throw new InvalidSelectorException("Selector of type " + selector.getClass().getName() + " not supported");
+            throw new InvalidSelectorException(String.format(
+                    "Selector of type %s not supported",
+                    selector == null ? null : selector.getClass().getName()
+            ));
         }
-        return node == null ? null : new AccessibleUiObject(toUiObject2(selector, node), node);
+        return node == null ? null : new AccessibleUiObject(toUiObject2(realSelector, node), node);
     }
 
     public synchronized GestureController getGestureController() {
         if (gestureController == null) {
-            UiObject2 dummyElement = toUiObject2(null, null);
+            UiObject2 dummyElement = toUiObject2(toBySelector(null), null);
             Gestures gestures = new Gestures(getField("mGestures", dummyElement));
             gestureController = new GestureController(getField("mGestureController", dummyElement), gestures);
         }
@@ -171,23 +174,17 @@ public class CustomUiDevice {
         } else if (selector instanceof NodeInfoList) {
             axNodesList = ((NodeInfoList) selector).getAll();
         } else {
-            throw new InvalidSelectorException("Selector of type " + selector.getClass().getName() + " not supported");
+            throw new InvalidSelectorException(String.format(
+                    "Selector of type %s not supported",
+                    selector == null ? null : selector.getClass().getName()
+            ));
         }
         for (AccessibilityNodeInfo node : axNodesList) {
-            UiObject2 uiObject2 = toUiObject2(toSelector(node), node);
+            UiObject2 uiObject2 = toUiObject2(toBySelector(node), node);
             ret.add(new AccessibleUiObject(uiObject2, node));
         }
 
         return ret;
-    }
-
-    @Nullable
-    private static BySelector toSelector(@Nullable AccessibilityNodeInfo nodeInfo) {
-        if (nodeInfo == null) {
-            return null;
-        }
-        final CharSequence className = nodeInfo.getClassName();
-        return className == null ? null : By.clazz(className.toString());
     }
 
     public ScreenRotation setRotationSync(ScreenRotation desired) {
@@ -204,6 +201,6 @@ public class CustomUiDevice {
             SystemClock.sleep(100);
         } while (System.currentTimeMillis() - start < CHANGE_ROTATION_TIMEOUT_MS);
         throw new InvalidElementStateException(String.format("Screen rotation cannot be changed to %s after %sms. " +
-                "Is it locked programmatically?", desired.toString(), CHANGE_ROTATION_TIMEOUT_MS));
+                "Is it locked programmatically?", desired, CHANGE_ROTATION_TIMEOUT_MS));
     }
 }

--- a/app/src/main/java/io/appium/uiautomator2/model/internal/Gestures.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/internal/Gestures.java
@@ -21,7 +21,6 @@ import static androidx.test.platform.app.InstrumentationRegistry.getInstrumentat
 import android.graphics.Point;
 import android.graphics.Rect;
 
-import androidx.test.platform.app.InstrumentationRegistry;
 import androidx.test.uiautomator.Direction;
 import androidx.test.uiautomator.UiObject2;
 

--- a/app/src/main/java/io/appium/uiautomator2/utils/AXWindowHelpers.java
+++ b/app/src/main/java/io/appium/uiautomator2/utils/AXWindowHelpers.java
@@ -28,8 +28,6 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
 
-import static androidx.test.internal.util.Checks.checkNotNull;
-
 import static androidx.test.platform.app.InstrumentationRegistry.getInstrumentation;
 
 import io.appium.uiautomator2.common.exceptions.UiAutomator2Exception;
@@ -116,7 +114,7 @@ public class AXWindowHelpers {
     }
 
     private static AccessibilityNodeInfo getTopmostWindowRootFromActivePackage() {
-        CharSequence activeRootPackageName = checkNotNull(getActiveWindowRoot().getPackageName());
+        CharSequence activeRootPackageName = Objects.requireNonNull(getActiveWindowRoot().getPackageName());
 
         List<AccessibilityWindowInfo> windows = getWindows();
         Collections.sort(windows, new Comparator<AccessibilityWindowInfo>() {
@@ -139,13 +137,11 @@ public class AXWindowHelpers {
 
     public static AccessibilityNodeInfo[] getCachedWindowRoots() {
         if (cachedWindowRoots == null) {
-            // Multi-window searches are supported since API level 21
-            boolean isMultiWindowSupported = Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP;
-            boolean shouldRetrieveAllWindowRoots = isMultiWindowSupported
-                    && Settings.get(EnableMultiWindows.class).getValue();
+            boolean shouldRetrieveAllWindowRoots = Settings.get(EnableMultiWindows.class).getValue();
             // Multi-window retrieval is needed to search the topmost window from active package.
-            boolean shouldRetrieveTopmostWindowRootFromActivePackage = isMultiWindowSupported
-                    && Settings.get(EnableTopmostWindowFromActivePackage.class).getValue();
+            boolean shouldRetrieveTopmostWindowRootFromActivePackage = Settings.get(
+                    EnableTopmostWindowFromActivePackage.class
+            ).getValue();
             /*
              * ENABLE_MULTI_WINDOWS and ENABLE_TOPMOST_WINDOW_FROM_ACTIVE_PACKAGE
              * are disabled by default


### PR DESCRIPTION
Done in preparation to UIA lib update to the version 2.3.0, where passing of `null` selector to UiObject2 is not allowed in the constructor.