### PR TITLE
feat: Add multi-display support for Android automation

### DIFF
--- a/app/src/main/java/io/appium/uiautomator2/common/selector/UiSelectorBuilder.java
+++ b/app/src/main/java/io/appium/uiautomator2/common/selector/UiSelectorBuilder.java
@@ -1,0 +1,735 @@
+package io.appium.uiautomator2.common.selector;
+
+import android.os.Build;
+
+import androidx.annotation.NonNull;
+import androidx.test.uiautomator.By;
+import androidx.test.uiautomator.BySelector;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.regex.Pattern;
+
+/**
+ * Builder for BySelector
+ * - Supports multiple condition combinations for element selection
+ * - Automatically compiles regular expressions
+ * - Prioritizes displayId if provided
+ * - Throws exception if no base condition is provided
+ */
+public class UiSelectorBuilder {
+    private static final int MAX_RECURSION_DEPTH = 10;
+
+    // Basic selection conditions
+    private String res;
+    private String text;
+    private String desc;
+    private String hint;
+    private String clazz;
+    private String pkg;
+
+    // Regex-based conditions
+    private Pattern resPattern;
+    private Pattern textPattern;
+    private Pattern descPattern;
+    private Pattern hintPattern;
+    private Pattern clazzPattern;
+    private Pattern pkgPattern;
+
+    // Resource package + ID combination
+    private String resId;
+    private String resPkg;
+
+
+    // Boolean state conditions
+    private Boolean checkable;
+    private Boolean checked;
+    private Boolean clickable;
+    private Boolean enabled;
+    private Boolean focusable;
+    private Boolean focused;
+    private Boolean longClickable;
+    private Boolean scrollable;
+    private Boolean selected;
+
+    // Hierarchy conditions
+    private BySelector hasParent;
+    private BySelector hasChild;
+    private BySelector hasAncestor;
+    private BySelector hasDescendant;
+    private Integer hasAncestorDistance;
+    private Integer hasDescendantDepth;
+
+    // Depth and display conditions
+    private Integer depth;
+    private Integer minDepth;
+    private Integer maxDepth;
+    private Integer displayId;
+
+    // Records which base condition is used
+    private String usedBaseCondition = null;
+
+    private UiSelectorBuilder() {}
+
+    /**
+     *  Creates a new builder instance
+     */
+    public static UiSelectorBuilder create() {
+        return new UiSelectorBuilder();
+    }
+
+    // ==================== Basic condition methods ====================
+
+    public UiSelectorBuilder res(String res) {
+        this.res = res;
+        return this;
+    }
+
+    public UiSelectorBuilder text(String text) {
+        this.text = text;
+        return this;
+    }
+
+    public UiSelectorBuilder desc(String desc) {
+        this.desc = desc;
+        return this;
+    }
+
+    public UiSelectorBuilder clazz(String clazz) {
+        this.clazz = clazz;
+        return this;
+    }
+
+    public UiSelectorBuilder pkg(String pkg) {
+        this.pkg = pkg;
+        return this;
+    }
+
+    public UiSelectorBuilder hint(String hint) {
+        this.hint = hint;
+        return this;
+    }
+
+    // ==================== Regex condition methods ====================
+
+    public UiSelectorBuilder clazzPattern(Pattern clazzPattern) {
+        this.clazzPattern = clazzPattern;
+        return this;
+    }
+
+    public UiSelectorBuilder textPattern(Pattern textPattern) {
+        this.textPattern = textPattern;
+        return this;
+    }
+
+    public UiSelectorBuilder descPattern(Pattern descPattern) {
+        this.descPattern = descPattern;
+        return this;
+    }
+
+    public UiSelectorBuilder pkgPattern(Pattern pkgPattern) {
+        this.pkgPattern = pkgPattern;
+        return this;
+    }
+
+    public UiSelectorBuilder resPattern(Pattern resPattern) {
+        this.resPattern = resPattern;
+        return this;
+    }
+
+    public UiSelectorBuilder hintPattern(Pattern hintPattern) {
+        this.hintPattern = hintPattern;
+        return this;
+    }
+
+    // ==================== Text matching variants ====================
+
+    public UiSelectorBuilder textContains(String substring) {
+        this.textPattern = Pattern.compile(".*" + Pattern.quote(substring) + ".*");
+        return this;
+    }
+
+    public UiSelectorBuilder textStartsWith(String prefix) {
+        this.textPattern = Pattern.compile("^" + Pattern.quote(prefix) + ".*");
+        return this;
+    }
+
+    public UiSelectorBuilder textEndsWith(String suffix) {
+        this.textPattern = Pattern.compile(".*" + Pattern.quote(suffix) + "$");
+        return this;
+    }
+
+    public UiSelectorBuilder descContains(String substring) {
+        this.descPattern = Pattern.compile(".*" + Pattern.quote(substring) + ".*");
+        return this;
+    }
+
+    public UiSelectorBuilder descStartsWith(String prefix) {
+        this.descPattern = Pattern.compile("^" + Pattern.quote(prefix) + ".*");
+        return this;
+    }
+
+    public UiSelectorBuilder descEndsWith(String suffix) {
+        this.descPattern = Pattern.compile(".*" + Pattern.quote(suffix) + "$");
+        return this;
+    }
+
+    public UiSelectorBuilder hintContains(String substring) {
+        this.hintPattern = Pattern.compile(".*" + Pattern.quote(substring) + ".*");
+        return this;
+    }
+
+    public UiSelectorBuilder hintStartsWith(String prefix) {
+        this.hintPattern = Pattern.compile("^" + Pattern.quote(prefix) + ".*");
+        return this;
+    }
+
+    public UiSelectorBuilder hintEndsWith(String suffix) {
+        this.hintPattern = Pattern.compile(".*" + Pattern.quote(suffix) + "$");
+        return this;
+    }
+
+    // ==================== Resource package + ID combination ====================
+
+    public UiSelectorBuilder res(String resPkg, String resId) {
+        this.resPkg = resPkg;
+        this.resId = resId;
+        return this;
+    }
+
+    // ==================== Boolean state methods ====================
+
+    public UiSelectorBuilder checkable(boolean checkable) {
+        this.checkable = checkable;
+        return this;
+    }
+
+    public UiSelectorBuilder checked(boolean checked) {
+        this.checked = checked;
+        return this;
+    }
+
+    public UiSelectorBuilder clickable(boolean clickable) {
+        this.clickable = clickable;
+        return this;
+    }
+
+    public UiSelectorBuilder enabled(boolean enabled) {
+        this.enabled = enabled;
+        return this;
+    }
+
+    public UiSelectorBuilder focusable(boolean focusable) {
+        this.focusable = focusable;
+        return this;
+    }
+
+    public UiSelectorBuilder focused(boolean focused) {
+        this.focused = focused;
+        return this;
+    }
+
+    public UiSelectorBuilder longClickable(boolean longClickable) {
+        this.longClickable = longClickable;
+        return this;
+    }
+
+    public UiSelectorBuilder scrollable(boolean scrollable) {
+        this.scrollable = scrollable;
+        return this;
+    }
+
+    public UiSelectorBuilder selected(boolean selected) {
+        this.selected = selected;
+        return this;
+    }
+
+    // ==================== Hierarchy methods ====================
+
+    public UiSelectorBuilder hasParent(BySelector hasParent) {
+        this.hasParent = hasParent;
+        return this;
+    }
+
+    public UiSelectorBuilder hasChild(BySelector hasChild) {
+        this.hasChild = hasChild;
+        return this;
+    }
+
+    public UiSelectorBuilder hasAncestor(BySelector hasAncestor) {
+        this.hasAncestor = hasAncestor;
+        return this;
+    }
+
+    public UiSelectorBuilder hasAncestor(BySelector hasAncestor, int distance) {
+        this.hasAncestor = hasAncestor;
+        this.hasAncestorDistance = distance;
+        return this;
+    }
+
+    public UiSelectorBuilder hasDescendant(BySelector hasDescendant) {
+        this.hasDescendant = hasDescendant;
+        return this;
+    }
+
+    public UiSelectorBuilder hasDescendant(BySelector hasDescendant, int depth) {
+        this.hasDescendant = hasDescendant;
+        this.hasDescendantDepth = depth;
+        return this;
+    }
+
+    // ==================== Depth and display methods ====================
+
+    public UiSelectorBuilder depth(int depth) {
+        this.depth = depth;
+        return this;
+    }
+
+    public UiSelectorBuilder minDepth(int minDepth) {
+        this.minDepth = minDepth;
+        return this;
+    }
+
+    public UiSelectorBuilder maxDepth(int maxDepth) {
+        this.maxDepth = maxDepth;
+        return this;
+    }
+
+    public UiSelectorBuilder depth(int minDepth, int maxDepth) {
+        this.minDepth = minDepth;
+        this.maxDepth = maxDepth;
+        return this;
+    }
+
+    public UiSelectorBuilder displayId(int displayId) {
+        this.displayId = displayId;
+        return this;
+    }
+
+    // ==================== Build methods ====================
+
+    /**
+     * Build a BySelector object based on current configuration
+     */
+    public BySelector build() {
+        BySelector selector = createBaseSelector();
+        applyAdditionalConditions(selector);
+        return selector;
+    }
+
+    /**
+     * Create the base selector - chooses the first available base condition
+     */
+    private BySelector createBaseSelector() {
+        if (res != null) {
+            usedBaseCondition = "res";
+            return By.res(res);
+        } else if (text != null) {
+            usedBaseCondition = "text";
+            return By.text(text);
+        } else if (desc != null) {
+            usedBaseCondition = "desc";
+            return By.desc(desc);
+        }else if (hint != null) {
+            usedBaseCondition = "hint";
+            return By.hint(hint);
+        }else if (clazz != null) {
+            usedBaseCondition = "clazz";
+            return By.clazz(clazz);
+        } else if (pkg != null) {
+            usedBaseCondition = "pkg";
+            return By.pkg(pkg);
+        } else if (resPattern != null) {
+            usedBaseCondition = "resPattern";
+            return By.res(resPattern);
+        } else if (textPattern != null) {
+            usedBaseCondition = "textPattern";
+            return By.text(textPattern);
+        } else if (descPattern != null) {
+            usedBaseCondition = "descPattern";
+            return By.desc(descPattern);
+        } else if (hintPattern != null) {
+            usedBaseCondition = "hintPattern";
+            return By.hint(hintPattern);
+        } else if (clazzPattern != null) {
+            usedBaseCondition = "clazzPattern";
+            return By.clazz(clazzPattern);
+        } else if (pkgPattern != null) {
+            usedBaseCondition = "pkgPattern";
+            return By.pkg(pkgPattern);
+        } else if (resPkg != null && resId != null) {
+            usedBaseCondition = "resPackage";
+            return By.res(resPkg, resId);
+        }
+
+        throw new IllegalStateException("At least one base condition must be provided (res, text, desc, clazz, pkg, hint)");
+    }
+
+    /**
+     * Apply additional conditions to the selector
+     */
+    private void applyAdditionalConditions(BySelector selector) {
+        // Apply remaining base conditions if not already used
+        if (text != null && !"text".equals(usedBaseCondition) && !"textPattern".equals(usedBaseCondition)) {
+            selector.text(text);
+        }
+        if (desc != null && !"desc".equals(usedBaseCondition) && !"descPattern".equals(usedBaseCondition)) {
+            selector.desc(desc);
+        }
+        if (hint != null && !"hint".equals(usedBaseCondition) && !"hintPattern".equals(usedBaseCondition)) {
+            selector.hint(hint);
+        }
+        if (clazz != null && !"clazz".equals(usedBaseCondition) && !"clazzPattern".equals(usedBaseCondition)) {
+            selector.clazz(clazz);
+        }
+        if (pkg != null && !"pkg".equals(usedBaseCondition) && !"pkgPattern".equals(usedBaseCondition)) {
+            selector.pkg(pkg);
+        }
+
+        // Apply regex-based conditions if not already used
+        if (clazzPattern != null && !"clazz".equals(usedBaseCondition) && !"clazzPattern".equals(usedBaseCondition)) {
+            selector.clazz(clazzPattern);
+        }
+        if (textPattern != null && !"text".equals(usedBaseCondition) && !"textPattern".equals(usedBaseCondition)) {
+            selector.text(textPattern);
+        }
+        if (descPattern != null && !"desc".equals(usedBaseCondition) && !"descPattern".equals(usedBaseCondition)) {
+            selector.desc(descPattern);
+        }
+        if (pkgPattern != null && !"pkg".equals(usedBaseCondition) && !"pkgPattern".equals(usedBaseCondition)) {
+            selector.pkg(pkgPattern);
+        }
+        if (resPattern != null && !"res".equals(usedBaseCondition) && !"resPattern".equals(usedBaseCondition) && !"resPackage".equals(usedBaseCondition)) {
+            selector.res(resPattern);
+        }
+        if (hintPattern != null && !"hint".equals(usedBaseCondition) && !"hintPattern".equals(usedBaseCondition)) {
+            selector.hint(hintPattern);
+        }
+
+        // Apply resource package + ID combination
+        if (resPkg != null && resId != null && !"res".equals(usedBaseCondition) && !"resPattern".equals(usedBaseCondition) && !"resPackage".equals(usedBaseCondition)) {
+            selector.res(resPkg, resId);
+        }
+
+        // Apply boolean state conditions
+        if (checkable != null) selector.checkable(checkable);
+        if (checked != null) selector.checked(checked);
+        if (clickable != null) selector.clickable(clickable);
+        if (enabled != null) selector.enabled(enabled);
+        if (focusable != null) selector.focusable(focusable);
+        if (focused != null) selector.focused(focused);
+        if (longClickable != null) selector.longClickable(longClickable);
+        if (scrollable != null) selector.scrollable(scrollable);
+        if (selected != null) selector.selected(selected);
+
+        // Apply hierarchy conditions
+        if (hasParent != null) selector.hasParent(hasParent);
+        if (hasChild != null) selector.hasDescendant(hasChild, 1);
+        if (hasAncestor != null) {
+            if (hasAncestorDistance != null) selector.hasAncestor(hasAncestor, hasAncestorDistance);
+            else selector.hasAncestor(hasAncestor);
+        }
+        if (hasDescendant != null) {
+            if (hasDescendantDepth != null) selector.hasDescendant(hasDescendant, hasDescendantDepth);
+            else selector.hasDescendant(hasDescendant);
+        }
+
+        // Apply depth and display conditions
+        if (depth != null) selector.depth(depth);
+        else if (minDepth != null && maxDepth != null) selector.depth(minDepth, maxDepth);
+        else {
+            if (minDepth != null) selector.minDepth(minDepth);
+            if (maxDepth != null) selector.maxDepth(maxDepth);
+        }
+        if (displayId != null && Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) selector.displayId(displayId);
+    }
+
+    // ==================== Static helper methods ====================
+
+    /**
+     * Create BySelector from a Map of parameters
+     */
+    public static BySelector fromMap(@NonNull Map<String, Object> params) {
+        return fromMap(params, 0);
+    }
+
+    private static BySelector fromMap(@NonNull Map<String, Object> params, int depth) {
+        // Check recursion depth
+        if (depth > MAX_RECURSION_DEPTH) {
+            throw new IllegalStateException("Selector recursion depth exceeded maximum: " + MAX_RECURSION_DEPTH);
+        }
+        if (params.isEmpty()) {
+            throw new IllegalArgumentException("Selector parameters cannot be empty");
+        }
+
+        UiSelectorBuilder builder = create();
+        Map<String, Object> mapCopy = new HashMap<>(params);
+
+        setExclusiveRes(builder, mapCopy);
+
+        // ===== Text Mutually Exclusive =====
+        setExclusiveString(builder::text, builder::textContains, builder::textStartsWith, builder::textEndsWith, builder::textPattern,
+                mapCopy,
+                "text", "textContains", "textStartsWith", "textEndsWith",
+                "name", "label", "value",
+                "textPattern", "textMatches");
+
+        // ===== Desc Mutually Exclusive =====
+        setExclusiveString(builder::desc, builder::descContains, builder::descStartsWith, builder::descEndsWith, builder::descPattern,
+                mapCopy,
+                "desc", "descContains", "descStartsWith", "descEndsWith",
+                "description", "content-desc", "contentDesc", "contentDescription",
+                "accessibilityId", "accessibility-id", "aid",
+                "descPattern", "content-desc-matches", "descMatches");
+
+        // ===== Hint Mutually Exclusive =====
+        setExclusiveString(builder::hint, builder::hintContains, builder::hintStartsWith, builder::hintEndsWith, builder::hintPattern,
+                mapCopy,
+                "hint", "hintContains", "hintStartsWith", "hintEndsWith",
+                "hintText", "hint-text",
+                "hintPattern", "hintMatches");
+
+        // ===== Class and Package =====
+        setExclusiveClass(builder, mapCopy);
+        setExclusivePackage(builder, mapCopy);
+
+        // ===== Boolean =====
+        if (mapCopy.containsKey("clickable")) {
+            builder.clickable((Boolean) mapCopy.get("clickable"));
+        }
+        if (mapCopy.containsKey("enabled")) {
+            builder.enabled((Boolean) mapCopy.get("enabled"));
+        }
+        if (mapCopy.containsKey("checked")) {
+            builder.checked((Boolean) mapCopy.get("checked"));
+        }
+        if (mapCopy.containsKey("checkable")) {
+            builder.checkable((Boolean) mapCopy.get("checkable"));
+        }
+        if (mapCopy.containsKey("focusable")) {
+            builder.focusable((Boolean) mapCopy.get("focusable"));
+        }
+        if (mapCopy.containsKey("focused")) {
+            builder.focused((Boolean) mapCopy.get("focused"));
+        }
+        if (mapCopy.containsKey("selected")) {
+            builder.selected((Boolean) mapCopy.get("selected"));
+        }
+        if (mapCopy.containsKey("scrollable")) {
+            builder.scrollable((Boolean) mapCopy.get("scrollable"));
+        }
+        if (mapCopy.containsKey("longClickable")) {
+            builder.longClickable((Boolean) mapCopy.get("longClickable"));
+        }
+
+        // ===== Depth & Display =====
+        if (mapCopy.containsKey("depth")) builder.depth((Integer) mapCopy.get("depth"));
+        if (mapCopy.containsKey("minDepth")) builder.minDepth((Integer) mapCopy.get("minDepth"));
+        if (mapCopy.containsKey("maxDepth")) builder.maxDepth((Integer) mapCopy.get("maxDepth"));
+        if (mapCopy.containsKey("displayId")) builder.displayId((Integer) mapCopy.get("displayId"));
+
+        // ===== Hierarchy recursively =====
+        processHierarchy(mapCopy, "hasParent", builder, depth);
+        processHierarchy(mapCopy, "hasChild", builder, depth);
+        processHierarchy(mapCopy, "hasAncestor", builder, depth);
+        processHierarchy(mapCopy, "hasDescendant", builder, depth);
+
+        return builder.build();
+    }
+
+    private static void setExclusiveRes(UiSelectorBuilder builder, Map<String, Object> mapCopy) {
+        String foundKey = null;
+        Object foundValue = null;
+
+        // First check package name + resource ID combination
+        boolean hasResPkg = mapCopy.containsKey("resPkg");
+        boolean hasResId = mapCopy.containsKey("resId");
+        if (hasResPkg && hasResId) {
+            // Check if other resource ID conditions are already set
+            String[] otherResourceKeys = {"res", "id", "resourceId", "resource-id", "resPattern", "resourceIdMatches"};
+            for (String key : otherResourceKeys) {
+                if (mapCopy.containsKey(key)) {
+                    throw new IllegalStateException(
+                            "Cannot set both package-resource combination and '" + key + "'"
+                    );
+                }
+            }
+            builder.res((String) mapCopy.get("resPkg"), (String) mapCopy.get("resId"));
+            return;
+        } else if (hasResPkg || hasResId) {
+            throw new IllegalStateException("resPkg and resId must be used together");
+        }
+
+        String[] resourceKeys = {"res", "id", "resourceId", "resource-id", "resPattern", "resourceIdMatches"};
+
+        for (String key : resourceKeys) {
+            if (mapCopy.containsKey(key)) {
+                if (foundKey != null) {
+                    throw new IllegalStateException(
+                            "Cannot set multiple resource conditions: '" + foundKey + "' and '" + key + "' are mutually exclusive"
+                    );
+                }
+                foundKey = key;
+                foundValue = mapCopy.get(key);
+            }
+        }
+
+        if (foundKey == null) return;
+
+        if (foundKey.equals("resPattern") || foundKey.equals("resourceIdMatches")) {
+            Pattern pattern = (foundValue instanceof Pattern) ?
+                    (Pattern) foundValue : Pattern.compile((String) foundValue);
+            builder.resPattern(pattern);
+        } else {
+            builder.res((String) foundValue);
+        }
+    }
+
+    private static void setExclusiveString(java.util.function.Consumer<String> base,
+                                           java.util.function.Consumer<String> contains,
+                                           java.util.function.Consumer<String> startsWith,
+                                           java.util.function.Consumer<String> endsWith,
+                                           java.util.function.Consumer<Pattern> pattern,
+                                           Map<String, Object> mapCopy,
+                                           String... keys) {
+        for (String key : keys) {
+            if (mapCopy.containsKey(key)) {
+                Object val = mapCopy.get(key);
+                switch (key) {
+                    case "textContains": case "descContains": case "hintContains":
+                        contains.accept((String) val); break;
+                    case "textStartsWith": case "descStartsWith": case "hintStartsWith":
+                        startsWith.accept((String) val); break;
+                    case "textEndsWith": case "descEndsWith": case "hintEndsWith":
+                        endsWith.accept((String) val); break;
+                    case "textPattern": case "descPattern": case "hintPattern":
+                    case "textMatches": case "descMatches": case "hintMatches":
+                        if (val instanceof Pattern) {
+                            pattern.accept((Pattern) val);
+                        } else if (val instanceof String) {
+                            pattern.accept(Pattern.compile((String) val));
+                        }
+                        break;
+                    default: base.accept((String) val); break;
+                }
+                return; // only first found variant is applied
+            }
+        }
+    }
+
+    private static void setExclusiveClass(UiSelectorBuilder builder, Map<String, Object> mapCopy) {
+        String foundKey = null;
+        Object foundValue = null;
+
+        String[] classKeys = {"clazz", "class", "className", "class-name", "clazzPattern", "classNameMatches"};
+
+        for (String key : classKeys) {
+            if (mapCopy.containsKey(key)) {
+                if (foundKey != null) {
+                    throw new IllegalStateException(
+                            "Cannot set multiple class conditions: '" + foundKey + "' and '" + key + "' are mutually exclusive"
+                    );
+                }
+                foundKey = key;
+                foundValue = mapCopy.get(key);
+            }
+        }
+
+        if (foundKey == null) return;
+
+        if (foundKey.endsWith("Pattern") || foundKey.endsWith("Matches")) {
+            Pattern pattern = (foundValue instanceof Pattern) ?
+                    (Pattern) foundValue : Pattern.compile((String) foundValue);
+            builder.clazzPattern(pattern);
+        } else {
+            builder.clazz((String) foundValue);
+        }
+    }
+
+    private static void setExclusivePackage(UiSelectorBuilder builder, Map<String, Object> mapCopy) {
+        String foundKey = null;
+        Object foundValue = null;
+
+        String[] packageKeys = {"pkg", "packageName", "package-name", "pkgPattern", "packageNameMatches"};
+
+        for (String key : packageKeys) {
+            if (mapCopy.containsKey(key)) {
+                if (foundKey != null) {
+                    throw new IllegalStateException(
+                            "Cannot set multiple package conditions: '" + foundKey + "' and '" + key + "' are mutually exclusive"
+                    );
+                }
+                foundKey = key;
+                foundValue = mapCopy.get(key);
+            }
+        }
+
+        if (foundKey == null) return;
+
+        if (foundKey.endsWith("Pattern") || foundKey.endsWith("Matches")) {
+            Pattern pattern = (foundValue instanceof Pattern) ?
+                    (Pattern) foundValue : Pattern.compile((String) foundValue);
+            builder.pkgPattern(pattern);
+        } else {
+            builder.pkg((String) foundValue);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private static void processHierarchy(Map<String,Object> map, String key, UiSelectorBuilder builder, int depth) {
+        if (!map.containsKey(key)) return;
+        Object obj = map.get(key);
+        if (obj instanceof Map) {
+            BySelector childSelector = fromMap((Map<String,Object>) obj, depth+1);
+            switch (key) {
+                case "hasParent": builder.hasParent(childSelector); break;
+                case "hasChild": builder.hasChild(childSelector); break;
+                case "hasAncestor": builder.hasAncestor(childSelector); break;
+                case "hasDescendant": builder.hasDescendant(childSelector); break;
+            }
+        } else if (obj instanceof BySelector) {
+            switch (key) {
+                case "hasParent": builder.hasParent((BySelector) obj); break;
+                case "hasChild": builder.hasChild((BySelector) obj); break;
+                case "hasAncestor": builder.hasAncestor((BySelector) obj); break;
+                case "hasDescendant": builder.hasDescendant((BySelector) obj); break;
+            }
+        } else throw new IllegalArgumentException("Hierarchy value must be Map or BySelector");
+    }
+
+
+    // ==================== Convenience static methods ====================
+    public static BySelector byRes(String resId) {
+        return create().res(resId).build();
+    }
+
+    public static BySelector byText(String text) {
+        return create().text(text).build();
+    }
+
+    public static BySelector byDesc(String desc) {
+        return create().desc(desc).build();
+    }
+
+    public static BySelector byClazz(String clazz) {
+        return create().clazz(clazz).build();
+    }
+
+    public static BySelector byTextContains(String text) {
+        return create().textContains(text).build();
+    }
+
+    public static BySelector byDescContains(String desc) {
+        return create().descContains(desc).build();
+    }
+
+    /**
+     * Create selector for child element with parent relationship
+     */
+    public static BySelector childOf(BySelector parent, BySelector child) {
+        return create()
+                .hasParent(parent)
+                .clazz(child.toString()) // Simplified - in practice you'd copy conditions
+                .build();
+    }
+}

--- a/app/src/main/java/io/appium/uiautomator2/handler/FindElementOnDisplay.java
+++ b/app/src/main/java/io/appium/uiautomator2/handler/FindElementOnDisplay.java
@@ -1,0 +1,159 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.appium.uiautomator2.handler;
+
+import static io.appium.uiautomator2.utils.ModelUtils.toModel;
+import static io.appium.uiautomator2.utils.StringHelpers.isBlank;
+
+import android.os.Build;
+import android.view.Display;
+
+import androidx.test.platform.app.InstrumentationRegistry;
+import androidx.test.uiautomator.BySelector;
+import androidx.test.uiautomator.UiDevice;
+import androidx.test.uiautomator.UiObject2;
+import androidx.test.uiautomator.UiObjectNotFoundException;
+import androidx.test.uiautomator.Until;
+
+import java.util.Map;
+
+import io.appium.uiautomator2.common.exceptions.ElementNotFoundException;
+import io.appium.uiautomator2.common.exceptions.InvalidArgumentException;
+import io.appium.uiautomator2.common.selector.UiSelectorBuilder;
+import io.appium.uiautomator2.handler.request.SafeRequestHandler;
+import io.appium.uiautomator2.http.AppiumResponse;
+import io.appium.uiautomator2.http.IHttpRequest;
+import io.appium.uiautomator2.model.AccessibleUiObject;
+import io.appium.uiautomator2.model.AndroidElement;
+import io.appium.uiautomator2.model.AppiumUIA2Driver;
+import io.appium.uiautomator2.model.ElementsCache;
+import io.appium.uiautomator2.model.api.FindElementOnDisplayModel;
+import io.appium.uiautomator2.utils.DisplayIdResolver;
+import io.appium.uiautomator2.utils.Logger;
+public class FindElementOnDisplay extends SafeRequestHandler {
+    private static final String TAG = FindElementOnDisplay.class.getSimpleName();
+    private static final long DEFAULT_TIMEOUT_MS = 1000L;
+
+    public FindElementOnDisplay(String mappedUri) {
+        super(mappedUri);
+    }
+
+    @Override
+    protected AppiumResponse safeHandle(IHttpRequest request) throws UiObjectNotFoundException {
+        FindElementOnDisplayModel model = toModel(request, FindElementOnDisplayModel.class);
+        final Map<String, Object> selectorMap = model.selector;
+        final Integer displayIndex = model.displayIndex; // index: 0=main, 1=secondary1 ...
+        final Long timeout = model.timeout;
+        final String contextId = isBlank(model.context) ? null : model.context;
+
+        if (displayIndex == null) {
+            throw new InvalidArgumentException("displayIndex parameter is required");
+        }
+        if (selectorMap == null || selectorMap.isEmpty()) {
+            throw new InvalidArgumentException("Invalid selector: selector must be a non-empty map of BySelector fields");
+        }
+
+        ElementsCache cache = AppiumUIA2Driver.getInstance().getSessionOrThrow().getElementsCache();
+
+        AndroidElement contextElement = contextId == null ? null : cache.get(contextId);
+        if (contextId != null && contextElement == null) {
+            throw new InvalidArgumentException("Context element not found in cache: " + contextId);
+        }
+
+        int displayId = DisplayIdResolver.resolveDisplayId(displayIndex);
+        Logger.info(TAG, String.format("Find element on display index=%d -> displayId=%d, selector='%s'",
+                displayIndex, displayId, selectorMap));
+
+        if (displayId == Display.DEFAULT_DISPLAY) {
+            throw new InvalidArgumentException(
+                    "Primary display search should use standard /element endpoint instead of /display/element"
+            );
+        }
+
+        return findElementOnDisplay(request, selectorMap, displayId, timeout, contextElement);
+    }
+
+    private AppiumResponse findElementOnDisplay(IHttpRequest request,  Map<String, Object> selector, int displayId, Long timeout, AndroidElement context) {
+        try {
+            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.R) {
+                throw new UnsupportedOperationException(
+                        "Multi-display element search requires Android API level >= 30 (R)."
+                );
+            }
+
+            long timeoutMs = (timeout == null) ? DEFAULT_TIMEOUT_MS : Math.max(timeout, 0L);
+
+            UiDevice device = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation());
+
+            BySelector bySelector = UiSelectorBuilder.fromMap(selector).displayId(displayId);
+
+            Logger.info(TAG, String.format(
+                    "Searching: displayId=%d timeout=%dms selector=%s",
+                    displayId, timeoutMs, bySelector
+            ));
+
+            UiObject2 uiObject2;
+            if (context != null) {
+                if (context.getDisplayId() != displayId && displayId != Display.DEFAULT_DISPLAY) {
+                    throw new IllegalArgumentException(String.format(
+                            "Context element is on display %d but search was requested on display %d",
+                            context.getDisplayId(), displayId));
+                }
+
+                Object uiObject = context.getUiObject();
+                if (uiObject instanceof UiObject2) {
+                    uiObject2 = ((UiObject2) uiObject).wait(Until.findObject(bySelector), timeoutMs);
+                } else {
+                    throw new InvalidArgumentException("Context search on display is supported only for UiObject2 elements");
+                }
+            } else {
+                uiObject2 = device.wait(Until.findObject(bySelector), timeoutMs);
+            }
+
+            if (uiObject2 == null) {
+                throw new ElementNotFoundException(String.format(
+                        "Element not found on displayId %d with selector: %s (timeout=%dms)",
+                        displayId, selector, timeoutMs));
+            }
+
+            AccessibleUiObject accessibleUiObject = AccessibleUiObject.toAccessibleUiObject(uiObject2);
+            if (accessibleUiObject == null) {
+                throw new ElementNotFoundException("Failed to convert UiObject2 to AccessibleUiObject");
+            }
+
+            ElementsCache elementsCache = AppiumUIA2Driver.getInstance().getSessionOrThrow().getElementsCache();
+            String contextId = context != null ? context.getId() : null;
+            AndroidElement androidElement = elementsCache.add(accessibleUiObject, true, null, contextId);
+            androidElement.setDisplayId(displayId);
+
+            Logger.info(TAG, String.format("Element found and cached: %s (displayId=%d)", androidElement, displayId));
+
+            return new AppiumResponse(getSessionId(request), androidElement.toModel());
+
+        } catch (ElementNotFoundException e) {
+            throw e;
+        } catch (InvalidArgumentException e) {
+            throw e;
+        } catch (UnsupportedOperationException e) {
+            Logger.error(TAG, String.format("Unsupported operation when finding element on displayId=%d", displayId), e);
+            throw e;
+        } catch (Exception e) {
+            Logger.error(TAG, String.format("Unexpected error finding element on displayId=%d", displayId), e);
+            throw new ElementNotFoundException(String.format("Failed to find element on displayId=%d", displayId), e);
+        }
+    }
+}

--- a/app/src/main/java/io/appium/uiautomator2/handler/FindElementsOnDisplay.java
+++ b/app/src/main/java/io/appium/uiautomator2/handler/FindElementsOnDisplay.java
@@ -1,0 +1,167 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.appium.uiautomator2.handler;
+
+import static io.appium.uiautomator2.utils.ModelUtils.toModel;
+import static io.appium.uiautomator2.utils.StringHelpers.isBlank;
+
+import android.os.Build;
+import android.view.Display;
+
+import androidx.test.platform.app.InstrumentationRegistry;
+import androidx.test.uiautomator.BySelector;
+import androidx.test.uiautomator.UiDevice;
+import androidx.test.uiautomator.UiObject2;
+import androidx.test.uiautomator.UiObjectNotFoundException;
+import androidx.test.uiautomator.Until;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import io.appium.uiautomator2.common.exceptions.ElementNotFoundException;
+import io.appium.uiautomator2.common.exceptions.InvalidArgumentException;
+import io.appium.uiautomator2.common.selector.UiSelectorBuilder;
+import io.appium.uiautomator2.handler.request.SafeRequestHandler;
+import io.appium.uiautomator2.http.AppiumResponse;
+import io.appium.uiautomator2.http.IHttpRequest;
+import io.appium.uiautomator2.model.AccessibleUiObject;
+import io.appium.uiautomator2.model.AndroidElement;
+import io.appium.uiautomator2.model.AppiumUIA2Driver;
+import io.appium.uiautomator2.model.ElementsCache;
+import io.appium.uiautomator2.model.api.FindElementOnDisplayModel;
+import io.appium.uiautomator2.utils.DisplayIdResolver;
+import io.appium.uiautomator2.utils.Logger;
+
+public class FindElementsOnDisplay extends SafeRequestHandler {
+    private static final long DEFAULT_TIMEOUT_MS = 1000L;
+
+    public FindElementsOnDisplay(String mappedUri) {
+        super(mappedUri);
+    }
+
+    @Override
+    protected AppiumResponse safeHandle(IHttpRequest request) throws UiObjectNotFoundException {
+        FindElementOnDisplayModel model = toModel(request, FindElementOnDisplayModel.class);
+        final Map<String, Object> selectorMap = model.selector;
+        final Integer displayIndex = model.displayIndex; // Python-side index: 0=main, 1=secondary1 ...
+        final Long timeout = model.timeout;
+        final String contextId = isBlank(model.context) ? null : model.context;
+
+        if (displayIndex == null) {
+            throw new InvalidArgumentException("displayId parameter (index) is required");
+        }
+        if (selectorMap == null || selectorMap.isEmpty()) {
+            throw new InvalidArgumentException("selector must be provided and non-empty");
+        }
+
+        AndroidElement contextElement = null;
+        if (contextId != null) {
+            ElementsCache elementsCache = AppiumUIA2Driver.getInstance().getSessionOrThrow().getElementsCache();
+            contextElement = elementsCache.get(contextId);
+            if (contextElement == null) {
+                throw new InvalidArgumentException("context element not found in session cache: " + contextId);
+            }
+        }
+
+        int systemDisplayId = DisplayIdResolver.resolveDisplayId(displayIndex);
+
+        Logger.info(String.format(
+                "[MultiDisplay] Find elements on display index=%d -> systemDisplayId=%d, selector='%s'",
+                displayIndex, systemDisplayId, selectorMap));
+
+        if (systemDisplayId == Display.DEFAULT_DISPLAY) {
+            throw new InvalidArgumentException("For primary display, please use standard /elements endpoint");
+        }
+
+        return findElementsOnDisplay(request, selectorMap, systemDisplayId, timeout, contextElement);
+    }
+
+    private AppiumResponse findElementsOnDisplay(IHttpRequest request,  Map<String, Object> selector, int displayId, Long timeout, AndroidElement context) {
+        try {
+            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.R) {
+                throw new UnsupportedOperationException("Multi display findElements not supported for Android API < 30");
+            }
+
+            long timeoutMs = (timeout == null) ? DEFAULT_TIMEOUT_MS : Math.max(timeout, 0L);
+            Logger.info(String.format("[MultiDisplay] Searching elements with timeout=%dms on displayId=%d", timeoutMs, displayId));
+
+            UiDevice device = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation());
+            BySelector bySelector = UiSelectorBuilder.fromMap(selector).displayId(displayId);
+
+            List<UiObject2> uiObjects;
+            if (context != null) {
+                if (context.getDisplayId() != displayId) {
+                    throw new InvalidArgumentException(String.format(
+                            "Context element is on display %d, but search is for display %d",
+                            context.getDisplayId(), displayId));
+                }
+
+                Object uiObject = context.getUiObject();
+                if (uiObject instanceof UiObject2) {
+                    uiObjects = ((UiObject2) uiObject).wait(Until.findObjects(bySelector), timeoutMs);
+                } else {
+                    throw new UnsupportedOperationException("Context element search only supported for UiObject2 elements");
+                }
+            } else {
+                uiObjects =  device.wait(Until.findObjects(bySelector), timeoutMs);
+            }
+
+            if (uiObjects == null || uiObjects.isEmpty()) {
+                Logger.info(String.format("[MultiDisplay] No elements found on displayId %d with selector: %s",
+                        displayId, selector));
+                return new AppiumResponse(getSessionId(request), new ArrayList<>());
+            }
+
+            ElementsCache elementsCache = AppiumUIA2Driver.getInstance().getSessionOrThrow().getElementsCache();
+            List<AndroidElement> androidElements = new ArrayList<>();
+            String contextId = context != null ? context.getId() : null;
+
+            for (UiObject2 uiObject : uiObjects) {
+                AccessibleUiObject accessibleUiObject = AccessibleUiObject.toAccessibleUiObject(uiObject);
+                if (accessibleUiObject != null) {
+                    AndroidElement androidElement = elementsCache.add(accessibleUiObject, false, null,contextId);
+                    androidElement.setDisplayId(displayId);
+                    androidElements.add(androidElement);
+                }
+            }
+
+            Logger.info(String.format("[MultiDisplay] Found %d elements on displayId %d",
+                    androidElements.size(), displayId));
+
+            List<Object> elementModels = androidElements.stream()
+                    .map(element -> {
+                        try {
+                            return element.toModel();
+                        } catch (Exception e) {
+                            Logger.error("Error converting element to model", e);
+                            return null;
+                        }
+                    })
+                    .filter(model -> model != null)
+                    .collect(Collectors.toList());
+
+            return new AppiumResponse(getSessionId(request), elementModels);
+
+        } catch (Exception e) {
+            Logger.error(String.format("Unexpected error finding elements on displayId=%d", displayId), e);
+            throw new ElementNotFoundException(String.format("Failed to find elements on displayId=%d", displayId), e);
+        }
+    }
+
+}

--- a/app/src/main/java/io/appium/uiautomator2/handler/GetDisplayInfo.java
+++ b/app/src/main/java/io/appium/uiautomator2/handler/GetDisplayInfo.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.appium.uiautomator2.handler;
+
+import android.content.Context;
+import android.hardware.display.DisplayManager;
+import android.util.DisplayMetrics;
+import android.view.Display;
+
+import androidx.test.core.app.ApplicationProvider;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import io.appium.uiautomator2.handler.request.SafeRequestHandler;
+import io.appium.uiautomator2.http.AppiumResponse;
+import io.appium.uiautomator2.http.IHttpRequest;
+import io.appium.uiautomator2.utils.DisplayIdHelper;
+import io.appium.uiautomator2.utils.Logger;
+
+public class GetDisplayInfo extends SafeRequestHandler {
+    private static final String TAG = GetDisplayInfo.class.getSimpleName();
+
+    public GetDisplayInfo(String mappedUri) {
+        super(mappedUri);
+    }
+
+    @Override
+    protected AppiumResponse safeHandle(IHttpRequest request) {
+        Logger.info(TAG, "Getting display information");
+
+        Context context = ApplicationProvider.getApplicationContext();
+        DisplayManager dm = (DisplayManager) context.getSystemService(Context.DISPLAY_SERVICE);
+        Display[] displays = dm.getDisplays();
+
+        List<Map<String, Object>> displayInfos = new ArrayList<>();
+        for (int displayIndex = 0; displayIndex < displays.length; displayIndex++) {
+            Display display = displays[displayIndex];
+
+            DisplayMetrics displayMetrics = new DisplayMetrics();
+            display.getMetrics(displayMetrics);
+
+            Map<String, Object> displayInfo = new HashMap<>();
+            // Appium display index (0, 1, 2...)
+            displayInfo.put("displayIndex", displayIndex);
+
+            // Android Display ID (DisplayManager's ID)
+            int displayId = display.getDisplayId();
+            displayInfo.put("displayId", displayId);
+
+            // Physical display ID
+            Long physicalDisplayId = DisplayIdHelper.getPhysicalDisplayId(display);
+            if (physicalDisplayId != null) {
+                displayInfo.put("physicalDisplayId", physicalDisplayId);
+            } else {
+                // If physical ID cannot be obtained, use display ID as fallback
+                displayInfo.put("physicalDisplayId", (long) displayId);
+                Logger.debug(TAG, String.format("Cannot get physical display ID for display index %d, using display ID as fallback", displayIndex));
+            }
+
+            // Basic display information
+            displayInfo.put("width", displayMetrics.widthPixels);
+            displayInfo.put("height", displayMetrics.heightPixels);
+            displayInfo.put("isDefault", displayId == Display.DEFAULT_DISPLAY);
+            displayInfo.put("name", display.getName() != null ? display.getName() : "Display " + displayIndex);
+
+            displayInfos.add(displayInfo);
+
+            Logger.info(TAG, String.format("Display index=%d, displayId=%d, physicalDisplayId=%s: %dx%d, name=%s",
+                    displayIndex, displayId, displayInfo.get("physicalDisplayId"),
+                    displayMetrics.widthPixels, displayMetrics.heightPixels,
+                    display.getName()));
+        }
+
+        Logger.info(TAG, String.format("Found %d displays", displayInfos.size()));
+        return new AppiumResponse(getSessionId(request), displayInfos);
+    }
+}

--- a/app/src/main/java/io/appium/uiautomator2/handler/SourceOnDisplay.java
+++ b/app/src/main/java/io/appium/uiautomator2/handler/SourceOnDisplay.java
@@ -1,0 +1,337 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.appium.uiautomator2.handler;
+
+import android.os.Build;
+import android.view.Display;
+import android.view.accessibility.AccessibilityNodeInfo;
+import android.view.accessibility.AccessibilityWindowInfo;
+
+import androidx.test.platform.app.InstrumentationRegistry;
+import androidx.test.uiautomator.UiDevice;
+import androidx.test.uiautomator.UiObjectNotFoundException;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import io.appium.uiautomator2.handler.request.SafeRequestHandler;
+import io.appium.uiautomator2.http.AppiumResponse;
+import io.appium.uiautomator2.http.IHttpRequest;
+import io.appium.uiautomator2.model.internal.CustomUiDevice;
+import io.appium.uiautomator2.utils.DisplayIdResolver;
+import io.appium.uiautomator2.utils.Logger;
+
+public class SourceOnDisplay extends SafeRequestHandler {
+    private static final String TAG = SourceOnDisplay.class.getSimpleName();
+    private static final Pattern DISPLAY_INDEX_PATTERN = Pattern.compile("displayIndex=(\\d+)");
+
+    public SourceOnDisplay(String mappedUri) {
+        super(mappedUri);
+    }
+
+    @Override
+    protected AppiumResponse safeHandle(IHttpRequest request) throws UiObjectNotFoundException {
+        Integer displayIndex = extractDisplayIndexFromQuery(request);
+
+        String xmlSource;
+        if (displayIndex != null) {
+            int displayId = DisplayIdResolver.resolveDisplayId(displayIndex);
+            Logger.info(TAG, String.format("Getting source for displayIndex=%d (displayId=%d)", displayIndex, displayId));
+            xmlSource = dumpDisplayHierarchy(displayId);
+        } else {
+            Logger.info(TAG, "Getting source for all displays");
+            xmlSource = dumpAllDisplaysHierarchy();
+        }
+
+        return new AppiumResponse(getSessionId(request), xmlSource);
+    }
+
+    private Integer extractDisplayIndexFromQuery(IHttpRequest request) {
+        try {
+            String uri = request.uri();
+            Matcher matcher = DISPLAY_INDEX_PATTERN.matcher(uri);
+            if (matcher.find()) {
+                return Integer.parseInt(matcher.group(1));
+            }
+            return null;
+        } catch (Exception e) {
+            Logger.error(TAG, "Failed to extract displayIndex from query", e);
+            return null;
+        }
+    }
+
+    private String dumpDisplayHierarchy(int displayId) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R && displayId != Display.DEFAULT_DISPLAY) {
+            return dumpMultiDisplayHierarchy(displayId);
+        } else {
+            return dumpDefaultDisplayHierarchy();
+        }
+    }
+
+    private String dumpAllDisplaysHierarchy() {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.R) {
+            return dumpDefaultDisplayHierarchy();
+        }
+
+        try {
+            android.util.SparseArray<List<AccessibilityWindowInfo>> windowsOnAllDisplays =
+                    CustomUiDevice.getInstance().getUiAutomation().getWindowsOnAllDisplays();
+
+            StringBuilder xmlBuilder = new StringBuilder();
+            xmlBuilder.append("<?xml version='1.0' encoding='UTF-8' standalone='yes' ?>\n");
+            xmlBuilder.append("<hierarchies>\n");
+
+            boolean hasValidContent = false;
+
+            for (int i = 0; i < windowsOnAllDisplays.size(); i++) {
+                int displayId = windowsOnAllDisplays.keyAt(i);
+                List<AccessibilityWindowInfo> displayWindows = windowsOnAllDisplays.valueAt(i);
+
+                if (displayWindows == null || displayWindows.isEmpty()) {
+                    continue;
+                }
+
+                String displayXml = dumpWindowsToXml(displayId, displayWindows);
+                if (displayXml != null && !displayXml.trim().isEmpty()) {
+                    xmlBuilder.append(displayXml).append("\n");
+                    hasValidContent = true;
+                }
+            }
+
+            xmlBuilder.append("</hierarchies>");
+
+            if (!hasValidContent) {
+                Logger.warn(TAG, "No accessible UI content found on any display");
+                return "<hierarchies><error>No accessible UI content found on any display</error></hierarchies>";
+            }
+
+            return xmlBuilder.toString();
+
+        } catch (Exception e) {
+            Logger.error(TAG, "Multi-display dump failed", e);
+            return "<hierarchies><error>Dump failed: " + e.getMessage() + "</error></hierarchies>";
+        }
+    }
+
+    private String dumpDefaultDisplayHierarchy() {
+        try {
+            UiDevice device = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation());
+            ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+            device.dumpWindowHierarchy(outputStream);
+            return outputStream.toString("UTF-8");
+        } catch (IOException e) {
+            Logger.error(TAG, "Failed to dump default display hierarchy", e);
+            return "<hierarchy><error>Failed to dump default display: " + e.getMessage() + "</error></hierarchy>";
+        }
+    }
+
+    private String dumpMultiDisplayHierarchy(int displayId) {
+        try {
+            android.util.SparseArray<List<AccessibilityWindowInfo>> windowsOnAllDisplays =
+                    CustomUiDevice.getInstance().getUiAutomation().getWindowsOnAllDisplays();
+
+            List<AccessibilityWindowInfo> displayWindows = windowsOnAllDisplays.get(displayId);
+            if (displayWindows == null || displayWindows.isEmpty()) {
+                int displayIndex = DisplayIdResolver.resolveDisplayIndex(displayId);
+                Logger.warn(TAG, String.format("No windows found for displayId=%d (displayIndex=%d)", displayId, displayIndex));
+                return String.format("<hierarchy displayId=\"%d\" displayIndex=\"%d\"><error>No windows found on this display</error></hierarchy>",
+                        displayId, displayIndex);
+            }
+
+            Logger.debug(TAG, String.format("Found %d windows for displayId=%d", displayWindows.size(), displayId));
+
+            return dumpWindowsToXml(displayId, displayWindows);
+
+        } catch (Exception e) {
+            Logger.error(TAG, String.format("Multi-display dump failed for displayId=%d", displayId), e);
+            int displayIndex = DisplayIdResolver.resolveDisplayIndex(displayId);
+            return String.format("<hierarchy displayId=\"%d\" displayIndex=\"%d\"><error>Dump failed: %s</error></hierarchy>",
+                    displayId, displayIndex, e.getMessage());
+        }
+    }
+
+    private String dumpWindowsToXml(int displayId, List<AccessibilityWindowInfo> windows) {
+        int displayIndex = DisplayIdResolver.resolveDisplayIndex(displayId);
+        StringBuilder xmlBuilder = new StringBuilder();
+        xmlBuilder.append("<hierarchy displayId=\"").append(displayId)
+                .append("\" displayIndex=\"").append(displayIndex).append("\">\n");
+
+        boolean hasValidContent = false;
+
+        for (AccessibilityWindowInfo window : windows) {
+            if (window == null) continue;
+
+            AccessibilityNodeInfo root = window.getRoot();
+            if (root == null) continue;
+
+            try {
+                String nodeXml = dumpSingleNodeInfo(root);
+                if (nodeXml != null && !nodeXml.trim().isEmpty()) {
+                    xmlBuilder.append("  ").append(nodeXml.replace("\n", "\n  ")).append("\n");
+                    hasValidContent = true;
+                }
+            } catch (Exception e) {
+                Logger.error(TAG, String.format("Failed to dump window on displayId=%d", displayId), e);
+            } finally {
+                if (root != null) {
+                    root.recycle();
+                }
+            }
+        }
+
+        xmlBuilder.append("</hierarchy>");
+
+        if (!hasValidContent) {
+            Logger.warn(TAG, String.format("No accessible UI content found for displayId=%d", displayId));
+            return String.format("<hierarchy displayId=\"%d\" displayIndex=\"%d\"><error>No accessible UI content found</error></hierarchy>",
+                    displayId, displayIndex);
+        }
+
+        return xmlBuilder.toString();
+    }
+
+    private String dumpSingleNodeInfo(AccessibilityNodeInfo node) {
+        if (node == null) {
+            return "";
+        }
+
+        StringBuilder xmlBuilder = new StringBuilder();
+        dumpNodeRecursive(node, xmlBuilder, 0);
+        return xmlBuilder.toString();
+    }
+
+    private void dumpNodeRecursive(AccessibilityNodeInfo node, StringBuilder xmlBuilder, int depth) {
+        if (node == null) {
+            return;
+        }
+
+        String indent = getIndent(depth);
+
+        // Start node
+        xmlBuilder.append(indent).append("<node");
+
+        // Add attributes
+        appendAttribute(xmlBuilder, "index", String.valueOf(node.getChildCount()));
+        appendAttribute(xmlBuilder, "text", safeGetText(node));
+        appendAttribute(xmlBuilder, "resource-id", safeGetResourceId(node));
+        appendAttribute(xmlBuilder, "class", safeGetClassName(node));
+        appendAttribute(xmlBuilder, "package", safeGetPackageName(node));
+        appendAttribute(xmlBuilder, "content-desc", safeGetContentDescription(node));
+        appendAttribute(xmlBuilder, "checkable", String.valueOf(node.isCheckable()));
+        appendAttribute(xmlBuilder, "checked", String.valueOf(node.isChecked()));
+        appendAttribute(xmlBuilder, "clickable", String.valueOf(node.isClickable()));
+        appendAttribute(xmlBuilder, "enabled", String.valueOf(node.isEnabled()));
+        appendAttribute(xmlBuilder, "focusable", String.valueOf(node.isFocusable()));
+        appendAttribute(xmlBuilder, "focused", String.valueOf(node.isFocused()));
+        appendAttribute(xmlBuilder, "scrollable", String.valueOf(node.isScrollable()));
+        appendAttribute(xmlBuilder, "long-clickable", String.valueOf(node.isLongClickable()));
+        appendAttribute(xmlBuilder, "password", String.valueOf(node.isPassword()));
+        appendAttribute(xmlBuilder, "selected", String.valueOf(node.isSelected()));
+
+        // Add bounds
+        android.graphics.Rect bounds = new android.graphics.Rect();
+        node.getBoundsInScreen(bounds);
+        appendAttribute(xmlBuilder, "bounds", String.format("[%d,%d][%d,%d]",
+                bounds.left, bounds.top, bounds.right, bounds.bottom));
+
+        int childCount = node.getChildCount();
+        if (childCount == 0) {
+            xmlBuilder.append("/>\n");
+        } else {
+            xmlBuilder.append(">\n");
+
+            // Recursively process child nodes
+            for (int i = 0; i < childCount; i++) {
+                AccessibilityNodeInfo child = node.getChild(i);
+                if (child != null) {
+                    dumpNodeRecursive(child, xmlBuilder, depth + 1);
+                    child.recycle();
+                }
+            }
+
+            xmlBuilder.append(indent).append("</node>\n");
+        }
+    }
+
+    private String getIndent(int depth) {
+        StringBuilder indent = new StringBuilder();
+        for (int i = 0; i < depth; i++) {
+            indent.append("  ");
+        }
+        return indent.toString();
+    }
+
+    private void appendAttribute(StringBuilder xmlBuilder, String name, String value) {
+        if (value != null) {
+            // XML escaping
+            String escapedValue = value.replace("&", "&amp;")
+                    .replace("<", "&lt;")
+                    .replace(">", "&gt;")
+                    .replace("\"", "&quot;")
+                    .replace("'", "&apos;");
+            xmlBuilder.append(" ").append(name).append("=\"").append(escapedValue).append("\"");
+        }
+    }
+
+    private String safeGetText(AccessibilityNodeInfo node) {
+        try {
+            CharSequence text = node.getText();
+            return text != null ? text.toString() : "";
+        } catch (Exception e) {
+            return "";
+        }
+    }
+
+    private String safeGetResourceId(AccessibilityNodeInfo node) {
+        try {
+            CharSequence id = node.getViewIdResourceName();
+            return id != null ? id.toString() : "";
+        } catch (Exception e) {
+            return "";
+        }
+    }
+
+    private String safeGetClassName(AccessibilityNodeInfo node) {
+        try {
+            CharSequence className = node.getClassName();
+            return className != null ? className.toString() : "";
+        } catch (Exception e) {
+            return "";
+        }
+    }
+
+    private String safeGetPackageName(AccessibilityNodeInfo node) {
+        try {
+            CharSequence packageName = node.getPackageName();
+            return packageName != null ? packageName.toString() : "";
+        } catch (Exception e) {
+            return "";
+        }
+    }
+
+    private String safeGetContentDescription(AccessibilityNodeInfo node) {
+        try {
+            CharSequence contentDesc = node.getContentDescription();
+            return contentDesc != null ? contentDesc.toString() : "";
+        } catch (Exception e) {
+            return "";
+        }
+    }
+}

--- a/app/src/main/java/io/appium/uiautomator2/model/AndroidElement.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/AndroidElement.java
@@ -32,6 +32,8 @@ public interface AndroidElement {
 
     int getDisplayId();
 
+    void setDisplayId(int displayId);
+
     boolean isSingleMatch();
 
     void clear() throws UiObjectNotFoundException;

--- a/app/src/main/java/io/appium/uiautomator2/model/UiObject2Element.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/UiObject2Element.java
@@ -43,6 +43,7 @@ import static io.appium.uiautomator2.utils.ElementHelpers.generateNoAttributeExc
 
 public class UiObject2Element extends BaseElement {
     private final UiObject2 element;
+    private Integer customDisplayId;
 
     public UiObject2Element(UiObject2 element, boolean isSingleMatch, By by, @Nullable String contextId) {
         super(isSingleMatch, by, contextId);
@@ -158,7 +159,14 @@ public class UiObject2Element extends BaseElement {
 
     @Override
     public int getDisplayId() {
+        if (customDisplayId != null) {
+            return customDisplayId;
+        }
         return element.getDisplayId();
+    }
+
+    public void setDisplayId(int displayId) {
+        this.customDisplayId = displayId;
     }
 
     @Override

--- a/app/src/main/java/io/appium/uiautomator2/model/UiObjectElement.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/UiObjectElement.java
@@ -45,6 +45,7 @@ import static io.appium.uiautomator2.utils.ElementHelpers.generateNoAttributeExc
 
 public class UiObjectElement extends BaseElement {
     private final UiObject element;
+    private Integer customDisplayId;
 
     public UiObjectElement(UiObject element, boolean isSingleMatch, By by, @Nullable String contextId) {
         super(isSingleMatch, by, contextId);
@@ -148,10 +149,17 @@ public class UiObjectElement extends BaseElement {
         return (result instanceof String) ? (String) result : String.valueOf(result);
     }
 
-    @Override
     public int getDisplayId() {
+        if (customDisplayId != null) {
+            return customDisplayId;
+        }
         return getAxNodeDisplayId(toAxNodeInfo(element));
     }
+
+    public void setDisplayId(int displayId) {
+        this.customDisplayId = displayId;
+    }
+
 
     @Override
     public void clear() throws UiObjectNotFoundException {

--- a/app/src/main/java/io/appium/uiautomator2/model/api/FindElementOnDisplayModel.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/api/FindElementOnDisplayModel.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.appium.uiautomator2.model.api;
+
+import java.util.Map;
+
+import io.appium.uiautomator2.model.RequiredField;
+
+public class FindElementOnDisplayModel extends BaseModel {
+    public String strategy;
+    @RequiredField
+    public Map<String, Object> selector;
+    public Integer displayIndex;
+    public Long timeout;
+    public String context;
+
+    public FindElementOnDisplayModel() {}
+}

--- a/app/src/main/java/io/appium/uiautomator2/server/AppiumServlet.java
+++ b/app/src/main/java/io/appium/uiautomator2/server/AppiumServlet.java
@@ -34,7 +34,9 @@ import io.appium.uiautomator2.handler.DeleteSession;
 import io.appium.uiautomator2.handler.DismissAlert;
 import io.appium.uiautomator2.handler.ActiveElement;
 import io.appium.uiautomator2.handler.FindElement;
+import io.appium.uiautomator2.handler.FindElementOnDisplay;
 import io.appium.uiautomator2.handler.FindElements;
+import io.appium.uiautomator2.handler.FindElementsOnDisplay;
 import io.appium.uiautomator2.handler.FirstVisibleView;
 import io.appium.uiautomator2.handler.GetActionHistory;
 import io.appium.uiautomator2.handler.GetAlertText;
@@ -44,6 +46,7 @@ import io.appium.uiautomator2.handler.GetDeviceInfo;
 import io.appium.uiautomator2.handler.GetDevicePixelRatio;
 import io.appium.uiautomator2.handler.GetDeviceSize;
 import io.appium.uiautomator2.handler.GetDisplayDensity;
+import io.appium.uiautomator2.handler.GetDisplayInfo;
 import io.appium.uiautomator2.handler.GetElementAttribute;
 import io.appium.uiautomator2.handler.GetElementScreenshot;
 import io.appium.uiautomator2.handler.GetName;
@@ -65,6 +68,7 @@ import io.appium.uiautomator2.handler.OpenNotification;
 import io.appium.uiautomator2.handler.PressBack;
 import io.appium.uiautomator2.handler.PressKeyCode;
 import io.appium.uiautomator2.handler.ScheduleAction;
+import io.appium.uiautomator2.handler.SourceOnDisplay;
 import io.appium.uiautomator2.handler.W3CActions;
 import io.appium.uiautomator2.handler.gestures.ScrollTo;
 import io.appium.uiautomator2.handler.gestures.ScrollToElement;
@@ -148,6 +152,9 @@ public class AppiumServlet implements IHttpServlet {
         register(postHandler, new ScheduleAction("/session/:sessionId/appium/schedule_action"));
         register(postHandler, new GetActionHistory("/session/:sessionId/appium/action_history"));
         register(postHandler, new UnscheduleAction("/session/:sessionId/appium/unschedule_action"));
+
+        register(postHandler, new FindElementOnDisplay("/session/:sessionId/appium/element/on_display"));
+        register(postHandler, new FindElementsOnDisplay("/session/:sessionId/appium/elements/on_display"));
     }
 
     private void registerGetHandler() {
@@ -180,6 +187,9 @@ public class AppiumServlet implements IHttpServlet {
         register(getHandler, new GetAlertText("/session/:sessionId/alert/text"));
         register(getHandler, new GetDeviceInfo("/session/:sessionId/appium/device/info"));
         register(getHandler, new GetDisplayDensity("/session/:sessionId/appium/device/display_density"));
+
+        register(getHandler, new GetDisplayInfo("/session/:sessionId/appium/device/display_info"));
+        register(getHandler, new SourceOnDisplay("/session/:sessionId/appium/source/on_display"));
     }
 
     private void register(Map<String, BaseRequestHandler> registerOn, BaseRequestHandler handler) {

--- a/app/src/main/java/io/appium/uiautomator2/utils/DisplayIdResolver.java
+++ b/app/src/main/java/io/appium/uiautomator2/utils/DisplayIdResolver.java
@@ -1,0 +1,153 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.appium.uiautomator2.utils;
+
+import android.content.Context;
+import android.hardware.display.DisplayManager;
+import android.view.Display;
+
+import androidx.test.core.app.ApplicationProvider;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import io.appium.uiautomator2.common.exceptions.InvalidArgumentException;
+
+public class DisplayIdResolver {
+    private static final String TAG = DisplayIdResolver.class.getSimpleName();
+    private static final Map<Integer, Integer> displayIndexToIdCache = new ConcurrentHashMap<>();
+    private static final Map<Integer, Integer> displayIdToIndexCache = new ConcurrentHashMap<>();
+    private static final Map<Integer, Long> displayIndexToPhysicalIdCache = new ConcurrentHashMap<>();
+
+    /**
+     * Resolves a display index (0 = main, 1+ = secondary) to display ID.
+     *
+     * @param displayIndex Appium display index
+     * @return Android display ID
+     */
+    public static int resolveDisplayId(int displayIndex) {
+        if (displayIndexToIdCache.containsKey(displayIndex)) {
+            return displayIndexToIdCache.get(displayIndex);
+        }
+
+        Context context = ApplicationProvider.getApplicationContext();
+        DisplayManager dm = (DisplayManager) context.getSystemService(Context.DISPLAY_SERVICE);
+        Display[] displays = dm.getDisplays();
+
+        if (displayIndex < 0 || displayIndex >= displays.length) {
+            throw new InvalidArgumentException(String.format(
+                    "Invalid display index %d. Device has %d display(s).", displayIndex, displays.length));
+        }
+
+        Display display = displays[displayIndex];
+        int displayId = display.getDisplayId();
+
+        Logger.info(TAG, String.format("Caching display index=%d -> displayId=%d, name=%s",
+                displayIndex, displayId, display.getName()));
+
+        displayIndexToIdCache.put(displayIndex, displayId);
+        displayIdToIndexCache.put(displayId, displayIndex);
+        return displayId;
+    }
+
+    /**
+     * Resolves a display ID to display index.
+     *
+     * @param displayId Android display ID
+     * @return Appium display index
+     */
+    public static int resolveDisplayIndex(int displayId) {
+        if (displayIdToIndexCache.containsKey(displayId)) {
+            return displayIdToIndexCache.get(displayId);
+        }
+
+        Context context = ApplicationProvider.getApplicationContext();
+        DisplayManager dm = (DisplayManager) context.getSystemService(Context.DISPLAY_SERVICE);
+        Display[] displays = dm.getDisplays();
+
+        for (int displayIndex = 0; displayIndex < displays.length; displayIndex++) {
+            Display display = displays[displayIndex];
+            if (display.getDisplayId() == displayId) {
+                Logger.info(TAG, String.format("Caching displayId=%d -> display index=%d, name=%s",
+                        displayId, displayIndex, display.getName()));
+
+                displayIdToIndexCache.put(displayId, displayIndex);
+                displayIndexToIdCache.put(displayIndex, displayId);
+                return displayIndex;
+            }
+        }
+
+        throw new InvalidArgumentException(String.format(
+                "Invalid display ID %d. Device has %d display(s).", displayId, displays.length));
+    }
+
+    /**
+     * Resolves a display index to physical display ID (for screenshot commands).
+     *
+     * @param displayIndex Appium display index
+     * @return Android physical display ID
+     */
+    public static Long resolvePhysicalDisplayId(int displayIndex) {
+        if (displayIndexToPhysicalIdCache.containsKey(displayIndex)) {
+            return displayIndexToPhysicalIdCache.get(displayIndex);
+        }
+
+        Context context = ApplicationProvider.getApplicationContext();
+        DisplayManager dm = (DisplayManager) context.getSystemService(Context.DISPLAY_SERVICE);
+        Display[] displays = dm.getDisplays();
+
+        if (displayIndex < 0 || displayIndex >= displays.length) {
+            throw new InvalidArgumentException(String.format(
+                    "Invalid display index %d. Device has %d display(s).", displayIndex, displays.length));
+        }
+
+        Display display = displays[displayIndex];
+        Long physicalDisplayId = DisplayIdHelper.getPhysicalDisplayId(display);
+
+        if (physicalDisplayId == null) {
+            physicalDisplayId = (long) display.getDisplayId();
+            Logger.debug(TAG, String.format("Cannot get physical display ID for display index %d, using display ID as fallback", displayIndex));
+        }
+
+        Logger.info(TAG, String.format("Caching display index=%d -> physicalDisplayId=%d, name=%s",
+                displayIndex, physicalDisplayId, display.getName()));
+
+        displayIndexToPhysicalIdCache.put(displayIndex, physicalDisplayId);
+        return physicalDisplayId;
+    }
+
+    /**
+     * Gets the number of available displays.
+     *
+     * @return number of displays
+     */
+    public static int getDisplayCount() {
+        Context context = ApplicationProvider.getApplicationContext();
+        DisplayManager dm = (DisplayManager) context.getSystemService(Context.DISPLAY_SERVICE);
+        return dm.getDisplays().length;
+    }
+
+    /**
+     * Clears the display ID cache. Useful for test or display hot-swap.
+     */
+    public static void clearCache() {
+        displayIndexToIdCache.clear();
+        displayIdToIndexCache.clear();
+        displayIndexToPhysicalIdCache.clear();
+        Logger.info(TAG, "DisplayIdResolver cache cleared");
+    }
+}


### PR DESCRIPTION
feat: Add multi-display support for Android automation

## Description
This PR implements comprehensive multi-display automation capabilities for Android devices, enabling robust testing of foldable phones, external displays, and multi-screen environments.

## Technical Changes

### New API Endpoints
- `POST /session/:sessionId/appium/element/on_display` - Find element on specific display
- `POST /session/:sessionId/appium/elements/on_display` - Find multiple elements on display  
- `GET /session/:sessionId/appium/device/display_info` - Retrieve display information
- `GET /session/:sessionId/appium/source/on_display` - Get page source from display

### Core Enhancements
- **AndroidElement Interface**: Added `setDisplayId()` method for display context tracking
- **DisplayIdResolver**: New utility for display identification and validation
- **UiSelectorBuilder**: Enhanced to support display-specific element queries
- **Four New Handlers**: Implement multi-display automation logic

## Key Benefits
-  Precision element location on specific displays
-  Complete display topology awareness  
-  Support for foldable devices and external displays
-  Fully backward compatible

## Testing
- Validated on multi-display Android devices
- Verified backward compatibility
- Confirmed parameter validation and error handling