### PR TITLE
#709 add individual exception for androidx.compose.ui.viewinterop.ViewFactoryHolder

### DIFF
--- a/app/src/main/java/io/appium/uiautomator2/model/UiElementSnapshot.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/UiElementSnapshot.java
@@ -297,8 +297,11 @@ public class UiElementSnapshot extends UiElement<AccessibilityNodeInfo, UiElemen
                 continue;
             }
 
+	        // See https://issuetracker.google.com/issues/354958193
+	        boolean mayContainVisibleChildren = node.getClassName().equals("androidx.compose.ui.viewinterop.ViewFactoryHolder");
+
             // Ignore if the element is not visible on the screen
-            if (areInvisibleElementsAllowed || child.isVisibleToUser()) {
+            if (areInvisibleElementsAllowed || child.isVisibleToUser() || mayContainVisibleChildren) {
                 children.add(take(child, index, depth + 1, includedAttributes));
             }
         }


### PR DESCRIPTION
Small fix for https://issuetracker.google.com/issues/354958193

Visible elements under ViewFactoryHolder are now shown in the page source.

C&C welcome,

Christian