### PR TITLE
test: improve stability of scrollByUiSelectorTest

### DIFF
--- a/app/src/androidTestE2eTest/java/io/appium/uiautomator2/unittest/test/DeviceCommandsTest.java
+++ b/app/src/androidTestE2eTest/java/io/appium/uiautomator2/unittest/test/DeviceCommandsTest.java
@@ -661,12 +661,11 @@ public class DeviceCommandsTest extends BaseTest {
      */
     @Test
     public void scrollByUiSelectorTest() throws JSONException {
-        startActivity(".preference.PreferencesFromCode");
-        waitForElement(By.id("android:id/list"));
+        startActivity(".ApiDemos");
+        Response response = findElement(By.accessibilityId("Views"));
+        clickAndWaitForStaleness(response.getElementId());
 
-        String uiSelectorSpec = "new UiSelector()" +
-                ".classNameMatches(\"android.widget.RelativeLayout\")" +
-                ".childSelector(new UiSelector().textStartsWith(\"Parent checkbox\"))";
+        String uiSelectorSpec = "new UiSelector().textStartsWith(\"WebView\")";
 
         By by = By.androidUiAutomator(uiSelectorSpec);
 


### PR DESCRIPTION
On my local device testing, it looks like this PR change would improve the stability of the scrollByUiSelectorTest.

The purpose of the testing is `UiSelector` with `scrollToElement`. Current master's scenario does not do any scroll as the screen size in the fact. This will let the scenario conduct actual scroll