### PR TITLE
Add support for setting the current display

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -19,12 +19,12 @@ android {
         applicationId 'io.appium.uiautomator2'
         minSdkVersion 21
         targetSdkVersion 34
-        versionCode 210
+        versionCode 211
         archivesBaseName = 'appium-uiautomator2'
         /**
          * versionName should be updated and inline with version in package.json for every npm release.
          */
-        versionName '7.3.1'
+        versionName '7.4.0'
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
     }
     buildTypes {

--- a/app/src/main/java/io/appium/uiautomator2/core/AccessibilityNodeInfoDumper.java
+++ b/app/src/main/java/io/appium/uiautomator2/core/AccessibilityNodeInfoDumper.java
@@ -148,7 +148,7 @@ public class AccessibilityNodeInfoDumper {
     }
 
     private void addDisplayInfo() throws IOException {
-        Display display = UiAutomatorBridge.getInstance().getDefaultDisplay();
+        Display display = UiAutomatorBridge.getInstance().getCurrentDisplay();
         Point size = new Point();
         display.getSize(size);
         serializer.attribute(NAMESPACE, "rotation", Integer.toString(display.getRotation()));

--- a/app/src/main/java/io/appium/uiautomator2/core/UiAutomatorBridge.java
+++ b/app/src/main/java/io/appium/uiautomator2/core/UiAutomatorBridge.java
@@ -24,6 +24,8 @@ import android.view.accessibility.AccessibilityNodeInfo;
 import androidx.test.uiautomator.UiDevice;
 
 import io.appium.uiautomator2.common.exceptions.UiAutomator2Exception;
+import io.appium.uiautomator2.model.settings.CurrentDisplayId;
+import io.appium.uiautomator2.model.settings.Settings;
 import io.appium.uiautomator2.utils.Device;
 
 import static io.appium.uiautomator2.utils.ReflectionUtils.getMethod;
@@ -43,6 +45,10 @@ public class UiAutomatorBridge {
         return INSTANCE;
     }
 
+    public int getCurrentDisplayId() {
+        return Settings.get(CurrentDisplayId.class).getValue();
+    }
+
     public InteractionController getInteractionController() throws UiAutomator2Exception {
         return new InteractionController(invoke(getMethod(UiDevice.class, "getInteractionController"),
                 Device.getUiDevice()));
@@ -57,13 +63,13 @@ public class UiAutomatorBridge {
         return (UiAutomation) invoke(getMethod(UiDevice.class, "getUiAutomation"), Device.getUiDevice());
     }
 
-    public Display getDefaultDisplay() throws UiAutomator2Exception {
+    public Display getCurrentDisplay() throws UiAutomator2Exception {
         // 'getDefaultDisplay' will be removed from androidx.test.uiautomator.UiDevice in 2.3.0-beta01,
         // thus here only relies on the getDisplay.
 
         // Device.getUiDevice gets the instance via 'androidx.test.platform.app.InstrumentationRegistry.getInstrumentation'
         // context, thus here directly calls the method.
         DisplayManager displayManager = (DisplayManager) getInstrumentation().getContext().getSystemService(Service.DISPLAY_SERVICE);
-        return displayManager.getDisplay(Display.DEFAULT_DISPLAY);
+        return displayManager.getDisplay(this.getCurrentDisplayId());
     }
 }

--- a/app/src/main/java/io/appium/uiautomator2/handler/GetDisplayDensity.java
+++ b/app/src/main/java/io/appium/uiautomator2/handler/GetDisplayDensity.java
@@ -31,7 +31,7 @@ public class GetDisplayDensity extends SafeRequestHandler {
     @Override
     protected AppiumResponse safeHandle(IHttpRequest request) {
         DisplayMetrics metrics = new DisplayMetrics();
-        UiAutomatorBridge.getInstance().getDefaultDisplay().getMetrics(metrics);
+        UiAutomatorBridge.getInstance().getCurrentDisplay().getMetrics(metrics);
         return new AppiumResponse(getSessionId(request), metrics.densityDpi);
     }
 }

--- a/app/src/main/java/io/appium/uiautomator2/model/settings/CurrentDisplayId.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/settings/CurrentDisplayId.java
@@ -1,0 +1,28 @@
+package io.appium.uiautomator2.model.settings;
+
+import android.view.Display;
+
+public class CurrentDisplayId extends AbstractSetting<Integer> {
+    private static final String SETTING_NAME = "currentDisplayId";
+    private static final Integer DEFAULT_VALUE = Display.DEFAULT_DISPLAY;
+    private Integer value = DEFAULT_VALUE;
+
+    public CurrentDisplayId() {
+        super(Integer.class, SETTING_NAME);
+    }
+
+    @Override
+    public Integer getValue() {
+        return value;
+    }
+
+    @Override
+    public Integer getDefaultValue() {
+        return DEFAULT_VALUE;
+    }
+
+    @Override
+    protected void apply(Integer currentDisplayId) {
+        value = currentDisplayId;
+    }
+}

--- a/app/src/main/java/io/appium/uiautomator2/model/settings/Settings.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/settings/Settings.java
@@ -46,7 +46,8 @@ public enum Settings {
     MJPEG_SERVER_SCREENSHOT_QUALITY(new MjpegServerScreenshotQuality()),
     MJPEG_BILINEAR_FILTERING(new MjpegBilinearFiltering()),
     USE_RESOURCES_FOR_ORIENTATION_DETECTION(new UseResourcesForOrientationDetection()),
-    SNAPSHOT_MAX_DEPTH(new SnapshotMaxDepth());
+    SNAPSHOT_MAX_DEPTH(new SnapshotMaxDepth()),
+    CURRENT_DISPLAY_ID(new CurrentDisplayId());
 
     private final ISetting<?> setting;
 

--- a/app/src/main/java/io/appium/uiautomator2/utils/AXWindowHelpers.java
+++ b/app/src/main/java/io/appium/uiautomator2/utils/AXWindowHelpers.java
@@ -16,7 +16,9 @@
 
 package io.appium.uiautomator2.utils;
 
+import android.os.Build;
 import android.os.SystemClock;
+import android.util.SparseArray;
 import android.view.accessibility.AccessibilityNodeInfo;
 import android.view.accessibility.AccessibilityWindowInfo;
 
@@ -87,7 +89,17 @@ public class AXWindowHelpers {
     }
 
     private static List<AccessibilityWindowInfo> getWindows() {
-        return CustomUiDevice.getInstance().getUiAutomation().getWindows();
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            int currentDisplayId = UiAutomatorBridge.getInstance().getCurrentDisplayId();
+
+            SparseArray<List<AccessibilityWindowInfo>> windowsOnAllDisplays= CustomUiDevice.getInstance().getUiAutomation().getWindowsOnAllDisplays();
+
+            return windowsOnAllDisplays.get(currentDisplayId);
+        }
+        else {
+            return CustomUiDevice.getInstance().getUiAutomation().getWindows();
+        }
+
     }
 
     private static AccessibilityNodeInfo[] getWindowRoots() {

--- a/app/src/main/java/io/appium/uiautomator2/utils/DeviceInfoHelper.java
+++ b/app/src/main/java/io/appium/uiautomator2/utils/DeviceInfoHelper.java
@@ -136,7 +136,7 @@ public class DeviceInfoHelper {
      * @return The logical density of the display in Density Independent Pixel units.
      */
     public int getDisplayDensity() {
-        Display display = UiAutomatorBridge.getInstance().getDefaultDisplay();
+        Display display = UiAutomatorBridge.getInstance().getCurrentDisplay();
         DisplayMetrics metrics = new DisplayMetrics();
         display.getRealMetrics(metrics);
         return (int) (metrics.density * 160);
@@ -262,7 +262,7 @@ public class DeviceInfoHelper {
      * @return The display size in 'WxH' format
      */
     public String getRealDisplaySize() {
-        Display display = UiAutomatorBridge.getInstance().getDefaultDisplay();
+        Display display = UiAutomatorBridge.getInstance().getCurrentDisplay();
         android.graphics.Point p = new android.graphics.Point();
         display.getRealSize(p);
         return String.format("%sx%s", p.x, p.y);

--- a/app/src/main/java/io/appium/uiautomator2/utils/DisplayIdHelper.java
+++ b/app/src/main/java/io/appium/uiautomator2/utils/DisplayIdHelper.java
@@ -1,0 +1,48 @@
+package io.appium.uiautomator2.utils;
+
+import android.annotation.SuppressLint;
+import android.view.Display;
+
+import java.lang.reflect.Method;
+
+import io.appium.uiautomator2.common.exceptions.UiAutomator2Exception;
+
+public class DisplayIdHelper {
+    /**
+     * Attempts to find the physical display ID that corresponds to the given Display.
+     *
+     * @param display android.view.Display instance
+     * @return matching physical display ID, or -1 if not found
+     */
+    public static long getPhysicalDisplayId(Display display) {
+        long physicalDisplayId = tryGetUsingAddress(display);
+
+        return physicalDisplayId;
+    }
+
+    @SuppressLint("BlockedPrivateApi")
+    private static long tryGetUsingAddress(Display display) {
+        try {
+            // Method is marked as public with @hide in AOSP https://cs.android.com/android/platform/superproject/main/+/main:frameworks/base/core/java/android/view/Display.java;l=836?q=Display
+            Method getAddress = ReflectionUtils.getMethod(display.getClass(), "getAddress");
+
+            Object address = getAddress.invoke(display);
+
+            Method getPhysicalDisplayId = ReflectionUtils.getMethod(address.getClass(), "getPhysicalDisplayId");
+
+            long physicalDisplayId = (long) getPhysicalDisplayId.invoke(address);
+
+            return physicalDisplayId;
+
+        } catch (UiAutomator2Exception e) {
+            Logger.error("Required method not found", e);
+        } catch (IllegalAccessException | IllegalArgumentException | SecurityException e) {
+            Logger.error("Reflection access error", e);
+        } catch (Exception e) {
+            Logger.error("Unexpected error while resolving physical display ID", e);
+        }
+
+        return -1;
+    }
+
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "appium-uiautomator2-server",
-  "version": "7.3.1",
+  "version": "7.4.0",
   "description": "A netty server with uiautomator2 handlers",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
The code changes that enable support for multiple displays build on top of the existing Settings API from
Appium. We've introduced a new setting named currentDisplayId (int) that can be set when creating the
Appium session and also updated throughout the session lifetime to control the display where the element
lookup and interactions happen.