### PR TITLE
fix: add null check for getAddress for emulator env to get getPhysicalDisplayId

### DIFF
--- a/app/src/main/java/io/appium/uiautomator2/utils/DisplayIdHelper.java
+++ b/app/src/main/java/io/appium/uiautomator2/utils/DisplayIdHelper.java
@@ -27,6 +27,12 @@ public class DisplayIdHelper {
         try {
             // Method is marked as public with @hide in AOSP https://cs.android.com/android/platform/superproject/main/+/main:frameworks/base/core/java/android/view/Display.java;l=836?q=Display
             Object address = invoke(getMethod(display.getClass(), "getAddress"), display);
+            if (address == null) {
+                // Emulators may return null.
+                // Display address, or null if none.
+                // https://cs.android.com/android/platform/superproject/main/+/main:frameworks/base/core/java/android/view/DisplayInfo.java;l=83-86;drc=61197364367c9e404c7da6900658f1b16c42d0da
+                return null;
+            }
             return (long) invoke(getMethod(address.getClass(), "getPhysicalDisplayId"), address);
 
         } catch (UiAutomator2Exception e) {


### PR DESCRIPTION
I met null pointer exception in https://github.com/appium/appium-uiautomator2-driver/pull/945 testing with an emulator's secondary display setting.

According to https://cs.android.com/android/platform/superproject/main/+/main:frameworks/base/core/java/android/view/DisplayInfo.java;l=83-86;drc=61197364367c9e404c7da6900658f1b16c42d0da, the `address` can be null, so it caused the error.

Also, I haven't investigated the place but according to https://stackoverflow.com/questions/78740881/take-screenshot-of-virtual-display-of-android-emulator-via-adb, we should modify the take screenshot logic as well for non-physical device id case