### PR TITLE
feat: calls clearCache from UiAutomation API for API level 34+

### DIFF
--- a/app/src/main/java/io/appium/uiautomator2/utils/AXWindowHelpers.java
+++ b/app/src/main/java/io/appium/uiautomator2/utils/AXWindowHelpers.java
@@ -49,7 +49,7 @@ public class AXWindowHelpers {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
                 boolean cleared = UiAutomatorBridge.getInstance().getUiAutomation().clearCache();
                 if (!cleared) {
-                    Logger.warn("Failed to clear Accessibility Node cache");
+                    Logger.info("Accessibility Node cache was not cleared");
                 }
             } else {
                 // This call invokes `AccessibilityInteractionClient.getInstance().clearCache();` method


### PR DESCRIPTION
I found out https://developer.android.com/reference/android/app/UiAutomation#clearCache() was available since api level 34.

- https://developer.android.com/reference/android/app/UiAutomation#clearCache()
- https://android.googlesource.com/platform/frameworks/base/+/refs/heads/android14-dev/core/java/android/app/UiAutomation.java#519


What about calling this for 34+?

I also marked this as `feat` since it may be better in the minor version change rather than a patch