### PR TITLE
feat: Bump Node.js version

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,8 +13,8 @@
     "uiautomator2"
   ],
   "engines": {
-    "node": ">=14",
-    "npm": ">=8"
+    "node": "^20.19.0 || ^22.12.0 || >=24.0.0",
+    "npm": ">=10"
   },
   "author": "Appium Contributors",
   "license": "Apache-2.0",
@@ -42,12 +42,12 @@
     "test": "./gradlew testServerDebugUnitTest"
   },
   "devDependencies": {
-    "@appium/eslint-config-appium-ts": "^1.0.0",
-    "@appium/support": "^6.0.0",
+    "@appium/eslint-config-appium-ts": "^2.0.0-rc.1",
+    "@appium/support": "^7.0.0-rc.1",
     "@semantic-release/changelog": "^6.0.1",
     "@semantic-release/git": "^10.0.1",
     "android-apidemos": "^4.0.0",
-    "appium-adb": "^12.0.2",
+    "appium-adb": "^13.0.0",
     "bluebird": "^3.7.2",
     "conventional-changelog-conventionalcommits": "^9.0.0",
     "semantic-release": "^24.0.0",


### PR DESCRIPTION
BREAKING CHANGE: Required Node.js version has been bumped to ^20.19.0 || ^22.12.0 || >=24.0.0
BREAKING CHANGE: Required npm version has been bumped to >=10