### PR TITLE
fix: XPath2 lookup with following/preceding axes

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,19 @@ you can also invoke the test using below command
 
 Note: AUT apk should be installed before executing above command.
 
+## Development tests
+
+Server JVM unit tests (including XPath 2.0 selector coverage) and the vendored PsychoPath processor suite:
+
+```bash
+npm run test                  # rebuilds vendor JAR, runs app unit tests
+npm run test:vendor-xpath2    # runs upstream XPath2 processor tests
+```
+
+The XPath 2.0 engine is vendored from Eclipse WTP; see [`vendor/README.md`](vendor/README.md) for build details, local patches, and troubleshooting.
+
 ## Other Sections
 
 * [WIKI](https://github.com/appium/appium-uiautomator2-server/wiki)
 * [Version Release](https://github.com/appium/appium-uiautomator2-server/blob/master/doc/release.md)
+* [Vendored dependencies](vendor/README.md)

--- a/app/src/test/java/io/appium/uiautomator2/utils/XMLHelpersTests.java
+++ b/app/src/test/java/io/appium/uiautomator2/utils/XMLHelpersTests.java
@@ -24,7 +24,6 @@ import org.eclipse.wst.xml.xpath2.processor.Engine;
 import org.eclipse.wst.xml.xpath2.processor.XPathParserException;
 import org.eclipse.wst.xml.xpath2.processor.util.DynamicContextBuilder;
 import org.eclipse.wst.xml.xpath2.processor.util.StaticContextBuilder;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
@@ -244,8 +243,6 @@ public class XMLHelpersTests {
     }
 
     @Test
-    @Ignore("XPath2 following:: axis still has issues with the new library version " +
-            "(https://github.com/eclipse-platform/eclipse.platform.ui/issues/3507)")
     public void parsesComplexXpath2() {
         String query = "(//android.widget.TextView[@text='some, text']/following::android.widget.ImageButton)[1]";
 

--- a/vendor/README.md
+++ b/vendor/README.md
@@ -43,4 +43,6 @@ Eclipse/OSGi resource loading is replaced with classpath lookup via `TestResourc
 npm run test:vendor-xpath2
 ```
 
+The `fetchXpath2TestData` task runs automatically before `test` (requires network on first run). CI runs this via `npm run test:vendor-xpath2`.
+
 This executes the upstream `AllPsychoPathTests` aggregate suite (8000+ cases) through `PsychoPathTestSuiteAdapter`.

--- a/vendor/README.md
+++ b/vendor/README.md
@@ -43,6 +43,4 @@ Eclipse/OSGi resource loading is replaced with classpath lookup via `TestResourc
 npm run test:vendor-xpath2
 ```
 
-The `fetchXpath2TestData` task runs automatically before `test` (requires network on first run). CI runs this via `npm run test:vendor-xpath2`.
-
 This executes the upstream `AllPsychoPathTests` aggregate suite (8000+ cases) through `PsychoPathTestSuiteAdapter`.

--- a/vendor/build.gradle.kts
+++ b/vendor/build.gradle.kts
@@ -1,4 +1,5 @@
 import org.gradle.api.tasks.testing.Test
+import java.io.File
 
 plugins {
     `java-library`
@@ -10,11 +11,80 @@ val xpath2TestsRoot = layout.projectDirectory.dir("org.eclipse.wst.xml.xpath2.pr
 val upstreamUrl =
     "https://eclipse.googlesource.com/sourceediting/webtools.sourceediting.git"
 val upstreamCommit = layout.projectDirectory.file("SOURCE_COMMIT").asFile.readText().trim()
-val upstreamCheckoutDir = layout.projectDirectory.dir(".upstream/webtools.sourceediting")
+val upstreamRoot = layout.projectDirectory.dir(".upstream")
+val upstreamCheckoutDir = upstreamRoot.dir("webtools.sourceediting")
 val upstreamXqtsRoot =
     upstreamCheckoutDir.dir("xpath/tests/org.w3c.xqts.testsuite")
 val upstreamProcessorTestsRoot =
     upstreamCheckoutDir.dir("xpath/tests/org.eclipse.wst.xml.xpath2.processor.tests")
+
+fun isUpstreamCheckoutContentValid(): Boolean {
+    val checkoutDir = upstreamCheckoutDir.asFile
+    val xqtsMarker = upstreamXqtsRoot.file("TestSources/emptydoc.xml").asFile
+    val expectedResults = upstreamXqtsRoot.dir("ExpectedTestResults").asFile
+    val processorBugFiles =
+        upstreamProcessorTestsRoot.dir("bugTestFiles").asFile
+
+    if (!checkoutDir.isDirectory ||
+        !xqtsMarker.isFile ||
+        !expectedResults.isDirectory ||
+        !processorBugFiles.isDirectory ||
+        !File(checkoutDir, ".git/HEAD").isFile
+    ) {
+        return false
+    }
+
+    return try {
+        ProcessBuilder("git", "-C", checkoutDir.absolutePath, "rev-parse", "--verify", "HEAD")
+            .redirectErrorStream(true)
+            .start()
+            .waitFor() == 0
+    } catch (_: Exception) {
+        false
+    }
+}
+
+fun isUpstreamCheckoutValid(): Boolean {
+    val commitMarker = File(upstreamCheckoutDir.asFile, ".commit")
+    return isUpstreamCheckoutContentValid() &&
+        commitMarker.isFile &&
+        commitMarker.readText().trim() == upstreamCommit
+}
+
+fun org.gradle.api.Project.deleteUpstreamCheckout(logger: org.gradle.api.logging.Logger) {
+    val checkoutDir = upstreamCheckoutDir.asFile
+    val upstreamRootDir = upstreamRoot.asFile
+    if (!checkoutDir.exists() && !upstreamRootDir.exists()) {
+        return
+    }
+
+    logger.lifecycle("Removing upstream XPath2 test data at ${checkoutDir.absolutePath}")
+    try {
+        delete(checkoutDir)
+        if (upstreamRootDir.exists() && upstreamRootDir.list().isNullOrEmpty()) {
+            delete(upstreamRootDir)
+        }
+    } catch (e: Exception) {
+        logger.warn("Gradle delete failed ({}), retrying with rm -rf", e.message)
+        exec {
+            if (checkoutDir.exists()) {
+                commandLine("rm", "-rf", checkoutDir.absolutePath)
+            }
+            isIgnoreExitValue = false
+        }
+        if (upstreamRootDir.exists() && upstreamRootDir.list().isNullOrEmpty()) {
+            upstreamRootDir.delete()
+        }
+    }
+}
+
+val cleanXpath2Upstream = tasks.register("cleanXpath2Upstream") {
+    group = "xpath2"
+    description = "Remove sparse-cloned upstream XPath2 test fixtures."
+    doLast {
+        deleteUpstreamCheckout(logger)
+    }
+}
 
 val fetchXpath2TestData = tasks.register("fetchXpath2TestData") {
     group = "xpath2"
@@ -27,9 +97,20 @@ val fetchXpath2TestData = tasks.register("fetchXpath2TestData") {
     outputs.file(xqtsMarker)
 
     onlyIf {
-        !commitMarker.asFile.exists() ||
-            commitMarker.asFile.readText().trim() != upstreamCommit ||
-            !xqtsMarker.asFile.exists()
+        if (isUpstreamCheckoutValid()) {
+            false
+        } else {
+            if (upstreamCheckoutDir.asFile.exists()) {
+                logger.lifecycle(
+                    "Upstream XPath2 test data is missing or invalid; re-fetching from $upstreamUrl",
+                )
+            }
+            true
+        }
+    }
+
+    doFirst {
+        deleteUpstreamCheckout(logger)
     }
 
     doLast {
@@ -37,7 +118,6 @@ val fetchXpath2TestData = tasks.register("fetchXpath2TestData") {
         logger.lifecycle(
             "Fetching XPath2 test data from $upstreamUrl @ $upstreamCommit",
         )
-        project.delete(checkoutDir)
         checkoutDir.mkdirs()
 
         fun git(vararg args: String) {
@@ -59,6 +139,15 @@ val fetchXpath2TestData = tasks.register("fetchXpath2TestData") {
             "xpath/tests/org.eclipse.wst.xml.xpath2.processor.tests",
             "xpath/tests/org.w3c.xqts.testsuite",
         )
+
+        if (!isUpstreamCheckoutContentValid()) {
+            deleteUpstreamCheckout(logger)
+            error(
+                "XPath2 test data fetch completed but checkout validation failed. " +
+                    "Try: ./gradlew :vendor-xpath2:cleanXpath2Upstream :vendor-xpath2:fetchXpath2TestData",
+            )
+        }
+
         commitMarker.asFile.writeText("$upstreamCommit\n")
         logger.lifecycle("XPath2 test data ready at ${checkoutDir.absolutePath}")
     }
@@ -174,6 +263,5 @@ tasks.register("cleanXpath2Jar", Delete::class) {
 }
 
 tasks.named("clean") {
-    dependsOn("cleanXpath2Jar")
-    delete(upstreamCheckoutDir)
+    dependsOn("cleanXpath2Jar", cleanXpath2Upstream)
 }

--- a/vendor/org.eclipse.wst.xml.xpath2.processor.tests/src/org/eclipse/wst/xml/xpath2/processor/test/AllPsychoPathTests.java
+++ b/vendor/org.eclipse.wst.xml.xpath2.processor.tests/src/org/eclipse/wst/xml/xpath2/processor/test/AllPsychoPathTests.java
@@ -38,6 +38,7 @@ public class AllPsychoPathTests {
 		suite.addTestSuite(KindTestSITest.class);
 		
 		suite.addTestSuite(StaticContextAdapterTest.class);
+		suite.addTestSuite(FollowingPrecedingAxisTest.class);
 		//$JUnit-END$
 		return suite;
 	}

--- a/vendor/org.eclipse.wst.xml.xpath2.processor.tests/src/org/eclipse/wst/xml/xpath2/processor/test/FollowingPrecedingAxisTest.java
+++ b/vendor/org.eclipse.wst.xml.xpath2.processor.tests/src/org/eclipse/wst/xml/xpath2/processor/test/FollowingPrecedingAxisTest.java
@@ -1,0 +1,130 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Appium Contributors.
+ * SPDX-License-Identifier: Apache-2.0
+ *******************************************************************************/
+package org.eclipse.wst.xml.xpath2.processor.test;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Iterator;
+
+import junit.framework.TestCase;
+
+import org.eclipse.wst.xml.xpath2.api.Item;
+import org.eclipse.wst.xml.xpath2.api.ResultBuffer;
+import org.eclipse.wst.xml.xpath2.api.ResultSequence;
+import org.eclipse.wst.xml.xpath2.api.XPath2Expression;
+import org.eclipse.wst.xml.xpath2.processor.DOMLoader;
+import org.eclipse.wst.xml.xpath2.processor.Engine;
+import org.eclipse.wst.xml.xpath2.processor.XercesLoader;
+import org.eclipse.wst.xml.xpath2.processor.internal.FollowingAxis;
+import org.eclipse.wst.xml.xpath2.processor.internal.PrecedingAxis;
+import org.eclipse.wst.xml.xpath2.processor.internal.types.NodeType;
+import org.eclipse.wst.xml.xpath2.processor.util.DynamicContextBuilder;
+import org.eclipse.wst.xml.xpath2.processor.util.StaticContextBuilder;
+import org.w3c.dom.Document;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+public class FollowingPrecedingAxisTest extends TestCase {
+
+    private static final String XML =
+            "<?xml version='1.0' encoding='UTF-8'?>\n"
+                    + "<root>\n"
+                    + "  <section>\n"
+                    + "    <android.widget.TextView text=\"anchor\"/>\n"
+                    + "    <android.widget.LinearLayout>\n"
+                    + "      <nested/>\n"
+                    + "    </android.widget.LinearLayout>\n"
+                    + "    <android.widget.ImageButton id=\"target\"/>\n"
+                    + "  </section>\n"
+                    + "  <other>\n"
+                    + "    <android.widget.ImageButton id=\"later\"/>\n"
+                    + "  </other>\n"
+                    + "</root>";
+
+    private Document loadDocument(String xml) throws Exception {
+        try (InputStream in = new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8))) {
+            DOMLoader loader = new XercesLoader();
+            loader.set_validating(false);
+            return loader.load(in);
+        }
+    }
+
+    private int countElementNodes(String xpath, Document doc) throws Exception {
+        StaticContextBuilder scb = new StaticContextBuilder();
+        XPath2Expression expr = new Engine().parseExpression(xpath, scb);
+        ResultSequence rs = expr.evaluate(new DynamicContextBuilder(scb), new Object[] { doc });
+        int count = 0;
+        Iterator<Item> iterator = rs.iterator();
+        while (iterator.hasNext()) {
+            Item item = iterator.next();
+            Object nativeValue = item.getNativeValue();
+            if (nativeValue instanceof Node
+                    && ((Node) nativeValue).getNodeType() == Node.ELEMENT_NODE) {
+                count++;
+            }
+        }
+        return count;
+    }
+
+    private Node findFirstElementByLocalName(Document doc, String localName) {
+        NodeList nodes = doc.getElementsByTagName(localName);
+        for (int i = 0; i < nodes.getLength(); i++) {
+            Node node = nodes.item(i);
+            if (node.getNodeType() == Node.ELEMENT_NODE) {
+                return node;
+            }
+        }
+        return null;
+    }
+
+    public void testFollowingAxisIterateAddsNodeTypes() throws Exception {
+        Document doc = loadDocument(XML);
+        Node anchor = findFirstElementByLocalName(doc, "android.widget.TextView");
+        assertNotNull(anchor);
+
+        NodeType anchorType = NodeType.dom_to_xpath(anchor, null);
+        ResultBuffer result = new ResultBuffer();
+        new FollowingAxis().iterate(anchorType, result, null);
+
+        assertTrue("following axis should return at least one node", result.size() > 0);
+        for (int i = 0; i < result.size(); i++) {
+            assertTrue(
+                    "following axis must add NodeType items, not iterators",
+                    result.item(i) instanceof NodeType);
+        }
+    }
+
+    public void testPrecedingAxisIterateAddsNodeTypes() throws Exception {
+        Document doc = loadDocument(XML);
+        Node marker = findFirstElementByLocalName(doc, "android.widget.ImageButton");
+        assertNotNull(marker);
+
+        NodeType markerType = NodeType.dom_to_xpath(marker, null);
+        ResultBuffer result = new ResultBuffer();
+        new PrecedingAxis().iterate(markerType, result, null);
+
+        assertTrue("preceding axis should return at least one node", result.size() > 0);
+        for (int i = 0; i < result.size(); i++) {
+            assertTrue(
+                    "preceding axis must add NodeType items, not iterators",
+                    result.item(i) instanceof NodeType);
+        }
+    }
+
+    public void testFollowingAxisStepSelectsFirstMatch() throws Exception {
+        Document doc = loadDocument(XML);
+        String xpath =
+                "(//android.widget.TextView[@text='anchor']/following::android.widget.ImageButton)[1]";
+        assertEquals(1, countElementNodes(xpath, doc));
+    }
+
+    public void testPrecedingAxisStepSelectsNodes() throws Exception {
+        Document doc = loadDocument(XML);
+        String xpath =
+                "//android.widget.ImageButton[@id='later']/preceding::android.widget.TextView[@text='anchor']";
+        assertEquals(1, countElementNodes(xpath, doc));
+    }
+}

--- a/vendor/org.eclipse.wst.xml.xpath2.processor.tests/src/org/eclipse/wst/xml/xpath2/processor/test/FollowingPrecedingAxisTestAdapter.java
+++ b/vendor/org.eclipse.wst.xml.xpath2.processor.tests/src/org/eclipse/wst/xml/xpath2/processor/test/FollowingPrecedingAxisTestAdapter.java
@@ -1,0 +1,60 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Appium Contributors.
+ * SPDX-License-Identifier: Apache-2.0
+ *******************************************************************************/
+package org.eclipse.wst.xml.xpath2.processor.test;
+
+import java.util.Enumeration;
+
+import junit.framework.Test;
+import junit.framework.TestFailure;
+import junit.framework.TestResult;
+import junit.framework.TestSuite;
+
+/**
+ * JUnit Platform entry point for {@link FollowingPrecedingAxisTest}.
+ */
+public class FollowingPrecedingAxisTestAdapter {
+
+    @org.junit.Test
+    public void runFollowingPrecedingAxisTests() {
+        Test suite = new TestSuite(FollowingPrecedingAxisTest.class);
+        TestResult result = new TestResult();
+        suite.run(result);
+
+        if (!result.wasSuccessful()) {
+            StringBuilder message = new StringBuilder();
+            message.append(String.format(
+                    "Ran %d tests: %d failures, %d errors.%n",
+                    result.runCount(),
+                    result.failureCount(),
+                    result.errorCount()));
+            appendFailures(message, "Failures", result.failures());
+            appendFailures(message, "Errors", result.errors());
+            throw new AssertionError(message.toString());
+        }
+    }
+
+    private static void appendFailures(
+            StringBuilder message,
+            String label,
+            Enumeration<? extends TestFailure> failures) {
+        int count = 0;
+        while (failures.hasMoreElements()) {
+            if (count == 0) {
+                message.append(label).append(":\n");
+            }
+            TestFailure failure = failures.nextElement();
+            message.append("  - ")
+                    .append(failure.failedTest())
+                    .append(": ")
+                    .append(failure.exceptionMessage())
+                    .append('\n');
+            count++;
+            if (count >= 25) {
+                message.append("  ... and more\n");
+                break;
+            }
+        }
+    }
+}

--- a/vendor/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/FollowingAxis.java
+++ b/vendor/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/FollowingAxis.java
@@ -57,8 +57,9 @@ public class FollowingAxis extends ForwardAxis {
 		// for each sibling, get all its descendants
 		DescendantAxis da = new DescendantAxis();
 		for (Iterator i = siblingBuffer.iterator(); i.hasNext();) {
-			result.add((NodeType)i);
-			da.iterate((NodeType) i.next(), result, null);
+			NodeType sibling = (NodeType) i.next();
+			result.add(sibling);
+			da.iterate(sibling, result, null);
 		}
 
 		// if we got a parent, we gotta repeat the story for the parent

--- a/vendor/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/PrecedingAxis.java
+++ b/vendor/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/PrecedingAxis.java
@@ -60,8 +60,9 @@ public class PrecedingAxis extends ReverseAxis {
 		// for each sibling, get all its descendants
 		DescendantAxis da = new DescendantAxis();
 		for (Iterator i = siblingBuffer.iterator(); i.hasNext();) {
-			result.add((NodeType)i);
-			da.iterate((NodeType) i.next(), result, null);
+			NodeType sibling = (NodeType) i.next();
+			result.add(sibling);
+			da.iterate(sibling, result, null);
 		}
 	}
 	


### PR DESCRIPTION
## Summary

Fixes XPath 2.0 `following::` and `preceding::` axis evaluation in the vendored PsychoPath processor (`org.eclipse.wst.xml.xpath2.processor`).

In `FollowingAxis` and `PrecedingAxis`, sibling iteration incorrectly added the `Iterator` to the result sequence instead of the current `NodeType`. That caused a `ClassCastException` (`ArrayList$ListItr` cannot be cast to `NodeType`) for queries such as:

```xpath
(//android.widget.TextView[@text='some, text']/following::android.widget.ImageButton)[1]
```

XPath 1.0 worked; XPath 2.0 did not. This matches [eclipse.platform.ui#3507](https://github.com/eclipse-platform/eclipse.platform.ui/issues/3507).

**Also in this PR:**
- Vendor regression tests (`FollowingPrecedingAxisTest`) and re-enabled `XMLHelpersTests.parsesComplexXpath2`
- `FollowingPrecedingAxisTestAdapter` for fast local runs via `--tests` (not duplicated in CI)
- Hardened `fetchXpath2TestData`: validates sparse checkout, auto-removes corrupt `vendor/.upstream/` trees, `cleanXpath2Upstream` task
- README updates for development tests and vendor docs link
