### PR TITLE
feat: Add deferAccessibilityCacheReset setting to bound LinearAlloc growth under sustained finds

### DIFF
--- a/app/src/main/java/io/appium/uiautomator2/handler/ResetAxCache.java
+++ b/app/src/main/java/io/appium/uiautomator2/handler/ResetAxCache.java
@@ -30,7 +30,8 @@ public class ResetAxCache extends SafeRequestHandler {
 
     @Override
     protected AppiumResponse safeHandle(IHttpRequest request) {
-        resetAccessibilityCache();
+        // Explicit reset endpoint: always clear, regardless of the deferred-reset optimization.
+        resetAccessibilityCache(true);
         return new AppiumResponse(getSessionId(request));
     }
 }

--- a/app/src/main/java/io/appium/uiautomator2/model/NotificationListener.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/NotificationListener.java
@@ -38,6 +38,11 @@ public class NotificationListener implements OnAccessibilityEventListener {
     private long recentToastTimestamp = currentTimeMillis();
     private OnAccessibilityEventListener originalListener = null;
     private volatile boolean isListening;
+    // Tracks whether a relevant UI-change AccessibilityEvent has been observed since the last
+    // accessibility-cache reset, so redundant per-find cache clears can be skipped while the UI is
+    // idle (see AXWindowHelpers.resetAccessibilityCache). Starts stale so the first reset after
+    // (re)starting the listener always clears.
+    private volatile boolean accessibilityCacheStale = true;
 
     protected NotificationListener() {
         uiAutomation = UiAutomation.getInstance();
@@ -61,6 +66,7 @@ public class NotificationListener implements OnAccessibilityEventListener {
         Logger.debug("Starting toast notification listener.");
         originalListener = uiAutomation.getOnAccessibilityEventListener();
         isListening = true;
+        accessibilityCacheStale = true;
         Logger.debug("Original listener: " + originalListener);
         uiAutomation.setOnAccessibilityEventListener(this);
     }
@@ -85,9 +91,35 @@ public class NotificationListener implements OnAccessibilityEventListener {
             }
         }
 
+        if (isAccessibilityCacheInvalidatingEvent(event.getEventType())) {
+            accessibilityCacheStale = true;
+        }
+
         if (originalListener != null) {
             originalListener.onAccessibilityEvent(event);
         }
+    }
+
+    private static boolean isAccessibilityCacheInvalidatingEvent(int eventType) {
+        return eventType == AccessibilityEvent.TYPE_WINDOW_CONTENT_CHANGED
+                || eventType == AccessibilityEvent.TYPE_WINDOW_STATE_CHANGED
+                || eventType == AccessibilityEvent.TYPE_WINDOWS_CHANGED
+                || eventType == AccessibilityEvent.TYPE_VIEW_SCROLLED;
+    }
+
+    /**
+     * Returns whether a relevant UI-change event has been observed since the last call, resetting
+     * the flag to {@code false}. Used by {@code AXWindowHelpers.resetAccessibilityCache()} to skip
+     * clearing the (expensive) AccessibilityInteractionClient cache while the UI is idle.
+     */
+    public synchronized boolean consumeAccessibilityCacheStaleFlag() {
+        boolean wasStale = accessibilityCacheStale;
+        accessibilityCacheStale = false;
+        return wasStale;
+    }
+
+    public synchronized void markAccessibilityCacheStale() {
+        accessibilityCacheStale = true;
     }
 
     public boolean isListening() {

--- a/app/src/main/java/io/appium/uiautomator2/model/settings/DeferAccessibilityCacheReset.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/settings/DeferAccessibilityCacheReset.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.appium.uiautomator2.model.settings;
+
+/**
+ * When enabled, the server clears the AccessibilityInteractionClient cache before a find/source
+ * lookup only if a relevant UI-change AccessibilityEvent has been observed since the last reset
+ * (rather than on every single lookup). This avoids forcing a full Binder re-traversal of the
+ * accessibility tree per find, which drives unbounded ART LinearAlloc growth under sustained
+ * lookups (see appium/appium-uiautomator2-server#774).
+ *
+ * Defaults to {@code false} to preserve the long-standing always-reset behavior. The optimization
+ * also fails safe to always-reset whenever the accessibility event listener is not active (since
+ * staleness cannot be detected without it).
+ */
+public class DeferAccessibilityCacheReset extends AbstractSetting<Boolean> {
+    private static final String SETTING_NAME = "deferAccessibilityCacheReset";
+    private static final Boolean DEFAULT_VALUE = false;
+    private Boolean value = DEFAULT_VALUE;
+
+    public DeferAccessibilityCacheReset() {
+        super(Boolean.class, SETTING_NAME);
+    }
+
+    @Override
+    public Boolean getValue() {
+        return value;
+    }
+
+    @Override
+    public Boolean getDefaultValue() {
+        return DEFAULT_VALUE;
+    }
+
+    @Override
+    protected void apply(Boolean deferAccessibilityCacheReset) {
+        value = deferAccessibilityCacheReset;
+    }
+}

--- a/app/src/main/java/io/appium/uiautomator2/model/settings/Settings.java
+++ b/app/src/main/java/io/appium/uiautomator2/model/settings/Settings.java
@@ -49,7 +49,8 @@ public enum Settings {
     USE_RESOURCES_FOR_ORIENTATION_DETECTION(new UseResourcesForOrientationDetection()),
     SNAPSHOT_MAX_DEPTH(new SnapshotMaxDepth()),
     CURRENT_DISPLAY_ID(new CurrentDisplayId()),
-    ALWAYS_TRAVERSABLE_VIEW_CLASSES(new AlwaysTraversableViewClasses());
+    ALWAYS_TRAVERSABLE_VIEW_CLASSES(new AlwaysTraversableViewClasses()),
+    DEFER_ACCESSIBILITY_CACHE_RESET(new DeferAccessibilityCacheReset());
 
     private final ISetting<?> setting;
 

--- a/app/src/main/java/io/appium/uiautomator2/utils/AXWindowHelpers.java
+++ b/app/src/main/java/io/appium/uiautomator2/utils/AXWindowHelpers.java
@@ -30,7 +30,9 @@ import java.util.Objects;
 
 import io.appium.uiautomator2.common.exceptions.UiAutomator2Exception;
 import io.appium.uiautomator2.core.UiAutomatorBridge;
+import io.appium.uiautomator2.model.NotificationListener;
 import io.appium.uiautomator2.model.internal.CustomUiDevice;
+import io.appium.uiautomator2.model.settings.DeferAccessibilityCacheReset;
 import io.appium.uiautomator2.model.settings.EnableMultiWindows;
 import io.appium.uiautomator2.model.settings.EnableTopmostWindowFromActivePackage;
 import io.appium.uiautomator2.model.settings.Settings;
@@ -41,11 +43,38 @@ public class AXWindowHelpers {
     private static final Map<String, AccessibilityNodeInfo[]> CACHED_WINDOW_ROOTS = new HashMap<>();
 
     public static void resetAccessibilityCache() {
+        resetAccessibilityCache(false);
+    }
+
+    /**
+     * @param forceClear when true the AccessibilityInteractionClient cache is always cleared (used
+     *                   by the explicit reset endpoint). When false the clear may be skipped if
+     *                   {@link DeferAccessibilityCacheReset} is enabled and no relevant UI-change
+     *                   event has been observed since the last reset.
+     */
+    public static void resetAccessibilityCache(boolean forceClear) {
         Device.waitForIdle();
-        clearAccessibilityCache();
+        if (forceClear || shouldClearAccessibilityCache()) {
+            clearAccessibilityCache();
+        }
         synchronized (CACHED_WINDOW_ROOTS) {
             CACHED_WINDOW_ROOTS.clear();
         }
+    }
+
+    private static boolean shouldClearAccessibilityCache() {
+        // Preserve the historical always-reset behavior unless the optimization is opted into.
+        if (!Settings.get(DeferAccessibilityCacheReset.class).getValue()) {
+            return true;
+        }
+        NotificationListener listener = NotificationListener.getInstance();
+        // Fail safe: without an active accessibility event listener we cannot tell whether the UI
+        // changed, so we must clear unconditionally to avoid serving stale cached nodes.
+        if (!listener.isListening()) {
+            return true;
+        }
+        // Otherwise only clear when a relevant UI-change event was seen since the last reset.
+        return listener.consumeAccessibilityCacheStaleFlag();
     }
 
     public static AccessibilityNodeInfo[] getCachedWindowRoots() {


### PR DESCRIPTION
Refs #774 — server-side mitigation. (The deeper ART conflict-table re-allocation question stays tracked in #774.)

## Problem
Clearing the `AccessibilityInteractionClient` cache before *every* find/source lookup (`AXWindowHelpers.resetAccessibilityCache()` → `clearCache()` / `setServiceInfo(null)`) forces a full Binder re-traversal of the accessibility tree each time. Under sustained zero-think-time finds this drives unbounded **ART `[anon:dalvik-LinearAlloc]`** growth — IMT conflict-table / method-resolution metadata (`art::ClassLinker::AddMethodToConflictTable` → `LinearAlloc::Alloc` → `MemMap::MapAnonymous` → `mmap`), attributed via simpleperf in #774 — which can OOM the server on long runs.

## Change
New **opt-in** setting **`deferAccessibilityCacheReset`** (default `false`). When enabled, the per-find cache clear is skipped *unless* `NotificationListener` has observed a relevant UI-change `AccessibilityEvent` (`TYPE_WINDOW_CONTENT_CHANGED` / `TYPE_WINDOW_STATE_CHANGED` / `TYPE_WINDOWS_CHANGED` / `TYPE_VIEW_SCROLLED`) since the last reset — i.e. event-driven invalidation that mirrors how the framework's own AIC cache invalidates.

- Defaults to `false` → **no behavior change** out of the box.
- **Fails safe**: always clears when the accessibility event listener is inactive (staleness can't be detected without it).
- The explicit `ResetAxCache` endpoint always forces a clear.

## Validation (Android 12 / API 32, real device)
- **Leak (same build, toggle only):** setting OFF → LinearAlloc 4→690 MB (= current baseline); setting ON → flat 3–4 MB across a sustained sleep=0 accessibility-id hammer. simpleperf self-time of `AddMethodToConflictTable` / `art_quick_imt_conflict_trampoline` returns with OFF and is gone with ON.
- **Staleness:** 12 h full-suite run with the fix ON, readback-confirmed across 34 sessions — logged stale-retries 3 vs 2 on the fix-OFF baseline (no spike); no fix-induced stale reads. Remaining failures are pre-existing baseline classes.

## Notes
- A text/locale change emits `TYPE_WINDOW_CONTENT_CHANGED` (in the invalidating set), and no fix-induced staleness was observed; a time-based backstop could be added as belt-and-suspenders if preferred.
- Default-off keeps this safe; happy to propose defaulting it on in a follow-up once it's proven across more app types.

🤖 Generated with [Claude Code](https://claude.com/claude-code)