### PR TITLE
 feat: add tooltip-text and text-has-clickable-span attributes to UI elements

### DIFF
--- a/app/src/main/java/io/appium/uiautomator2/utils/Attribute.java
+++ b/app/src/main/java/io/appium/uiautomator2/utils/Attribute.java
@@ -70,6 +70,8 @@ public enum Attribute {
     CONTENT_INVALID(new String[]{"content-invalid", "contentInvalid"}),
     ERROR_TEXT(new String[]{"error", "errorText"}),
     PANE_TITLE(new String[]{"pane-title", "paneTitle"}),
+    TOOLTIP_TEXT(new String[]{"tooltip-text", "tooltipText"}),
+    TEXT_HAS_CLICKABLE_SPAN(new String[]{"text-has-clickable-span", "textHasClickableSpan"}),
     ACTIONS(new String[]{"actions"});
 
     private final String[] aliases;


### PR DESCRIPTION
We previously worked on a similar PR that added more fields to the UI elements here:
https://github.com/appium/appium-uiautomator2-server/pull/682

Now, I’d like to add a few additional fields:

 - `tooltip-text` - The value of AccessibilityNodeInfo::getTooltipText() - In many cases, this data can be obtained from the `content-desc` field, but for some apps a separate field is necessary (particularly for Flutter and React Native apps);

 - `text-has-clickable-span` - A new custom field that describes whether there are ClickableSpan or URLSpan elements in the TextView content. We need to check if the TextView has clickable elements and thus actually can be focused.
 
 Both fields are empty for most elements and will appear only on specific nodes, so there will be no page source bloat. 