### PR TITLE
fix: Revert "fix: Always make sure we put valid utf8-encoded strings into attribute values"

### DIFF
--- a/app/src/main/java/io/appium/uiautomator2/utils/XMLHelpers.java
+++ b/app/src/main/java/io/appium/uiautomator2/utils/XMLHelpers.java
@@ -18,7 +18,6 @@ package io.appium.uiautomator2.utils;
 
 import androidx.annotation.Nullable;
 
-import java.nio.charset.StandardCharsets;
 import java.util.regex.Pattern;
 
 public abstract class XMLHelpers {
@@ -51,18 +50,7 @@ public abstract class XMLHelpers {
     @Nullable
     public static String toSafeString(@Nullable Object source, String replacement) {
         return source == null ? null : XML10_PATTERN
-                .matcher(toSafeUtf8String(String.valueOf(source)))
+                .matcher(String.valueOf(source))
                 .replaceAll(replacement);
-    }
-
-    @Nullable
-    public static String toSafeUtf8String(@Nullable String source) {
-        if (source == null) {
-            return null;
-        }
-
-        // This method always replaces malformed-input and unmappable-character sequences
-        // with this charset's default replacement byte array.
-        return new String(source.getBytes(StandardCharsets.UTF_8), StandardCharsets.UTF_8);
     }
 }

--- a/app/src/test/java/io/appium/uiautomator2/utils/XMLHelpersTests.java
+++ b/app/src/test/java/io/appium/uiautomator2/utils/XMLHelpersTests.java
@@ -34,8 +34,6 @@ import org.xml.sax.SAXException;
 
 import static org.junit.Assert.assertEquals;
 
-import static io.appium.uiautomator2.utils.XMLHelpers.toSafeString;
-
 import android.os.SystemClock;
 
 import java.io.ByteArrayInputStream;
@@ -238,12 +236,6 @@ public class XMLHelpersTests {
         } catch (XPathExpressionException e) {
             throw new RuntimeException(e);
         }
-    }
-
-    @Test
-    public void createsSafeXmlString() {
-        String text = toSafeString("°C\u000b", "?");
-        assertEquals(text, "°C?");
     }
 
     @Test


### PR DESCRIPTION
Reverts appium/appium-uiautomator2-server#661

It turned out there was a [bug in Node.js](https://github.com/appium/appium/issues/20503#issuecomment-2357928628) causing encoding issues. This server patch may reverted now as obsolete