### PR TITLE
fix: Recycling of screenshot bitmaps

### DIFF
--- a/app/src/main/java/io/appium/uiautomator2/utils/ScreenshotHelper.java
+++ b/app/src/main/java/io/appium/uiautomator2/utils/ScreenshotHelper.java
@@ -58,14 +58,16 @@ public class ScreenshotHelper {
             return takeDeviceScreenshot(String.class);
         }
 
-        Bitmap screenshot = takeDeviceScreenshot(Bitmap.class);
+        Bitmap fullScreenshot = takeDeviceScreenshot(Bitmap.class);
+        Bitmap elementScreenshot = null;
         try {
-            final Bitmap elementScreenshot = crop(screenshot, cropArea);
-            screenshot.recycle();
-            screenshot = elementScreenshot;
-            return Base64.encodeToString(compress(screenshot), Base64.NO_WRAP);
+            elementScreenshot = crop(fullScreenshot, cropArea);
+            return Base64.encodeToString(compress(elementScreenshot), Base64.NO_WRAP);
         } finally {
-            screenshot.recycle();
+            fullScreenshot.recycle();
+            if (elementScreenshot != null && elementScreenshot != fullScreenshot) {
+                elementScreenshot.recycle();
+            }
         }
     }
 


### PR DESCRIPTION
Addresses https://github.com/appium/appium-uiautomator2-server/issues/608

I turns out the `Bitmap.createBitmap` does not always create a new Bitmap instance and may also return the same instance that has been passed in arguments.